### PR TITLE
Remove unnecessary constraint which requires unused cells to be `0`

### DIFF
--- a/zkevm-circuits/src/evm_circuit/op_execution.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution.rs
@@ -437,15 +437,6 @@ impl<F: FieldExt> OpExecutionGadget<F> {
                         .collect(),
                     lookups: vec![],
                 });
-                constraints.push(Constraint {
-                    name: "case unused",
-                    selector: qs_op.expr() * qs_case.expr(),
-                    polys: unused_idxs
-                        .into_iter()
-                        .map(|idx| free_cells[idx].expr())
-                        .collect(),
-                    lookups: vec![],
-                });
 
                 assert!(
                     preset_map


### PR DESCRIPTION
Currently EVM circuit put constraints to require unused cells to be `0`, which is actually unnecessary and increase the test time a lot.

In #88 the test time in release mode cost around 6 minutes, after removal of these constraints, the test time decreases to 2 minutes.