### PR TITLE
feat: Add specific CODEOWNERS for particular code sections

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,15 @@
+# For any file modification done to the repo, `zkevm-reviewers` team will be requested a review.
 * @appliedzkp/zkevm-reviewers
 
+# PRs done to `prover` workspace member will require an extra review from @pinkiebell.
+prover/* @pinkiebell
+
+# PRs done to `mock` workspace will require an extra review from @CPerezz
+mock/* @CPerezz
+
+# Prs done to `integration-tests` will require an extra review from @ed255
+integration-tests/* @ed255
+
+# Prs done to `zkevm-circuits/state-circuit` will require an extra review from @miha-stopar
 zkevm-circuits/src/state_circuit/ @miha-stopar
 zkevm-circuits/src/state_circuit.rs @miha-stopar


### PR DESCRIPTION
As discussed in the ZKEVM team meeting at 2022/04/08 we will request a
review extra to mantainers that have build and mantained almost
completely any of the workspace members.

On that way, the person that is most inline with the code is able to
provide a more accurate review for the code changes.