### PR TITLE
change: Update sdb/storage-related ops warm check fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2048,9 +2048,9 @@ checksum = "229d53d58899083193af11e15917b5640cd40b29ff475a1fe4ef725deb02d0f2"
 
 [[package]]
 name = "js-sys"
-version = "0.3.56"
+version = "0.3.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
+checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3827,9 +3827,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
+checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -3837,9 +3837,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
+checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3852,9 +3852,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb6ec270a31b1d3c7e266b999739109abce8b6c87e4b31fcfcd788b65267395"
+checksum = "6f741de44b75e14c35df886aff5f1eb73aa114fa5d4d00dcd37b5e01259bf3b2"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -3864,9 +3864,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
+checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3874,9 +3874,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
+checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3887,9 +3887,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
+checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
 
 [[package]]
 name = "wasm-timer"
@@ -3908,9 +3908,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.56"
+version = "0.3.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
+checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -1150,19 +1150,19 @@ impl<'a> CircuitInputStateRef<'a> {
                 self.sdb.set_storage(&op.address, &op.key, &op.value);
             }
             OpEnum::TxAccessListAccount(op) => {
-                if !op.value_prev && op.value {
+                if !op.is_warm_prev && op.is_warm {
                     self.sdb.add_account_to_access_list(op.address);
                 }
-                if op.value_prev && !op.value {
+                if op.is_warm_prev && !op.is_warm {
                     self.sdb.remove_account_from_access_list(&op.address);
                 }
             }
             OpEnum::TxAccessListAccountStorage(op) => {
-                if !op.value_prev && op.value {
+                if !op.is_warm_prev && op.is_warm {
                     self.sdb
                         .add_account_storage_to_access_list((op.address, op.key));
                 }
-                if op.value_prev && !op.value {
+                if op.is_warm_prev && !op.is_warm {
                     self.sdb
                         .remove_account_storage_from_access_list(&(op.address, op.key));
                 }

--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -300,8 +300,8 @@ pub fn gen_begin_tx_ops(state: &mut CircuitInputStateRef) -> Result<ExecStep, Er
             TxAccessListAccountOp {
                 tx_id: state.tx_ctx.id(),
                 address,
-                value: true,
-                value_prev: false,
+                is_warm: true,
+                is_warm_prev: false,
             },
         );
     }

--- a/bus-mapping/src/evm/opcodes/call.rs
+++ b/bus-mapping/src/evm/opcodes/call.rs
@@ -87,8 +87,8 @@ impl Opcode for Call {
             TxAccessListAccountOp {
                 tx_id,
                 address: callee.address,
-                value: true,
-                value_prev: is_warm_access,
+                is_warm: true,
+                is_warm_prev: is_warm_access,
             },
         )?;
 

--- a/bus-mapping/src/evm/opcodes/extcodehash.rs
+++ b/bus-mapping/src/evm/opcodes/extcodehash.rs
@@ -70,8 +70,8 @@ impl Opcode for Extcodehash {
             TxAccessListAccountOp {
                 tx_id: state.tx_ctx.id(),
                 address: external_address,
-                value: true,
-                value_prev: is_warm,
+                is_warm: true,
+                is_warm_prev: is_warm,
             },
         )?;
 
@@ -305,8 +305,8 @@ mod extcodehash_tests {
                 &TxAccessListAccountOp {
                     tx_id,
                     address: external_address,
-                    value: true,
-                    value_prev: is_warm
+                    is_warm: true,
+                    is_warm_prev: is_warm
                 }
             )
         );

--- a/bus-mapping/src/evm/opcodes/sload.rs
+++ b/bus-mapping/src/evm/opcodes/sload.rs
@@ -99,8 +99,8 @@ impl Opcode for Sload {
                 tx_id: state.tx_ctx.id(),
                 address: contract_addr,
                 key,
-                value: true,
-                value_prev: is_warm,
+                is_warm: true,
+                is_warm_prev: is_warm,
             },
         )?;
 
@@ -209,8 +209,8 @@ mod sload_tests {
                     tx_id: 1,
                     address: MOCK_ACCOUNTS[0],
                     key: Word::from(0x0u32),
-                    value: true,
-                    value_prev: is_warm,
+                    is_warm: true,
+                    is_warm_prev: is_warm,
                 },
             )
         )

--- a/bus-mapping/src/evm/opcodes/sstore.rs
+++ b/bus-mapping/src/evm/opcodes/sstore.rs
@@ -98,8 +98,8 @@ impl Opcode for Sstore {
                 tx_id: state.tx_ctx.id(),
                 address: state.call()?.address,
                 key,
-                value: true,
-                value_prev: is_warm,
+                is_warm: true,
+                is_warm_prev: is_warm,
             },
         )?;
 

