### PR TITLE
Move chain_id from Tx to Block on mock 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1058,9 +1058,9 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.30"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
+checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -2095,9 +2095,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
+checksum = "ec647867e2bf0772e28c8bcde4f0d19a9216916e890543b5a03ed8ef27b8f259"
 
 [[package]]
 name = "lock_api"
@@ -2700,9 +2700,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
 dependencies = [
  "unicode-xid",
 ]
@@ -2900,7 +2900,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.22.2",
+ "webpki-roots 0.22.3",
  "winreg",
 ]
 
@@ -3374,9 +3374,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.90"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
+checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3945,9 +3945,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552ceb903e957524388c4d3475725ff2c8b7960922063af6ce53c9a43da07449"
+checksum = "44d8de8415c823c8abd270ad483c6feeac771fad964890779f9a8cb24fbbc1bf"
 dependencies = [
  "webpki 0.22.0",
 ]

--- a/mock/src/block.rs
+++ b/mock/src/block.rs
@@ -1,6 +1,6 @@
 //! Mock Block definition and builder related methods.
 
-use crate::MockTransaction;
+use crate::{MockTransaction, MOCK_CHAIN_ID};
 use eth_types::{Address, Block, Bytes, Hash, Transaction, Word, U64};
 use ethbloom::Bloom;
 
