### PR TITLE
Fix some bugs of `CircuitInputBuilder`

### DIFF
--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -227,8 +227,10 @@ fn fn_gen_associated_ops(opcode_id: &OpcodeId) -> FnGenAssociatedOps {
         // TODO: Handle REVERT by its own gen_associated_ops.
         OpcodeId::REVERT => Stop::gen_associated_ops,
         // OpcodeId::SELFDESTRUCT => {},
-        // _ => panic!("Opcode {:?} gen_associated_ops not implemented",
-        // self),
+        OpcodeId::CALLCODE | OpcodeId::DELEGATECALL | OpcodeId::STATICCALL => {
+            warn!("Using dummy gen_call_ops for opcode {:?}", opcode_id);
+            dummy_gen_call_ops
+        }
         _ => {
             warn!("Using dummy gen_associated_ops for opcode {:?}", opcode_id);
             dummy_gen_associated_ops
@@ -499,4 +501,35 @@ pub fn gen_end_tx_ops(state: &mut CircuitInputStateRef) -> Result<ExecStep, Erro
     }
 
     Ok(exec_step)
+}
+
+fn dummy_gen_call_ops(
+    state: &mut CircuitInputStateRef,
+    geth_steps: &[GethExecStep],
+) -> Result<Vec<ExecStep>, Error> {
+    let geth_step = &geth_steps[0];
+    let exec_step = state.new_step(geth_step)?;
+
+    let call = state.call()?.clone();
+    let callee = state.parse_call(geth_step)?;
+
+    let (_, account) = state.sdb.get_account(&callee.address);
+    let callee_code_hash = account.code_hash;
+
+    state.push_call(callee.clone());
+
+    match (
+        state.is_precompiled(&call.address),
+        callee_code_hash.to_fixed_bytes() == *EMPTY_HASH,
+    ) {
+        // 1. Call to precompiled.
+        (true, _) => Ok(vec![exec_step]),
+        // 2. Call to account with empty code.
+        (_, true) => {
+            state.handle_return()?;
+            Ok(vec![exec_step])
+        }
+        // 3. Call to account with non-empty code.
+        (_, false) => Ok(vec![exec_step]),
+    }
 }

