### PR TITLE
pub mod container

### DIFF
--- a/bus-mapping/src/operation.rs
+++ b/bus-mapping/src/operation.rs
@@ -4,7 +4,7 @@
 //!   [`Operation`] enum).
 //! - Define structures that interact with operations such as
 //!   [`OperationContainer`].
-pub(crate) mod container;
+pub mod container;
 
 pub use container::OperationContainer;
 pub use eth_types::evm_types::{MemoryAddress, StackAddress};

--- a/bus-mapping/src/operation.rs
+++ b/bus-mapping/src/operation.rs
@@ -4,6 +4,7 @@
 //!   [`Operation`] enum).
 //! - Define structures that interact with operations such as
 //!   [`OperationContainer`].
+/// For external calls, usually in building `state_circuit`.
 pub mod container;
 
 pub use container::OperationContainer;


### PR DESCRIPTION
We need to customize `state_circuit` and it needs to call the `bus-mapping::operation::container::OperationContainer`, so I make `mod container` public