@@ -31,6 +31,10 @@ pub struct MockBlock {
     size: Word,
     mix_hash: Hash,
     nonce: U64,
+    // This field is handled here as we assume that all block txs have the same ChainId.
+    // Also, the field is stored in the block_table since we don't have a chain_config
+    // structure/table.
+    pub(crate) chain_id: Word,
 }
 
 impl Default for MockBlock {
@@ -58,12 +62,13 @@ impl Default for MockBlock {
             size: Word::zero(),
             mix_hash: Hash::zero(),
             nonce: U64::zero(),
+            chain_id: *MOCK_CHAIN_ID,
         }
     }
 }
 
 impl From<MockBlock> for Block<Transaction> {
-    fn from(mock: MockBlock) -> Self {
+    fn from(mut mock: MockBlock) -> Self {
         Block {
             hash: mock.hash.or_else(|| Some(Hash::default())),
             parent_hash: mock.parent_hash,
@@ -84,8 +89,8 @@ impl From<MockBlock> for Block<Transaction> {
             uncles: mock.uncles,
             transactions: mock
                 .transactions
-                .iter()
-                .map(|mock_tx| (mock_tx.to_owned()).into())
+                .iter_mut()
+                .map(|mock_tx| (mock_tx.chain_id(mock.chain_id).to_owned()).into())
                 .collect::<Vec<Transaction>>(),
             size: Some(mock.size),
             mix_hash: Some(mock.mix_hash),
@@ -258,6 +263,12 @@ impl MockBlock {
     /// Set nonce field for the MockBlock.
     pub fn nonce(&mut self, nonce: u64) -> &mut Self {
         self.nonce = U64::from(nonce);
+        self
+    }
+
+    /// Set chain_id field for the MockBlock.
+    pub fn chain_id(&mut self, chain_id: Word) -> &mut Self {
+        self.chain_id = chain_id;
         self
     }
 

--- a/mock/src/test_ctx.rs
+++ b/mock/src/test_ctx.rs
@@ -161,12 +161,7 @@ impl<const NACC: usize, const NTX: usize> TestContext<NACC, NTX> {
         block.transactions.extend_from_slice(&transactions);
         func_block(&mut block, transactions).build();
 
-        let transactions: Vec<Transaction> = block
-            .transactions
-            .iter()
-            .cloned()
-            .map(Transaction::from)
-            .collect();
+        let chain_id = block.chain_id;
         let block = Block::<Transaction>::from(block);
         let accounts: [Account; NACC] = accounts
             .iter()
@@ -179,7 +174,7 @@ impl<const NACC: usize, const NTX: usize> TestContext<NACC, NTX> {
         let geth_traces = gen_geth_traces(block.clone(), accounts.clone(), history_hashes.clone())?;
 
         Ok(Self {
-            chain_id: transactions[0].chain_id.unwrap_or_default(),
+            chain_id,
             accounts,
             history_hashes: history_hashes.unwrap_or_default(),
             eth_block: block,

--- a/mock/src/transaction.rs
+++ b/mock/src/transaction.rs
@@ -182,7 +182,7 @@ impl MockTransaction {
     }
 
     /// Set chain_id field for the MockBlock.
-    pub fn chain_id(&mut self, chain_id: Word) -> &mut Self {
+    pub(crate) fn chain_id(&mut self, chain_id: Word) -> &mut Self {
         self.chain_id = chain_id;
         self
     }

--- a/mock/src/transaction.rs
+++ b/mock/src/transaction.rs
@@ -95,61 +95,61 @@ impl MockTransaction {
         self
     }
 
-    /// Set block_hash field for the MockBlock.
+    /// Set block_hash field for the MockTransaction.
     pub fn block_hash(&mut self, block_hash: Hash) -> &mut Self {
         self.block_hash = block_hash;
         self
     }
 
-    /// Set block_number field for the MockBlock.
+    /// Set block_number field for the MockTransaction.
     pub fn block_number(&mut self, block_number: u64) -> &mut Self {
         self.block_number = U64::from(block_number);
         self
     }
 
-    /// Set transaction_idx field for the MockBlock.
+    /// Set transaction_idx field for the MockTransaction.
     pub fn transaction_idx(&mut self, transaction_idx: u64) -> &mut Self {
         self.transaction_index = U64::from(transaction_idx);
         self
     }
 
-    /// Set from field for the MockBlock.
+    /// Set from field for the MockTransaction.
     pub fn from(&mut self, from: Address) -> &mut Self {
         self.from = from;
         self
     }
 
-    /// Set to field for the MockBlock.
+    /// Set to field for the MockTransaction.
     pub fn to(&mut self, to: Address) -> &mut Self {
         self.to = Some(to);
         self
     }
 
-    /// Set value field for the MockBlock.
+    /// Set value field for the MockTransaction.
     pub fn value(&mut self, value: Word) -> &mut Self {
         self.value = value;
         self
     }
 
-    /// Set gas_price field for the MockBlock.
+    /// Set gas_price field for the MockTransaction.
     pub fn gas_price(&mut self, gas_price: Word) -> &mut Self {
         self.gas_price = gas_price;
         self
     }
 
-    /// Set gas field for the MockBlock.
+    /// Set gas field for the MockTransaction.
     pub fn gas(&mut self, gas: Word) -> &mut Self {
         self.gas = gas;
         self
     }
 
-    /// Set input field for the MockBlock.
+    /// Set input field for the MockTransaction.
     pub fn input(&mut self, input: Bytes) -> &mut Self {
         self.input = input;
         self
     }
 
-    /// Set sig_data field for the MockBlock.
+    /// Set sig_data field for the MockTransaction.
     pub fn sig_data(&mut self, data: (u64, Word, Word)) -> &mut Self {
         self.v = U64::from(data.0);
         self.r = data.1;
@@ -157,38 +157,38 @@ impl MockTransaction {
         self
     }
 
-    /// Set transaction_type field for the MockBlock.
+    /// Set transaction_type field for the MockTransaction.
     pub fn transaction_type(&mut self, transaction_type: u64) -> &mut Self {
         self.transaction_type = U64::from(transaction_type);
         self
     }
 
-    /// Set access_list field for the MockBlock.
+    /// Set access_list field for the MockTransaction.
     pub fn access_list(&mut self, access_list: AccessList) -> &mut Self {
         self.access_list = access_list;
         self
     }
 
-    /// Set max_priority_fee_per_gas field for the MockBlock.
+    /// Set max_priority_fee_per_gas field for the MockTransaction.
     pub fn max_priority_fee_per_gas(&mut self, max_priority_fee_per_gas: Word) -> &mut Self {
         self.max_priority_fee_per_gas = max_priority_fee_per_gas;
         self
     }
 
-    /// Set max_fee_per_gas field for the MockBlock.
+    /// Set max_fee_per_gas field for the MockTransaction.
     pub fn max_fee_per_gas(&mut self, max_fee_per_gas: Word) -> &mut Self {
         self.max_fee_per_gas = max_fee_per_gas;
         self
     }
 
-    /// Set chain_id field for the MockBlock.
+    /// Set chain_id field for the MockTransaction.
     pub(crate) fn chain_id(&mut self, chain_id: Word) -> &mut Self {
         self.chain_id = chain_id;
         self
     }
 
-    /// Consumes the mutable ref to the MockBlock returning the structure by
-    /// value.
+    /// Consumes the mutable ref to the MockTransaction returning the structure
+    /// by value.
     pub fn build(&mut self) -> Self {
         self.to_owned()
     }


### PR DESCRIPTION
When generating a `TestContext` now, users will be able to set the
`chain_id` parameter only at block level but not at tx one.

Anyway, `MockTransaction` will still have this field. But there's no
public API to interact with it. Instead, the values of the `chain_id`
for the txs of a block will automatically be set to the value that was
set as `chain_id` for the block.

This closes the circle on the turn arround that was done in
https://github.com/appliedzkp/zkevm-specs/pull/168 by adding `CHAINID`
as a blockCtx Opcode rather than a Tx one for simplification &
optimization purposes.

Resolves: https://github.com/appliedzkp/zkevm-circuits/issues/437