### PR TITLE
Try wrap read/write ops 

### DIFF
--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -13,7 +13,7 @@ mod transaction;
 use self::access::gen_state_access_trace;
 use crate::error::Error;
 use crate::evm::opcodes::{gen_associated_ops, gen_begin_tx_ops, gen_end_tx_ops};
-use crate::operation::{CallContextField, CallContextOp, RW};
+use crate::operation::{CallContextField, RW};
 use crate::rpc::GethClient;
 use crate::state_db::{self, CodeDB, StateDB};
 pub use access::{Access, AccessSet, AccessValue, CodeSource};

--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -13,7 +13,7 @@ mod transaction;
 use self::access::gen_state_access_trace;
 use crate::error::Error;
 use crate::evm::opcodes::{gen_associated_ops, gen_begin_tx_ops, gen_end_tx_ops};
-use crate::operation::{CallContextField, RW};
+use crate::operation::{CallContextField, CallContextOp, RW};
 use crate::rpc::GethClient;
 use crate::state_db::{self, CodeDB, StateDB};
 pub use access::{Access, AccessSet, AccessValue, CodeSource};

--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -95,11 +95,12 @@ impl<'a> CircuitInputStateRef<'a> {
         step.bus_mapping_instance.push(op_ref);
     }
 
-    /// Push a read type [`CallContextOp`] into the [`OperationContainer`] with
-    /// the next [`RWCounter`] and then adds a reference to the stored
-    /// operation ([`OperationRef`]) inside the bus-mapping instance of the
-    /// current [`ExecStep`].  Then increase the block_ctx [`RWCounter`] by
-    /// one.
+    /// Push a read type [`CallContextOp`] into the
+    /// [`OperationContainer`](crate::operation::OperationContainer) with
+    /// the next [`RWCounter`](crate::operation::RWCounter)  and then adds a
+    /// reference to the stored operation ([`OperationRef`]) inside the
+    /// bus-mapping instance of the current [`ExecStep`].  Then increase the
+    /// block_ctx [`RWCounter`](crate::operation::RWCounter)  by one.
     pub fn call_context_read(
         &mut self,
         step: &mut ExecStep,
@@ -178,11 +179,12 @@ impl<'a> CircuitInputStateRef<'a> {
         Ok(())
     }
 
-    /// Push a read type [`MemoryOp`] into the [`OperationContainer`] with the
-    /// next [`RWCounter`] and `call_id`, and then adds a reference to
-    /// the stored operation ([`OperationRef`]) inside the bus-mapping
-    /// instance of the current [`ExecStep`].  Then increase the `block_ctx`
-    /// [`RWCounter`] by one.
+    /// Push a read type [`MemoryOp`] into the
+    /// [`OperationContainer`](crate::operation::OperationContainer) with the
+    /// next [`RWCounter`](crate::operation::RWCounter) and `call_id`, and then
+    /// adds a reference to the stored operation ([`OperationRef`]) inside
+    /// the bus-mapping instance of the current [`ExecStep`].  Then increase
+    /// the `block_ctx` [`RWCounter`](crate::operation::RWCounter) by one.
     pub fn memory_read(
         &mut self,
         step: &mut ExecStep,
@@ -194,11 +196,12 @@ impl<'a> CircuitInputStateRef<'a> {
         Ok(())
     }
 
-    /// Push a write type [`MemoryOp`] into the [`OperationContainer`] with the
-    /// next [`RWCounter`] and `call_id`, and then adds a reference to
-    /// the stored operation ([`OperationRef`]) inside the bus-mapping
-    /// instance of the current [`ExecStep`].  Then increase the `block_ctx`
-    /// [`RWCounter`] by one.
+    /// Push a write type [`MemoryOp`] into the
+    /// [`OperationContainer`](crate::operation::OperationContainer) with the
+    /// next [`RWCounter`](crate::operation::RWCounter) and `call_id`, and then
+    /// adds a reference to the stored operation ([`OperationRef`]) inside
+    /// the bus-mapping instance of the current [`ExecStep`].  Then increase
+    /// the `block_ctx` [`RWCounter`](crate::operation::RWCounter)  by one.
     pub fn memory_write(
         &mut self,
         step: &mut ExecStep,
@@ -229,11 +232,12 @@ impl<'a> CircuitInputStateRef<'a> {
         Ok(())
     }
 
-    /// Push a write type [`StackOp`] into the [`OperationContainer`] with the
-    /// next [`RWCounter`] and `call_id`, and then adds a reference to
-    /// the stored operation ([`OperationRef`]) inside the bus-mapping
-    /// instance of the current [`ExecStep`].  Then increase the `block_ctx`
-    /// [`RWCounter`] by one.
+    /// Push a write type [`StackOp`] into the
+    /// [`OperationContainer`](crate::operation::OperationContainer) with the
+    /// next [`RWCounter`](crate::operation::RWCounter)  and `call_id`, and then
+    /// adds a reference to the stored operation ([`OperationRef`]) inside
+    /// the bus-mapping instance of the current [`ExecStep`].  Then increase
+    /// the `block_ctx` [`RWCounter`](crate::operation::RWCounter) by one.
     pub fn stack_write(
         &mut self,
         step: &mut ExecStep,
@@ -245,11 +249,12 @@ impl<'a> CircuitInputStateRef<'a> {
         Ok(())
     }
 
-    /// Push a read type [`StackOp`] into the [`OperationContainer`] with the
-    /// next [`RWCounter`] and `call_id`, and then adds a reference to
-    /// the stored operation ([`OperationRef`]) inside the bus-mapping
-    /// instance of the current [`ExecStep`].  Then increase the `block_ctx`
-    /// [`RWCounter`] by one.
+    /// Push a read type [`StackOp`] into the
+    /// [`OperationContainer`](crate::operation::OperationContainer) with the
+    /// next [`RWCounter`](crate::operation::RWCounter)  and `call_id`, and then
+    /// adds a reference to the stored operation ([`OperationRef`]) inside
+    /// the bus-mapping instance of the current [`ExecStep`].  Then increase
+    /// the `block_ctx` [`RWCounter`](crate::operation::RWCounter)  by one.
     pub fn stack_read(
         &mut self,
         step: &mut ExecStep,

--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -7,7 +7,10 @@ use super::{
 use crate::{
     error::{get_step_reported_error, ExecError},
     exec_trace::OperationRef,
-    operation::{AccountField, MemoryOp, Op, OpEnum, Operation, StackOp, Target, RW},
+    operation::{
+        AccountField, CallContextField, CallContextOp, MemoryOp, Op, OpEnum, Operation, StackOp,
+        Target, RW,
+    },
     state_db::{CodeDB, StateDB},
     Error,
 };
@@ -92,6 +95,27 @@ impl<'a> CircuitInputStateRef<'a> {
         step.bus_mapping_instance.push(op_ref);
     }
 
+    /// Push a read type [`CallContextOp`] into the [`OperationContainer`] with
+    /// the next [`RWCounter`] and then adds a reference to the stored
+    /// operation ([`OperationRef`]) inside the bus-mapping instance of the
+    /// current [`ExecStep`].  Then increase the block_ctx [`RWCounter`] by
+    /// one.
+    pub fn call_context_read(
+        &mut self,
+        step: &mut ExecStep,
+        call_id: usize,
+        field: CallContextField,
+        value: Word,
+    ) {
+        let op = CallContextOp {
+            call_id,
+            field,
+            value,
+        };
+
+        self.push_op(step, RW::READ, op);
+    }
+
     /// Push an [`Operation`](crate::operation::Operation) with reversible to be
     /// true into the
     /// [`OperationContainer`](crate::operation::OperationContainer) with the
@@ -154,6 +178,38 @@ impl<'a> CircuitInputStateRef<'a> {
         Ok(())
     }
 
+    /// Push a read type [`MemoryOp`] into the [`OperationContainer`] with the
+    /// next [`RWCounter`] and `call_id`, and then adds a reference to
+    /// the stored operation ([`OperationRef`]) inside the bus-mapping
+    /// instance of the current [`ExecStep`].  Then increase the `block_ctx`
+    /// [`RWCounter`] by one.
+    pub fn memory_read(
+        &mut self,
+        step: &mut ExecStep,
+        address: MemoryAddress,
+        value: u8,
+    ) -> Result<(), Error> {
+        let call_id = self.call()?.call_id;
+        self.push_op(step, RW::READ, MemoryOp::new(call_id, address, value));
+        Ok(())
+    }
+
+    /// Push a write type [`MemoryOp`] into the [`OperationContainer`] with the
+    /// next [`RWCounter`] and `call_id`, and then adds a reference to
+    /// the stored operation ([`OperationRef`]) inside the bus-mapping
+    /// instance of the current [`ExecStep`].  Then increase the `block_ctx`
+    /// [`RWCounter`] by one.
+    pub fn memory_write(
+        &mut self,
+        step: &mut ExecStep,
+        address: MemoryAddress,
+        value: u8,
+    ) -> Result<(), Error> {
+        let call_id = self.call()?.call_id;
+        self.push_op(step, RW::WRITE, MemoryOp::new(call_id, address, value));
+        Ok(())
+    }
+
     /// Push a [`StackOp`] into the
     /// [`OperationContainer`](crate::operation::OperationContainer) with the
     /// next [`RWCounter`](crate::operation::RWCounter) and `call_id`, and
@@ -170,6 +226,38 @@ impl<'a> CircuitInputStateRef<'a> {
     ) -> Result<(), Error> {
         let call_id = self.call()?.call_id;
         self.push_op(step, rw, StackOp::new(call_id, address, value));
+        Ok(())
+    }
+
+    /// Push a write type [`StackOp`] into the [`OperationContainer`] with the
+    /// next [`RWCounter`] and `call_id`, and then adds a reference to
+    /// the stored operation ([`OperationRef`]) inside the bus-mapping
+    /// instance of the current [`ExecStep`].  Then increase the `block_ctx`
+    /// [`RWCounter`] by one.
+    pub fn stack_write(
+        &mut self,
+        step: &mut ExecStep,
+        address: StackAddress,
+        value: Word,
+    ) -> Result<(), Error> {
+        let call_id = self.call()?.call_id;
+        self.push_op(step, RW::WRITE, StackOp::new(call_id, address, value));
+        Ok(())
+    }
+
+    /// Push a read type [`StackOp`] into the [`OperationContainer`] with the
+    /// next [`RWCounter`] and `call_id`, and then adds a reference to
+    /// the stored operation ([`OperationRef`]) inside the bus-mapping
+    /// instance of the current [`ExecStep`].  Then increase the `block_ctx`
+    /// [`RWCounter`] by one.
+    pub fn stack_read(
+        &mut self,
+        step: &mut ExecStep,
+        address: StackAddress,
+        value: Word,
+    ) -> Result<(), Error> {
+        let call_id = self.call()?.call_id;
+        self.push_op(step, RW::READ, StackOp::new(call_id, address, value));
         Ok(())
     }
 


### PR DESCRIPTION
currently in buss mapping op codes,   it is often used` state.push_op(xxx)`, which is not very much meaningful & readable,  
Here try to wrap read/write ops  with specific op naming, like `call_context_read` `memory_read` `stack_write` etc.    this PR just update `sload` `mload` as an example !
Glad to know if you like it !    

if so, we update all op types in further PR, Thanks !