--- a/bus-mapping/src/operation.rs
+++ b/bus-mapping/src/operation.rs
@@ -393,7 +393,7 @@ impl fmt::Debug for TxAccessListAccountOp {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("TxAccessListAccountOp { ")?;
         f.write_fmt(format_args!(
-            "tx_id: {:?}, addr: {:?}, val_prev: {:?}, val: {:?}",
+            "tx_id: {:?}, addr: {:?}, is_warm_prev: {:?}, is_warm: {:?}",
             self.tx_id, self.address, self.is_warm_prev, self.is_warm
         ))?;
         f.write_str(" }")
@@ -444,7 +444,7 @@ impl fmt::Debug for TxAccessListAccountStorageOp {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("TxAccessListAccountStorageOp { ")?;
         f.write_fmt(format_args!(
-            "tx_id: {:?}, addr: {:?}, key: 0x{:x}, val_prev: {:?}, val: {:?}",
+            "tx_id: {:?}, addr: {:?}, key: 0x{:x}, is_warm_prev: {:?}, is_warm: {:?}",
             self.tx_id, self.address, self.key, self.is_warm_prev, self.is_warm
         ))?;
         f.write_str(" }")
@@ -603,7 +603,7 @@ impl fmt::Debug for AccountDestructedOp {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("AccountDestructedOp { ")?;
         f.write_fmt(format_args!(
-            "tx_id: {:?}, addr: {:?}, val_prev: {:?}, val: {:?}",
+            "tx_id: {:?}, addr: {:?}, is_destructed_prev: {:?}, is_destructed: {:?}",
             self.tx_id, self.address, self.is_destructed_prev, self.is_destructed
         ))?;
         f.write_str(" }")

--- a/bus-mapping/src/operation.rs
+++ b/bus-mapping/src/operation.rs
@@ -382,10 +382,11 @@ pub struct TxAccessListAccountOp {
     pub tx_id: usize,
     /// Account Address
     pub address: Address,
-    /// Value after the operation
-    pub value: bool,
-    /// Value before the operation
-    pub value_prev: bool,
+    /// Represents whether we can classify the access to the value as `WARM`.
+    pub is_warm: bool,
+    /// Represents whether we can classify the access to the previous value as
+    /// `WARM`.
+    pub is_warm_prev: bool,
 }
 
 impl fmt::Debug for TxAccessListAccountOp {
@@ -393,7 +394,7 @@ impl fmt::Debug for TxAccessListAccountOp {
         f.write_str("TxAccessListAccountOp { ")?;
         f.write_fmt(format_args!(
             "tx_id: {:?}, addr: {:?}, val_prev: {:?}, val: {:?}",
-            self.tx_id, self.address, self.value_prev, self.value
+            self.tx_id, self.address, self.is_warm_prev, self.is_warm
         ))?;
         f.write_str(" }")
     }
@@ -418,7 +419,7 @@ impl Op for TxAccessListAccountOp {
 
     fn reverse(&self) -> Self {
         let mut rev = self.clone();
-        swap(&mut rev.value, &mut rev.value_prev);
+        swap(&mut rev.is_warm, &mut rev.is_warm_prev);
         rev
     }
 }
@@ -433,10 +434,10 @@ pub struct TxAccessListAccountStorageOp {
     pub address: Address,
     /// Storage Key
     pub key: Word,
-    /// Value after the operation
-    pub value: bool,
-    /// Value before the operation
-    pub value_prev: bool,
+    /// Whether the access was classified as `WARM` or not.
+    pub is_warm: bool,
+    /// Whether the prev_value access was classified as `WARM` or not.
+    pub is_warm_prev: bool,
 }
 
 impl fmt::Debug for TxAccessListAccountStorageOp {
@@ -444,7 +445,7 @@ impl fmt::Debug for TxAccessListAccountStorageOp {
         f.write_str("TxAccessListAccountStorageOp { ")?;
         f.write_fmt(format_args!(
             "tx_id: {:?}, addr: {:?}, key: 0x{:x}, val_prev: {:?}, val: {:?}",
-            self.tx_id, self.address, self.key, self.value_prev, self.value
+            self.tx_id, self.address, self.key, self.is_warm_prev, self.is_warm
         ))?;
         f.write_str(" }")
     }
@@ -469,7 +470,7 @@ impl Op for TxAccessListAccountStorageOp {
 
     fn reverse(&self) -> Self {
         let mut rev = self.clone();
-        swap(&mut rev.value, &mut rev.value_prev);
+        swap(&mut rev.is_warm, &mut rev.is_warm_prev);
         rev
     }
 }
@@ -592,10 +593,10 @@ pub struct AccountDestructedOp {
     pub tx_id: usize,
     /// Account Address
     pub address: Address,
-    /// Value after the operation
-    pub value: bool,
-    /// Value before the operation
-    pub value_prev: bool,
+    /// Whether the account is destructed.
+    pub is_destructed: bool,
+    /// Whether the account was previously destructed.
+    pub is_destructed_prev: bool,
 }
 
 impl fmt::Debug for AccountDestructedOp {
@@ -603,7 +604,7 @@ impl fmt::Debug for AccountDestructedOp {
         f.write_str("AccountDestructedOp { ")?;
         f.write_fmt(format_args!(
             "tx_id: {:?}, addr: {:?}, val_prev: {:?}, val: {:?}",
-            self.tx_id, self.address, self.value_prev, self.value
+            self.tx_id, self.address, self.is_destructed_prev, self.is_destructed
         ))?;
         f.write_str(" }")
     }
@@ -628,7 +629,7 @@ impl Op for AccountDestructedOp {
 
     fn reverse(&self) -> Self {
         let mut rev = self.clone();
-        swap(&mut rev.value, &mut rev.value_prev);
+        swap(&mut rev.is_destructed, &mut rev.is_destructed_prev);
         rev
     }
 }

--- a/zkevm-circuits/src/evm_circuit/witness.rs
+++ b/zkevm-circuits/src/evm_circuit/witness.rs
@@ -427,8 +427,8 @@ pub enum Rw {
         is_write: bool,
         tx_id: usize,
         account_address: Address,
-        value: bool,
-        value_prev: bool,
+        is_warm: bool,
+        is_warm_prev: bool,
     },
     TxAccessListAccountStorage {
         rw_counter: usize,
@@ -436,8 +436,8 @@ pub enum Rw {
         tx_id: usize,
         account_address: Address,
         storage_key: Word,
-        value: bool,
-        value_prev: bool,
+        is_warm: bool,
+        is_warm_prev: bool,
     },
     TxRefund {
         rw_counter: usize,
@@ -469,8 +469,8 @@ pub enum Rw {
         is_write: bool,
         tx_id: usize,
         account_address: Address,
-        value: bool,
-        value_prev: bool,
+        is_destructed: bool,
+        is_destructed_prev: bool,
     },
     CallContext {
         rw_counter: usize,
@@ -545,11 +545,15 @@ impl Rw {
     pub fn tx_access_list_value_pair(&self) -> (bool, bool) {
         match self {
             Self::TxAccessListAccount {
-                value, value_prev, ..
-            } => (*value, *value_prev),
+                is_warm,
+                is_warm_prev,
+                ..
+            } => (*is_warm, *is_warm_prev),
             Self::TxAccessListAccountStorage {
-                value, value_prev, ..
-            } => (*value, *value_prev),
+                is_warm,
+                is_warm_prev,
+                ..
+            } => (*is_warm, *is_warm_prev),
             _ => unreachable!(),
         }
     }
@@ -624,8 +628,8 @@ impl Rw {
                 is_write,
                 tx_id,
                 account_address,
-                value,
-                value_prev,
+                is_warm,
+                is_warm_prev,
             } => [
                 F::from(*rw_counter as u64),
                 F::from(*is_write as u64),
@@ -634,8 +638,8 @@ impl Rw {
                 account_address.to_scalar().unwrap(),
                 F::zero(),
                 F::zero(),
-                F::from(*value as u64),
-                F::from(*value_prev as u64),
+                F::from(*is_warm as u64),
+                F::from(*is_warm_prev as u64),
                 F::zero(),
                 F::zero(),
             ]
@@ -646,8 +650,8 @@ impl Rw {
                 tx_id,
                 account_address,
                 storage_key,
-                value,
-                value_prev,
+                is_warm,
+                is_warm_prev,
             } => [
                 F::from(*rw_counter as u64),
                 F::from(*is_write as u64),
@@ -659,8 +663,8 @@ impl Rw {
                     storage_key.to_le_bytes(),
                     randomness,
                 ),
-                F::from(*value as u64),
-                F::from(*value_prev as u64),
+                F::from(*is_warm as u64),
+                F::from(*is_warm_prev as u64),
                 F::zero(),
                 F::zero(),
             ]
@@ -852,8 +856,8 @@ impl From<&operation::OperationContainer> for RwMap {
                     is_write: true,
                     tx_id: op.op().tx_id,
                     account_address: op.op().address,
-                    value: op.op().value,
-                    value_prev: op.op().value_prev,
+                    is_warm: op.op().is_warm,
+                    is_warm_prev: op.op().is_warm_prev,
                 })
                 .collect(),
         );
@@ -868,8 +872,8 @@ impl From<&operation::OperationContainer> for RwMap {
                     tx_id: op.op().tx_id,
                     account_address: op.op().address,
                     storage_key: op.op().key,
-                    value: op.op().value,
-                    value_prev: op.op().value_prev,
+                    is_warm: op.op().is_warm,
+                    is_warm_prev: op.op().is_warm_prev,
                 })
                 .collect(),
         );
@@ -933,8 +937,8 @@ impl From<&operation::OperationContainer> for RwMap {
                     is_write: true,
                     tx_id: op.op().tx_id,
                     account_address: op.op().address,
-                    value: op.op().value,
-                    value_prev: op.op().value_prev,
+                    is_destructed: op.op().is_destructed,
+                    is_destructed_prev: op.op().is_destructed_prev,
                 })
                 .collect(),
         );


### PR DESCRIPTION
`TxAccessListAccountOp`, `TxAccessListAccountStorageOp` and
`AccountDestructedOp` contain fields called `value` and `value_prev`
which basically are `bool`s marking whether the access to these values in the operation are WARM or not.

Makes more sense to name them as `is_warm`/`is_warm_prev`
(is_destructed/is_destructed_prev for `AccountDestructedOp`.

Resolves: #442