### PR TITLE
prover: add http/json-rpc daemon command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2732,6 +2732,7 @@ dependencies = [
  "eth-types",
  "ethers-providers",
  "halo2_proofs",
+ "hyper",
  "log",
  "pairing_bn256",
  "rand",

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -8,6 +8,7 @@ bus-mapping = { path = "../bus-mapping"}
 env_logger = "0.9.0"
 ethers-providers = "0.6"
 eth-types = { path = "../eth-types" }
+hyper = { version = "0.14.16", features = ["server"] }
 rand_xorshift = "0.3"
 halo2_proofs = { git = "https://github.com/appliedzkp/halo2.git", tag = "v2022_03_06" }
 log = "0.4.14"

--- a/prover/src/bin/prover_cmd.rs
+++ b/prover/src/bin/prover_cmd.rs
@@ -1,37 +1,17 @@
-use bus_mapping::circuit_input_builder::BuilderClient;
-use bus_mapping::rpc::GethClient;
 use env_logger::Env;
-use ethers_providers::Http;
-use halo2_proofs::{
-    plonk::*,
-    poly::commitment::Params,
-    transcript::{Blake2bWrite, Challenge255},
-};
-use pairing::bn256::{Fr, G1Affine};
-use rand::SeedableRng;
-use rand_xorshift::XorShiftRng;
+use halo2_proofs::poly::commitment::Params;
+use pairing::bn256::G1Affine;
 use std::env::var;
 use std::fs::File;
 use std::io::BufReader;
-use std::str::FromStr;
-use zkevm_circuits::evm_circuit::{
-    table::FixedTableTag, test::TestCircuit, witness::block_convert,
-};
-use zkevm_circuits::state_circuit::StateCircuit;
 
-#[derive(serde::Serialize)]
-pub struct Proofs {
-    state_proof: eth_types::Bytes,
-    evm_proof: eth_types::Bytes,
-}
+use prover::compute_proof::compute_proof;
 
 /// This command generates and prints the proofs to stdout.
 /// Required environment variables:
 /// - BLOCK_NUM - the block number to generate the proof for
 /// - RPC_URL - a geth http rpc that supports the debug namespace
 /// - PARAMS_PATH - a path to a file generated with the gen_params tool
-// TODO: move the proof generation into a module once we implement a rpc daemon for generating
-// proofs.
 #[tokio::main]
 async fn main() {
     env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
@@ -54,85 +34,9 @@ async fn main() {
     let params: Params<G1Affine> =
         Params::read::<_>(&mut BufReader::new(params_fs)).expect("Failed to read params");
 
-    // request & build the inputs for the circuits
-    let geth_client = GethClient::new(Http::from_str(&rpc_url).expect("GethClient from RPC_URL"));
-    let builder = BuilderClient::new(geth_client)
+    let result = compute_proof(&params, &block_num, &rpc_url)
         .await
-        .expect("BuilderClient from GethClient");
-    let builder = builder
-        .gen_inputs(block_num)
-        .await
-        .expect("gen_inputs for BLOCK_NUM");
+        .expect("compute_proof");
 
-    // TODO: only {evm,state}_proof are implemented right now
-    let evm_proof;
-    let state_proof;
-    let block = block_convert(&builder.block, &builder.code_db);
-    {
-        // generate evm_circuit proof
-        let circuit = TestCircuit::<Fr>::new(block.clone(), FixedTableTag::iterator().collect());
-
-        // TODO: can this be pre-generated to a file?
-        // related
-        // https://github.com/zcash/halo2/issues/443
-        // https://github.com/zcash/halo2/issues/449
-        let vk = keygen_vk(&params, &circuit).expect("keygen_vk for params, evm_circuit");
-        let pk = keygen_pk(&params, vk, &circuit).expect("keygen_pk for params, vk, evm_circuit");
-
-        // Create randomness
-        let rng = XorShiftRng::from_seed([
-            0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06,
-            0xbc, 0xe5,
-        ]);
-
-        // create a proof
-        let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
-        create_proof(&params, &pk, &[circuit], &[], rng, &mut transcript).expect("evm proof");
-        evm_proof = transcript.finalize();
-    }
-
-    {
-        // generate state_circuit proof
-        //
-        // TODO: this should be configurable
-        const MEMORY_ADDRESS_MAX: usize = 2000;
-        const STACK_ADDRESS_MAX: usize = 1300;
-        const MEMORY_ROWS_MAX: usize = 16384;
-        const STACK_ROWS_MAX: usize = 16384;
-        const STORAGE_ROWS_MAX: usize = 16384;
-        const GLOBAL_COUNTER_MAX: usize = MEMORY_ROWS_MAX + STACK_ROWS_MAX + STORAGE_ROWS_MAX;
-
-        let circuit = StateCircuit::<
-            Fr,
-            true,
-            GLOBAL_COUNTER_MAX,
-            MEMORY_ADDRESS_MAX,
-            STACK_ADDRESS_MAX,
-            GLOBAL_COUNTER_MAX,
-        >::new(block.randomness, &block.rws);
-
-        // TODO: same quest like in the first scope
-        let vk = keygen_vk(&params, &circuit).expect("keygen_vk for params, state_circuit");
-        let pk = keygen_pk(&params, vk, &circuit).expect("keygen_pk for params, vk, state_circuit");
-
-        // Create randomness
-        let rng = XorShiftRng::from_seed([
-            0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06,
-            0xbc, 0xe5,
-        ]);
-
-        // create a proof
-        let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
-        create_proof(&params, &pk, &[circuit], &[], rng, &mut transcript).expect("state proof");
-        state_proof = transcript.finalize();
-    }
-
-    serde_json::to_writer(
-        std::io::stdout(),
-        &Proofs {
-            evm_proof: evm_proof.into(),
-            state_proof: state_proof.into(),
-        },
-    )
-    .expect("serialize and write");
+    serde_json::to_writer(std::io::stdout(), &result).expect("serialize and write");
 }

--- a/prover/src/bin/prover_rpcd.rs
+++ b/prover/src/bin/prover_rpcd.rs
@@ -1,0 +1,267 @@
+use env_logger::Env;
+use halo2_proofs::poly::commitment::Params;
+use hyper::body::Buf;
+use hyper::body::HttpBody;
+use hyper::header::HeaderValue;
+use hyper::service::{make_service_fn, service_fn};
+use hyper::{Body, Method, Request, Response, Server, StatusCode};
+use pairing::bn256::G1Affine;
+use std::env::var;
+use std::fs::File;
+use std::sync::Arc;
+
+use prover::shared_state::SharedState;
+use prover::structs::*;
+
+/// sets default headers for CORS requests
+fn set_headers(headers: &mut hyper::HeaderMap, extended: bool) {
+    headers.insert("content-type", HeaderValue::from_static("application/json"));
+    headers.insert("access-control-allow-origin", HeaderValue::from_static("*"));
+
+    if extended {
+        headers.insert(
+            "access-control-allow-methods",
+            HeaderValue::from_static("post, get, options"),
+        );
+        headers.insert(
+            "access-control-allow-headers",
+            HeaderValue::from_static("origin, content-type, accept, x-requested-with"),
+        );
+        headers.insert("access-control-max-age", HeaderValue::from_static("300"));
+    }
+}
+
+async fn handle_request(
+    shared_state: SharedState,
+    req: Request<Body>,
+) -> Result<Response<Body>, hyper::Error> {
+    {
+        // limits the request size
+        const MAX_BODY_SIZE: u64 = 1 << 20;
+        let response_content_length = match req.body().size_hint().upper() {
+            Some(v) => v,
+            None => MAX_BODY_SIZE + 1,
+        };
+
+        if response_content_length > MAX_BODY_SIZE {
+            let mut resp = Response::new(Body::from("request too large"));
+            *resp.status_mut() = StatusCode::BAD_REQUEST;
+            return Ok(resp);
+        }
+    }
+
+    match (req.method(), req.uri().path()) {
+        (&Method::GET, "/health") => {
+            // nothing to report yet - healthy by default
+            let mut resp = Response::default();
+            set_headers(resp.headers_mut(), false);
+            Ok(resp)
+        }
+
+        // returns http 200 if busy else 204.
+        // can be used programmatically for e.g. shutting down the instance if no workis being
+        // done.
+        (&Method::GET, "/status") => {
+            let rw = shared_state.rw.lock().await;
+            let is_busy = rw.pending_tasks > 0 || rw.tasks.iter().any(|e| e.result.is_none());
+            drop(rw);
+
+            let mut resp = Response::default();
+            *resp.status_mut() = match is_busy {
+                false => StatusCode::NO_CONTENT,
+                true => StatusCode::OK,
+            };
+            set_headers(resp.headers_mut(), false);
+            Ok(resp)
+        }
+
+        // json-rpc
+        (&Method::POST, "/") => {
+            let body_bytes = hyper::body::aggregate(req.into_body())
+                .await
+                .unwrap()
+                .reader();
+            let json_req: Result<JsonRpcRequest<Vec<serde_json::Value>>, serde_json::Error> =
+                serde_json::from_reader(body_bytes);
+
+            if let Err(err) = json_req {
+                let payload = serde_json::to_vec(&JsonRpcResponseError {
+                    jsonrpc: "2.0".to_string(),
+                    id: 0.into(),
+                    error: JsonRpcError {
+                        // parser error
+                        code: -32700,
+                        message: err.to_string(),
+                    },
+                })
+                .unwrap();
+                let mut resp = Response::new(Body::from(payload));
+                set_headers(resp.headers_mut(), false);
+                return Ok(resp);
+            }
+
+            let json_req = json_req.unwrap();
+            let result: Result<serde_json::Value, String> =
+                handle_method(json_req.method.as_str(), &json_req.params, &shared_state).await;
+            let payload = match result {
+                Err(err) => {
+                    serde_json::to_vec(&JsonRpcResponseError {
+                        jsonrpc: "2.0".to_string(),
+                        id: json_req.id,
+                        error: JsonRpcError {
+                            // internal server error
+                            code: -32000,
+                            message: err,
+                        },
+                    })
+                }
+                Ok(val) => serde_json::to_vec(&JsonRpcResponse {
+                    jsonrpc: "2.0".to_string(),
+                    id: json_req.id,
+                    result: val,
+                }),
+            };
+            let mut resp = Response::new(Body::from(payload.unwrap()));
+            set_headers(resp.headers_mut(), false);
+            Ok(resp)
+        }
+
+        // serve CORS headers
+        (&Method::OPTIONS, "/") => {
+            let mut resp = Response::default();
+            set_headers(resp.headers_mut(), true);
+            Ok(resp)
+        }
+
+        // everything else
+        _ => {
+            let mut not_found = Response::default();
+            *not_found.status_mut() = StatusCode::NOT_FOUND;
+            Ok(not_found)
+        }
+    }
+}
+
+async fn handle_method(
+    method: &str,
+    params: &[serde_json::Value],
+    shared_state: &SharedState,
+) -> Result<serde_json::Value, String> {
+    match method {
+        // enqueues a task for computating proof for any given block
+        "proof" => {
+            if params.len() != 3 {
+                return Err("expected [block_num, rpc_url, retry_if_error]".to_string());
+            }
+
+            let block_num = params[0].as_u64().ok_or("block number at params[0]")?;
+            let rpc_url = params[1].as_str().ok_or("rpc url at params[1]")?;
+            let retry_if_error = params[2]
+                .as_bool()
+                .ok_or("bool retry_if_error at params[2]")?;
+
+            match shared_state
+                .get_or_enqueue(&block_num, rpc_url, &retry_if_error)
+                .await
+            {
+                // No error
+                None => Ok(serde_json::Value::Null),
+                Some(result) => {
+                    if let Err(err) = result {
+                        return Err(err);
+                    }
+
+                    Ok(serde_json::to_value(result.unwrap()).unwrap())
+                }
+            }
+        }
+        // TODO/TBD: add method to only return the witnesses for a block.
+        //  block table, tx table, etc...
+        //
+        // TODO: Add the abilitity to abort the current task.
+
+        // the following methods can be used to programmatically
+        // prune the `tasks` from the list.
+        "flushAll" => {
+            shared_state.rw.lock().await.tasks.clear();
+            Ok(serde_json::Value::Bool(true))
+        }
+        "flushPending" => {
+            shared_state
+                .rw
+                .lock()
+                .await
+                .tasks
+                .retain(|e| e.result.is_some());
+            Ok(serde_json::Value::Bool(true))
+        }
+        "flushCompleted" => {
+            shared_state
+                .rw
+                .lock()
+                .await
+                .tasks
+                .retain(|e| e.result.is_none());
+            Ok(serde_json::Value::Bool(true))
+        }
+        _ => Err("this method is not available".to_string()),
+    }
+}
+
+/// This command starts a http/json-rpc server and serves proof oriented
+/// methods. Required environment variables:
+/// - BIND - the interface address + port combination to accept connections on
+///   `[::]:1234`
+/// - PARAMS_PATH - a path to a file generated with the gen_params tool
+#[tokio::main]
+async fn main() {
+    env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
+
+    let addr = var("BIND")
+        .expect("BIND env var")
+        .parse::<std::net::SocketAddr>()
+        .expect("valid socket address");
+    let shared_state = SharedState::new();
+
+    {
+        // start the http server
+        let ctx = shared_state.clone();
+        let h1 = tokio::spawn(async move {
+            let service = make_service_fn(move |_| {
+                let ctx = ctx.clone();
+                let service = service_fn(move |req| handle_request(ctx.clone(), req));
+
+                async move { Ok::<_, hyper::Error>(service) }
+            });
+            let server = Server::bind(&addr).serve(service);
+            log::info!("Listening on http://{}", addr);
+            server.await.expect("server should be serving");
+        });
+
+        // starts the duty cycle loop
+        let ctx = shared_state.clone();
+        let h2 = tokio::spawn(async move {
+            // lazily load params
+            let params_path: String = var("PARAMS_PATH")
+                .expect("PARAMS_PATH env var")
+                .parse()
+                .expect("Cannot parse PARAMS_PATH env var");
+            // load polynomial commitment parameters
+            let params_fs = File::open(&params_path).expect("couldn't open params");
+            let params: Arc<Params<G1Affine>> = Arc::new(
+                Params::read::<_>(&mut std::io::BufReader::new(params_fs))
+                    .expect("Failed to read params"),
+            );
+            log::info!("params: initialized");
+
+            let ctx = ctx.clone();
+            loop {
+                ctx.duty_cycle(params.clone()).await;
+                tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
+            }
+        });
+
+        // wait for all tasks
+        let _ = tokio::join!(h1, h2);
+    }
+}

--- a/prover/src/compute_proof.rs
+++ b/prover/src/compute_proof.rs
@@ -1,0 +1,103 @@
+use bus_mapping::circuit_input_builder::BuilderClient;
+use bus_mapping::rpc::GethClient;
+use ethers_providers::Http;
+use halo2_proofs::{
+    plonk::*,
+    poly::commitment::Params,
+    transcript::{Blake2bWrite, Challenge255},
+};
+use pairing::bn256::{Fr, G1Affine};
+use rand::SeedableRng;
+use rand_xorshift::XorShiftRng;
+use std::str::FromStr;
+use zkevm_circuits::evm_circuit::{
+    table::FixedTableTag, test::TestCircuit, witness::block_convert,
+};
+use zkevm_circuits::state_circuit::StateCircuit;
+
+use crate::structs::Proofs;
+
+/// Gathers debug trace(s) from `rpc_url` for block `block_num` with `params`
+/// created via the `gen_params` tool.
+/// Expects a go-ethereum node with debug & archive capabilities on `rpc_url`.
+pub async fn compute_proof(
+    params: &Params<G1Affine>,
+    block_num: &u64,
+    rpc_url: &str,
+) -> Result<Proofs, Box<dyn std::error::Error>> {
+    // request & build the inputs for the circuits
+    let url = Http::from_str(rpc_url)?;
+    let geth_client = GethClient::new(url);
+    let builder = BuilderClient::new(geth_client).await?;
+    let builder = builder.gen_inputs(*block_num).await?;
+
+    // TODO: only {evm,state}_proof are implemented right now
+    let evm_proof;
+    let state_proof;
+    let block = block_convert(&builder.block, &builder.code_db);
+    {
+        // generate evm_circuit proof
+        let circuit = TestCircuit::<Fr>::new(block.clone(), FixedTableTag::iterator().collect());
+
+        // TODO: can this be pre-generated to a file?
+        // related
+        // https://github.com/zcash/halo2/issues/443
+        // https://github.com/zcash/halo2/issues/449
+        let vk = keygen_vk(params, &circuit)?;
+        let pk = keygen_pk(params, vk, &circuit)?;
+
+        // Create randomness
+        let rng = XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06,
+            0xbc, 0xe5,
+        ]);
+
+        // create a proof
+        let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
+        create_proof(params, &pk, &[circuit], &[], rng, &mut transcript)?;
+        evm_proof = transcript.finalize();
+    }
+
+    {
+        // generate state_circuit proof
+        //
+        // TODO: this should be configurable
+        const MEMORY_ADDRESS_MAX: usize = 2000;
+        const STACK_ADDRESS_MAX: usize = 1300;
+        const MEMORY_ROWS_MAX: usize = 16384;
+        const STACK_ROWS_MAX: usize = 16384;
+        const STORAGE_ROWS_MAX: usize = 16384;
+        const GLOBAL_COUNTER_MAX: usize = MEMORY_ROWS_MAX + STACK_ROWS_MAX + STORAGE_ROWS_MAX;
+
+        let circuit = StateCircuit::<
+            Fr,
+            true,
+            GLOBAL_COUNTER_MAX,
+            MEMORY_ADDRESS_MAX,
+            STACK_ADDRESS_MAX,
+            GLOBAL_COUNTER_MAX,
+        >::new(block.randomness, &block.rws);
+
+        // TODO: same quest like in the first scope
+        let vk = keygen_vk(params, &circuit)?;
+        let pk = keygen_pk(params, vk, &circuit)?;
+
+        // Create randomness
+        let rng = XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06,
+            0xbc, 0xe5,
+        ]);
+
+        // create a proof
+        let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
+        create_proof(params, &pk, &[circuit], &[], rng, &mut transcript)?;
+        state_proof = transcript.finalize();
+    }
+
+    let ret = Proofs {
+        evm_proof: evm_proof.into(),
+        state_proof: state_proof.into(),
+    };
+
+    Ok(ret)
+}

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod compute_proof;
+pub mod shared_state;
+pub mod structs;