--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -516,7 +516,7 @@ fn dummy_gen_call_ops(
     let (_, account) = state.sdb.get_account(&callee.address);
     let callee_code_hash = account.code_hash;
 
-    state.push_call(callee.clone());
+    state.push_call(callee.clone(), geth_step);
 
     match (
         state.is_precompiled(&call.address),

--- a/bus-mapping/src/evm/opcodes/call.rs
+++ b/bus-mapping/src/evm/opcodes/call.rs
@@ -93,7 +93,7 @@ impl Opcode for Call {
         )?;
 
         // Switch to callee's call context
-        state.push_call(callee.clone());
+        state.push_call(callee.clone(), geth_step);
 
         for (field, value) in [
             (CallContextField::RwCounterEndOfReversion, 0.into()),

--- a/bus-mapping/src/evm/opcodes/calldatacopy.rs
+++ b/bus-mapping/src/evm/opcodes/calldatacopy.rs
@@ -98,7 +98,7 @@ fn gen_memory_copy_step(
     for idx in 0..std::cmp::min(bytes_left, MAX_COPY_BYTES) {
         let addr = src_addr + idx as u64;
         let byte = if addr < src_addr_end {
-            let byte = state.call()?.call_data_source[addr as usize];
+            let byte = state.call_ctx()?.call_data_source[addr as usize];
             if !is_root {
                 state.push_op(
                     exec_step,

--- a/bus-mapping/src/evm/opcodes/calldatacopy.rs
+++ b/bus-mapping/src/evm/opcodes/calldatacopy.rs
@@ -103,11 +103,7 @@ fn gen_memory_copy_step(
                 state.push_op(
                     exec_step,
                     RW::READ,
-                    MemoryOp::new(
-                        state.call()?.caller_id,
-                        (idx + dst_addr as usize).into(),
-                        byte,
-                    ),
+                    MemoryOp::new(state.call()?.caller_id, (addr as usize).into(), byte),
                 );
             }
             byte

--- a/bus-mapping/src/evm/opcodes/calldatacopy.rs
+++ b/bus-mapping/src/evm/opcodes/calldatacopy.rs
@@ -2,7 +2,7 @@ use super::Opcode;
 use crate::circuit_input_builder::{
     CircuitInputStateRef, CopyToMemoryAuxData, ExecState, ExecStep, StepAuxiliaryData,
 };
-use crate::operation::{CallContextField, CallContextOp, RW};
+use crate::operation::{CallContextField, CallContextOp, MemoryOp, RW};
 use crate::Error;
 use eth_types::GethExecStep;
 
@@ -98,12 +98,19 @@ fn gen_memory_copy_step(
     for idx in 0..std::cmp::min(bytes_left, MAX_COPY_BYTES) {
         let addr = src_addr + idx as u64;
         let byte = if addr < src_addr_end {
-            if is_root {
-                state.tx.input[addr as usize]
-            } else {
-                // TODO: read caller memory
-                unimplemented!()
+            let byte = state.call()?.call_data_source[addr as usize];
+            if !is_root {
+                state.push_op(
+                    exec_step,
+                    RW::READ,
+                    MemoryOp::new(
+                        state.call()?.caller_id,
+                        (idx + dst_addr as usize).into(),
+                        byte,
+                    ),
+                );
             }
+            byte
         } else {
             0
         };

--- a/bus-mapping/src/evm/opcodes/calldatacopy.rs
+++ b/bus-mapping/src/evm/opcodes/calldatacopy.rs
@@ -98,7 +98,8 @@ fn gen_memory_copy_step(
     for idx in 0..std::cmp::min(bytes_left, MAX_COPY_BYTES) {
         let addr = src_addr + idx as u64;
         let byte = if addr < src_addr_end {
-            let byte = state.call_ctx()?.call_data_source[addr as usize];
+            let byte =
+                state.call_ctx()?.call_data[(addr - state.call()?.call_data_offset) as usize];
             if !is_root {
                 state.push_op(
                     exec_step,

--- a/zkevm-circuits/src/evm_circuit/execution/calldatasize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldatasize.rs
@@ -90,7 +90,8 @@ impl<F: Field> ExecutionGadget<F> for CallDataSizeGadget<F> {
 #[cfg(test)]
 mod test {
     use crate::evm_circuit::{
-        test::run_test_circuit_incomplete_fixed_table, witness::block_convert,
+        test::{rand_bytes, run_test_circuit_incomplete_fixed_table},
+        witness::block_convert,
     };
     use eth_types::{address, bytecode, Word};
     use itertools::Itertools;
@@ -119,8 +120,8 @@ mod test {
                         txs[0]
                             .from(accs[0].address)
                             .to(accs[1].address)
-                            .input(vec![0; call_data_size].into())
-                            .gas(Word::from(30000));
+                            .input(rand_bytes(call_data_size).into())
+                            .gas(Word::from(40000));
                     },
                     |block, _tx| block.number(0xcafeu64),
                 )

--- a/zkevm-circuits/src/evm_circuit/execution/calldatasize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldatasize.rs
@@ -89,108 +89,98 @@ impl<F: Field> ExecutionGadget<F> for CallDataSizeGadget<F> {
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashMap;
-
-    use bus_mapping::evm::OpcodeId;
-    use eth_types::{bytecode, Word};
-    use halo2_proofs::arithmetic::BaseExt;
-    use pairing::bn256::Fr;
-
     use crate::evm_circuit::{
-        step::ExecutionState,
-        table::{CallContextFieldTag, RwTableTag},
-        test::{rand_bytes, run_test_circuit_incomplete_fixed_table},
-        witness::{Block, Bytecode, Call, CodeSource, ExecStep, Rw, RwMap, Transaction},
+        test::run_test_circuit_incomplete_fixed_table, witness::block_convert,
     };
+    use eth_types::{address, bytecode, Word};
+    use itertools::Itertools;
+    use mock::TestContext;
 
     fn test_ok(call_data_size: usize, is_root: bool) {
-        let randomness = Fr::rand();
         let bytecode = bytecode! {
             CALLDATASIZE
             STOP
         };
-        let bytecode = Bytecode::new(bytecode.to_vec());
-        let call_id = 1;
-        let call_data = rand_bytes(call_data_size);
 
-        let mut rw_map = HashMap::new();
-        rw_map.insert(
-            RwTableTag::CallContext,
-            vec![Rw::CallContext {
-                rw_counter: 9,
-                is_write: false,
-                call_id,
-                field_tag: CallContextFieldTag::CallDataLength,
-                value: Word::from(call_data_size),
-            }],
-        );
-        rw_map.insert(
-            RwTableTag::Stack,
-            vec![Rw::Stack {
-                rw_counter: 10,
-                is_write: true,
-                call_id,
-                stack_pointer: 1023,
-                value: Word::from(call_data_size),
-            }],
-        );
-
-        let steps = vec![
-            ExecStep {
-                execution_state: ExecutionState::CALLDATASIZE,
-                rw_indices: vec![(RwTableTag::CallContext, 0), (RwTableTag::Stack, 0)],
-                rw_counter: 9,
-                program_counter: 0,
-                stack_pointer: 1024,
-                gas_left: OpcodeId::CALLDATASIZE.constant_gas_cost().as_u64(),
-                gas_cost: OpcodeId::CALLDATASIZE.constant_gas_cost().as_u64(),
-                opcode: Some(OpcodeId::CALLDATASIZE),
-                ..Default::default()
-            },
-            ExecStep {
-                execution_state: ExecutionState::STOP,
-                rw_counter: 11,
-                program_counter: 1,
-                stack_pointer: 1023,
-                gas_left: 0,
-                opcode: Some(OpcodeId::STOP),
-                ..Default::default()
-            },
-        ];
-
-        let block = Block {
-            randomness,
-            txs: vec![Transaction {
-                id: 1,
-                call_data,
-                call_data_length: call_data_size,
-                steps,
-                calls: vec![Call {
-                    id: call_id,
-                    is_root,
-                    is_create: false,
-                    call_data_length: call_data_size as u64,
-                    code_source: CodeSource::Account(bytecode.hash),
-                    ..Default::default()
-                }],
-                ..Default::default()
-            }],
-            rws: RwMap(rw_map),
-            bytecodes: vec![bytecode],
-            ..Default::default()
+        let block_data = if is_root {
+            bus_mapping::mock::BlockData::new_from_geth_data(
+                TestContext::<2, 1>::new(
+                    None,
+                    |accs| {
+                        accs[0]
+                            .address(address!("0x0000000000000000000000000000000000000000"))
+                            .balance(Word::from(1u64 << 30));
+                        accs[1]
+                            .address(address!("0x0000000000000000000000000000000000000010"))
+                            .balance(Word::from(1u64 << 20))
+                            .code(bytecode);
+                    },
+                    |mut txs, accs| {
+                        txs[0]
+                            .from(accs[0].address)
+                            .to(accs[1].address)
+                            .input(vec![0; call_data_size].into())
+                            .gas(Word::from(30000));
+                    },
+                    |block, _tx| block.number(0xcafeu64),
+                )
+                .unwrap()
+                .into(),
+            )
+        } else {
+            bus_mapping::mock::BlockData::new_from_geth_data(
+                TestContext::<3, 1>::new(
+                    None,
+                    |accs| {
+                        accs[0]
+                            .address(address!("0x0000000000000000000000000000000000000000"))
+                            .balance(Word::from(1u64 << 30));
+                        accs[1]
+                            .address(address!("0x0000000000000000000000000000000000000010"))
+                            .balance(Word::from(1u64 << 20))
+                            .code(bytecode! {
+                                PUSH1(0)
+                                PUSH1(0)
+                                PUSH32(call_data_size)
+                                PUSH1(0)
+                                PUSH1(0)
+                                PUSH1(0x20)
+                                GAS
+                                CALL
+                                STOP
+                            });
+                        accs[2]
+                            .address(address!("0x0000000000000000000000000000000000000020"))
+                            .balance(Word::from(1u64 << 20))
+                            .code(bytecode);
+                    },
+                    |mut txs, accs| {
+                        txs[0]
+                            .from(accs[0].address)
+                            .to(accs[1].address)
+                            .gas(Word::from(30000));
+                    },
+                    |block, _tx| block.number(0xcafeu64),
+                )
+                .unwrap()
+                .into(),
+            )
         };
-
+        let mut builder = block_data.new_circuit_input_builder();
+        builder
+            .handle_block(&block_data.eth_block, &block_data.geth_traces)
+            .unwrap();
+        let block = block_convert(&builder.block, &builder.code_db);
         assert_eq!(run_test_circuit_incomplete_fixed_table(block), Ok(()));
     }
 
     #[test]
     fn calldatasize_gadget_root() {
-        test_ok(32, true);
-        test_ok(64, true);
-        test_ok(96, true);
-        test_ok(128, true);
-        test_ok(256, true);
-        test_ok(512, true);
-        test_ok(1024, true);
+        for (call_data_size, is_root) in vec![32, 64, 96, 128, 256, 512, 1024]
+            .into_iter()
+            .cartesian_product([true, false])
+        {
+            test_ok(call_data_size, is_root);
+        }
     }
 }

--- a/zkevm-circuits/src/evm_circuit/witness.rs
+++ b/zkevm-circuits/src/evm_circuit/witness.rs
@@ -1099,6 +1099,7 @@ impl From<&circuit_input_builder::ExecStep> for ExecutionState {
                     OpcodeId::SELFBALANCE => ExecutionState::SELFBALANCE,
                     OpcodeId::SLOAD => ExecutionState::SLOAD,
                     OpcodeId::SSTORE => ExecutionState::SSTORE,
+                    OpcodeId::CALLDATASIZE => ExecutionState::CALLDATASIZE,
                     OpcodeId::CALLDATACOPY => ExecutionState::CALLDATACOPY,
                     OpcodeId::CHAINID => ExecutionState::CHAINID,
                     OpcodeId::ISZERO => ExecutionState::ISZERO,


### PR DESCRIPTION
This PR aims to fix some bugs of `CircuitInputBuilder` to resolve #431, it includes:

1. Doing `push_call` and `handle_return` for other call-family opcodes by `dummy_gen_call_ops`.
2. Add a copy of caller's memory as `call_data_source` in struct `CallContext` struct for `CALLDATACOPY` to be able to generate memory operations and remove `unimplement!`. However, it doesn't work when I tried to apply to circuit testing, need more investigation (appliedzkp/zkevm-specs#134 also needs to be addressed).
3. Add address into access set when code information (e.g. length and bytes) is accessed.
4. Since `CALLDATASIZE` has its `gen_associated_ops` implemented, I tried to replace handcrafted testing data for it in circuit testing to make sure it works (and unblock #419).
