### PR TITLE
add rho and pi interface

### DIFF
--- a/keccak256/src/gates.rs
+++ b/keccak256/src/gates.rs
@@ -1,5 +1,8 @@
 pub mod absorb;
+pub mod gate_helpers;
 pub mod iota_b13;
 pub mod iota_b9;
+pub mod pi;
+pub mod rho;
 pub mod theta;
 pub mod xi;

--- a/keccak256/src/gates/gate_helpers.rs
+++ b/keccak256/src/gates/gate_helpers.rs
@@ -1,0 +1,7 @@
+use halo2::circuit::Cell;
+
+#[derive(Debug)]
+pub struct Lane<F> {
+    pub cell: Cell,
+    pub value: F,
+}

--- a/keccak256/src/gates/pi.rs
+++ b/keccak256/src/gates/pi.rs
@@ -1,0 +1,75 @@
+use crate::gates::gate_helpers::Lane;
+
+use halo2::{
+    circuit::Region,
+    plonk::{Advice, Column, ConstraintSystem, Error, Expression, Selector},
+    poly::Rotation,
+};
+use itertools::Itertools;
+use pasta_curves::arithmetic::FieldExt;
+use std::convert::TryInto;
+use std::marker::PhantomData;
+
+pub struct PiConfig<F> {
+    q_enable: Selector,
+    state: [Column<Advice>; 25],
+    _marker: PhantomData<F>,
+}
+
+impl<F: FieldExt> PiConfig<F> {
+    pub fn configure(
+        q_enable: Selector,
+        meta: &mut ConstraintSystem<F>,
+        state: [Column<Advice>; 25],
+    ) -> PiConfig<F> {
+        meta.create_gate("pi", |meta| {
+            let q_enable = meta.query_selector(q_enable);
+            (0..5)
+                .cartesian_product(0..5)
+                .map(|(x, y)| {
+                    let lane = meta.query_advice(
+                        state[5 * ((x + 3 * y) % 5) + x],
+                        Rotation::cur(),
+                    );
+                    let new_lane =
+                        meta.query_advice(state[5 * x + y], Rotation::next());
+
+                    q_enable.clone() * (new_lane - lane)
+                })
+                .collect::<Vec<Expression<F>>>()
+        });
+
+        PiConfig {
+            q_enable,
+            state,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn assign_region(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        previous_state: [Lane<F>; 25],
+    ) -> Result<[Lane<F>; 25], Error> {
+        self.q_enable.enable(region, offset)?;
+        let mut next_state: Vec<Lane<F>> = vec![];
+
+        for (x, y) in (0..5).cartesian_product(0..5) {
+            let idx_prev = 5 * ((x + 3 * y) % 5) + x;
+            let idx_next = 5 * x + y;
+            let lane = &previous_state[idx_prev];
+            let cell = region.assign_advice(
+                || "lane next row",
+                self.state[idx_next],
+                offset,
+                || Ok(lane.value),
+            )?;
+            next_state.push(Lane {
+                cell,
+                value: lane.value,
+            });
+        }
+        Ok(next_state.try_into().unwrap())
+    }
+}

--- a/keccak256/src/gates/rho.rs
+++ b/keccak256/src/gates/rho.rs
@@ -1,0 +1,63 @@
+use crate::arith_helpers::convert_b13_lane_to_b9;
+use crate::common::ROTATION_CONSTANTS;
+use crate::gates::gate_helpers::Lane;
+
+use halo2::{
+    circuit::Region,
+    plonk::{Advice, Column, Error},
+};
+use itertools::Itertools;
+use num_bigint::BigUint;
+use pasta_curves::arithmetic::FieldExt;
+use std::convert::TryInto;
+use std::marker::PhantomData;
+
+pub struct RhoConfig<F> {
+    state: [Column<Advice>; 25],
+    _marker: PhantomData<F>,
+}
+
+impl<F: FieldExt> RhoConfig<F> {
+    pub fn configure(state: [Column<Advice>; 25]) -> Self {
+        Self {
+            state,
+            _marker: PhantomData,
+        }
+    }
+    pub fn assign_region(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        previous_state: [Lane<F>; 25],
+    ) -> Result<[Lane<F>; 25], Error> {
+        let mut next_state: Vec<Lane<F>> = vec![];
+
+        for (x, y) in (0..5).cartesian_product(0..5) {
+            let idx = 5 * x + y;
+            let lane_base_13 = &previous_state[idx];
+            let lane_base_13_big_uint =
+                BigUint::from_bytes_le(&lane_base_13.value.to_bytes());
+            let lane_base_9_big_uint = convert_b13_lane_to_b9(
+                lane_base_13_big_uint,
+                ROTATION_CONSTANTS[x][y],
+            );
+            let lane_base_9 = Option::from(F::from_bytes(
+                lane_base_9_big_uint.to_bytes_le()[..=32]
+                    .try_into()
+                    .unwrap(),
+            ))
+            .ok_or(Error::SynthesisError)?;
+            let cell = region.assign_advice(
+                || "lane next row",
+                self.state[idx],
+                offset,
+                || Ok(lane_base_9),
+            )?;
+            next_state.push(Lane {
+                cell,
+                value: lane_base_9,
+            });
+        }
+        Ok(next_state.try_into().unwrap())
+    }
+}


### PR DESCRIPTION
### Problem

We create this PR to check-in rho and pi gates without their actual implementation, so that @CPerezz can work on the keccak main config with the rho and pi configs.

### What's still missing?

- Pi gate is feature complete actually. Unit tests are missing but seem easy to add later.
- The Rho gates detail implementation is still ongoing, but the current assign_regions function can magically assign the next state without actually validating them.