--- a/prover/src/shared_state.rs
+++ b/prover/src/shared_state.rs
@@ -1,0 +1,172 @@
+use halo2_proofs::poly::commitment::Params;
+use pairing::bn256::G1Affine;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+use crate::compute_proof::compute_proof;
+use crate::structs::Proofs;
+
+#[derive(Debug, Clone)]
+pub struct ProofRequest {
+    pub block_num: u64,
+    pub rpc_url: String,
+    pub result: Option<Result<Proofs, String>>,
+}
+
+pub struct RwState {
+    pub tasks: Vec<ProofRequest>,
+    pub pending_tasks: u32,
+}
+
+#[derive(Clone)]
+pub struct SharedState {
+    pub rw: Arc<Mutex<RwState>>,
+}
+
+impl SharedState {
+    pub fn new() -> SharedState {
+        Self {
+            rw: Arc::new(Mutex::new(RwState {
+                tasks: Vec::new(),
+                pending_tasks: 0,
+            })),
+        }
+    }
+
+    /// Will return the result or error of the task if it's completed.
+    /// Otherwise enqueues the task and returns `None`.
+    /// `retry_if_error` enqueues the task again if it returned with an error
+    /// before.
+    pub async fn get_or_enqueue(
+        &self,
+        block_num: &u64,
+        rpc_url: &str,
+        retry_if_error: &bool,
+    ) -> Option<Result<Proofs, String>> {
+        let mut rw = self.rw.lock().await;
+
+        // task already pending or completed?
+        let task = rw
+            .tasks
+            .iter_mut()
+            .find(|e| e.block_num == *block_num && e.rpc_url == *rpc_url);
+
+        if task.is_some() {
+            let mut task = task.unwrap();
+
+            if task.result.is_some() {
+                if *retry_if_error && task.result.as_ref().unwrap().is_err() {
+                    log::info!("retrying: {:#?}", task);
+                    // will be a candidate in `duty_cycle` again
+                    task.result = None;
+                } else {
+                    log::info!("completed: {:#?}", task);
+                    return task.result.clone();
+                }
+            } else {
+                log::info!("pending: {:#?}", task);
+                return None;
+            }
+        } else {
+            // enqueue the task
+            let task = ProofRequest {
+                block_num: *block_num,
+                rpc_url: rpc_url.to_string(),
+                result: None,
+            };
+            log::info!("enqueue: {:#?}", task);
+            rw.tasks.push(task);
+        }
+
+        None
+    }
+
+    /// Checks if there is anything to do like:
+    /// - records if a task completed
+    /// - starting a new task
+    /// Blocks until completion but releases the lock of `self.rw` in between.
+    pub async fn duty_cycle(&self, params: Arc<Params<G1Affine>>) {
+        let mut rw = self.rw.lock().await;
+
+        if rw.pending_tasks > 0 {
+            // already computing
+            // TODO: can spawn multiple tasks if ever required
+            return;
+        }
+
+        // find a pending task
+        let pending_task = rw.tasks.iter().find(|&e| e.result.is_none());
+        if pending_task.is_none() {
+            // nothing to do
+            return;
+        }
+
+        // needs to be cloned because of long running tasks and
+        // the possibility that the task gets removed in the meantime
+        let pending_task = pending_task.unwrap().clone();
+        {
+            rw.pending_tasks += 1;
+            log::info!("compute_proof: {:#?}", pending_task);
+            drop(rw);
+        }
+
+        // Note: this catches any panics for the task itself but will not help in the
+        // situation when the process get itself OOM killed, stack overflows etc.
+        // This could be avoided by spawning a subprocess for the proof computation
+        // instead.
+
+        let _pending_task = pending_task.clone();
+        let task_result: Result<Result<Proofs, String>, tokio::task::JoinError> =
+            tokio::spawn(async move {
+                let res = compute_proof(
+                    params.as_ref(),
+                    &_pending_task.block_num,
+                    &_pending_task.rpc_url,
+                )
+                .await;
+
+                if let Err(err) = res {
+                    // cast Error to string
+                    return Err(err.to_string());
+                }
+
+                Ok(res.unwrap())
+            })
+            .await;
+
+        // convert the JoinError to string - if applicable
+        let task_result: Result<Proofs, String> = match task_result {
+            Err(err) => Err(err.to_string()),
+            Ok(val) => val,
+        };
+
+        {
+            // done, update the queue
+            log::info!("task_result: {:#?}", task_result);
+
+            let mut rw = self.rw.lock().await;
+            rw.pending_tasks -= 1;
+
+            let task = rw.tasks.iter_mut().find(|e| {
+                e.block_num == pending_task.block_num && e.rpc_url == pending_task.rpc_url
+            });
+            if let Some(task) = task {
+                // found our task, update result
+                task.result = Some(task_result);
+            } else {
+                // task was already removed in the meantime, insert it again
+                rw.tasks.push(ProofRequest {
+                    block_num: pending_task.block_num,
+                    rpc_url: pending_task.rpc_url,
+                    result: Some(task_result),
+                });
+            }
+        }
+    }
+}
+
+impl Default for SharedState {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/prover/src/structs.rs
+++ b/prover/src/structs.rs
@@ -1,0 +1,32 @@
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct Proofs {
+    pub state_proof: eth_types::Bytes,
+    pub evm_proof: eth_types::Bytes,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct JsonRpcError {
+    pub code: i32,
+    pub message: String,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct JsonRpcResponseError {
+    pub jsonrpc: String,
+    pub id: serde_json::Value,
+    pub error: JsonRpcError,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct JsonRpcResponse<T: serde::Serialize> {
+    pub jsonrpc: String,
+    pub id: serde_json::Value,
+    pub result: T,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct JsonRpcRequest<T: serde::Serialize> {
+    pub id: serde_json::Value,
+    pub method: String,
+    pub params: T,
+}


### PR DESCRIPTION
* Moves the proof computation function from prover_cmd into a module.
* Add prover_rpcd that provides a task-queue-like JSON-RPC interface
  for dispatching proof generation work.