### PR TITLE
fix Execution::assign_block_exact to allow gen vk from empty circuit

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -607,9 +607,9 @@ impl<F: Field> ExecutionConfig<F> {
                         offset += STEP_HEIGHT;
                     }
                 }
-
-                self.q_step_last.enable(&mut region, offset - STEP_HEIGHT)?;
-
+                if offset >= STEP_HEIGHT {
+                    self.q_step_last.enable(&mut region, offset - STEP_HEIGHT)?;
+                }
                 Ok(())
             },
         )

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -607,7 +607,6 @@ impl<F: Field> ExecutionConfig<F> {
                         offset += STEP_HEIGHT;
                     }
                 }
-                
                 if offset >= STEP_HEIGHT {
                     self.q_step_last.enable(&mut region, offset - STEP_HEIGHT)?;
                 }

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -607,6 +607,7 @@ impl<F: Field> ExecutionConfig<F> {
                         offset += STEP_HEIGHT;
                     }
                 }
+                
                 if offset >= STEP_HEIGHT {
                     self.q_step_last.enable(&mut region, offset - STEP_HEIGHT)?;
                 }


### PR DESCRIPTION


or else, empty circuit cannot be synthesized