### PR TITLE
check rw_counter is unique 

### DIFF
--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -137,8 +137,6 @@ pub mod test {
         distributions::uniform::{SampleRange, SampleUniform},
         random, thread_rng, Rng,
     };
-    use std::collections::HashSet;
-    use std::hash::Hash;
 
     pub(crate) fn rand_range<T, R>(range: R) -> T
     where
@@ -164,14 +162,6 @@ pub mod test {
         Fp::rand()
     }
 
-    fn has_unique_elements<T>(iter: T) -> bool
-    where
-        T: IntoIterator,
-        T::Item: Eq + Hash,
-    {
-        let mut uniq = HashSet::new();
-        iter.into_iter().all(move |x| uniq.insert(x))
-    }
 
     #[derive(Clone)]
     pub struct TestCircuitConfig<F> {

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -230,16 +230,12 @@ pub mod test {
                         .flat_map(|rws| rws.iter())
                         .collect::<Vec<_>>();
 
-                    rows.sort_by_key(|a| a.get_rw_counter());
-                    let mut pre_rw_counter = 0;
+                    rows.sort_by_key(|a| a.rw_counter());
+                    let mut expected_rw_counter = 1;
                     for rw in rows {
-                        if pre_rw_counter == 0 {
-                            assert!(rw.get_rw_counter() == 1);
-                        } else {
-                            assert!(rw.get_rw_counter() == pre_rw_counter + 1);
-                        }
+                        assert!(rw.rw_counter() == expected_rw_counter);
+                        expected_rw_counter += 1;
 
-                        pre_rw_counter = rw.get_rw_counter();
                         self.rw_table.assign(
                             &mut region,
                             offset,

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -137,8 +137,8 @@ pub mod test {
         distributions::uniform::{SampleRange, SampleUniform},
         random, thread_rng, Rng,
     };
-    use std::hash::Hash;
     use std::collections::HashSet;
+    use std::hash::Hash;
 
     pub(crate) fn rand_range<T, R>(range: R) -> T
     where
@@ -172,7 +172,6 @@ pub mod test {
         let mut uniq = HashSet::new();
         iter.into_iter().all(move |x| uniq.insert(x))
     }
-
 
     #[derive(Clone)]
     pub struct TestCircuitConfig<F> {
@@ -236,14 +235,14 @@ pub mod test {
                         .assign(&mut region, offset, &Default::default())?;
                     offset += 1;
 
-                    let mut rows = rws
+                    let rows = rws
                         .0
                         .values()
-                        .flat_map(|rws| rws.iter().map(|rw|rw.get_rw_counter()))
+                        .flat_map(|rws| rws.iter().map(|rw| rw.get_rw_counter()))
                         .collect::<Vec<_>>();
 
                     let is_unique = has_unique_elements(rows);
-                    assert_eq!(is_unique, true);
+                    assert!(is_unique);
 
                     for rw in rws.0.values().flat_map(|rws| rws.iter()) {
                         self.rw_table.assign(

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -162,7 +162,6 @@ pub mod test {
         Fp::rand()
     }
 
-
     #[derive(Clone)]
     pub struct TestCircuitConfig<F> {
         tx_table: [Column<Advice>; 4],

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -224,7 +224,20 @@ pub mod test {
                         .assign(&mut region, offset, &Default::default())?;
                     offset += 1;
 
-                    for rw in rws.0.values().flat_map(|rws| rws.iter()) {
+                    let mut rows = rws
+                        .0
+                        .values()
+                        .flat_map(|rws| rws.iter())
+                        .collect::<Vec<_>>();
+
+                    rows.sort_by_key(|a| a.get_rw_counter());
+                    let mut pre_rw_counter = 0;
+                    for rw in rows {
+                        if pre_rw_counter != 0 {
+                            assert!(rw.get_rw_counter() > pre_rw_counter);
+                        }
+
+                        pre_rw_counter = rw.get_rw_counter();
                         self.rw_table.assign(
                             &mut region,
                             offset,

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -236,17 +236,17 @@ pub mod test {
                     offset += 1;
 
                     let mut rows = rws
-                    .0
-                    .values()
-                    .flat_map(|rws| rws.iter())
-                    .collect::<Vec<_>>();
+                        .0
+                        .values()
+                        .flat_map(|rws| rws.iter())
+                        .collect::<Vec<_>>();
 
                     rows.sort_by_key(|a| a.get_rw_counter());
                     let mut pre_rw_counter = 0;
                     for rw in rows {
                         if pre_rw_counter == 0 {
                             assert!(rw.get_rw_counter() == 1);
-                        }else{
+                        } else {
                             assert!(rw.get_rw_counter() == pre_rw_counter + 1);
                         }
 

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -235,16 +235,22 @@ pub mod test {
                         .assign(&mut region, offset, &Default::default())?;
                     offset += 1;
 
-                    let rows = rws
-                        .0
-                        .values()
-                        .flat_map(|rws| rws.iter().map(|rw| rw.get_rw_counter()))
-                        .collect::<Vec<_>>();
+                    let mut rows = rws
+                    .0
+                    .values()
+                    .flat_map(|rws| rws.iter())
+                    .collect::<Vec<_>>();
 
-                    let is_unique = has_unique_elements(rows);
-                    assert!(is_unique);
+                    rows.sort_by_key(|a| a.get_rw_counter());
+                    let mut pre_rw_counter = 0;
+                    for rw in rows {
+                        if pre_rw_counter == 0 {
+                            assert!(rw.get_rw_counter() == 1);
+                        }else{
+                            assert!(rw.get_rw_counter() == pre_rw_counter + 1);
+                        }
 
-                    for rw in rws.0.values().flat_map(|rws| rws.iter()) {
+                        pre_rw_counter = rw.get_rw_counter();
                         self.rw_table.assign(
                             &mut region,
                             offset,

--- a/zkevm-circuits/src/evm_circuit/execution/calldatasize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldatasize.rs
@@ -102,7 +102,6 @@ mod test {
             CALLDATASIZE
             STOP
         };
-
         let block_data = if is_root {
             bus_mapping::mock::BlockData::new_from_geth_data(
                 TestContext::<2, 1>::new(
@@ -166,7 +165,7 @@ mod test {
                 .unwrap()
                 .into(),
             )
-        };
+    };
         let mut builder = block_data.new_circuit_input_builder();
         builder
             .handle_block(&block_data.eth_block, &block_data.geth_traces)

--- a/zkevm-circuits/src/evm_circuit/execution/calldatasize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldatasize.rs
@@ -102,6 +102,7 @@ mod test {
             CALLDATASIZE
             STOP
         };
+        
         let block_data = if is_root {
             bus_mapping::mock::BlockData::new_from_geth_data(
                 TestContext::<2, 1>::new(

--- a/zkevm-circuits/src/evm_circuit/execution/calldatasize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldatasize.rs
@@ -102,7 +102,7 @@ mod test {
             CALLDATASIZE
             STOP
         };
-        
+
         let block_data = if is_root {
             bus_mapping::mock::BlockData::new_from_geth_data(
                 TestContext::<2, 1>::new(

--- a/zkevm-circuits/src/evm_circuit/execution/calldatasize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldatasize.rs
@@ -165,7 +165,7 @@ mod test {
                 .unwrap()
                 .into(),
             )
-    };
+        };
         let mut builder = block_data.new_circuit_input_builder();
         builder
             .handle_block(&block_data.eth_block, &block_data.geth_traces)

--- a/zkevm-circuits/src/evm_circuit/witness.rs
+++ b/zkevm-circuits/src/evm_circuit/witness.rs
@@ -528,6 +528,20 @@ impl<F: FieldExt> From<[F; 11]> for RwRow<F> {
 }
 
 impl Rw {
+    pub fn get_rw_counter(&self) -> usize {
+        match self {
+            Self::TxAccessListAccount { rw_counter, .. } => (*rw_counter),
+            Self::TxAccessListAccountStorage { rw_counter, .. } => (*rw_counter),
+            Self::Stack { rw_counter, .. } => (*rw_counter),
+            Self::Memory { rw_counter, .. } => (*rw_counter),
+            Self::Account { rw_counter, .. } => (*rw_counter),
+            Self::AccountDestructed { rw_counter, .. } => (*rw_counter),
+            Self::CallContext { rw_counter, .. } => (*rw_counter),
+            Self::AccountStorage { rw_counter, .. } => (*rw_counter),
+            Self::TxRefund { rw_counter, .. } => (*rw_counter),
+        }
+    }
+
     pub fn tx_access_list_value_pair(&self) -> (bool, bool) {
         match self {
             Self::TxAccessListAccount {

--- a/zkevm-circuits/src/evm_circuit/witness.rs
+++ b/zkevm-circuits/src/evm_circuit/witness.rs
@@ -528,7 +528,7 @@ impl<F: FieldExt> From<[F; 11]> for RwRow<F> {
 }
 
 impl Rw {
-    pub fn get_rw_counter(&self) -> usize {
+    pub fn rw_counter(&self) -> usize {
         match self {
             Self::TxAccessListAccount { rw_counter, .. } => (*rw_counter),
             Self::TxAccessListAccountStorage { rw_counter, .. } => (*rw_counter),


### PR DESCRIPTION
when develop unit tests , it is often to manually add RW entries with wrong `rw_counter` specified,  leading to lookup failures eventually, This PR is aim to check `rw_counter ` is unique and increasing at early stage.  it will help trouble shooting this kind of issue for developers.  


  