### PR TITLE
chore(github CI): use `pull_request_target` event for external reveiwers

### DIFF
--- a/.github/workflows/external_reviewers_assig.yml
+++ b/.github/workflows/external_reviewers_assig.yml
@@ -1,6 +1,6 @@
 name: "Reviewer lottery"
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 jobs:


### PR DESCRIPTION
test