### PR TITLE
Multi-AZ provers

### DIFF
--- a/.github/proverCiScripts/execBench.sh
+++ b/.github/proverCiScripts/execBench.sh
@@ -10,27 +10,26 @@ circuit=$(echo $3 | awk '{ print $2 }' | tr '[:upper:]' '[:lower:]')
 printf -v _date '%(%Y-%m-%d_%H:%M:%S)T' -1
 
 case $circuit in
-   "all")
-      echo "To be implemented"
-      exit 1
-      ;;
-   "evm")
-      run_suffix="evm_circuit_prover"
-      ;;
-   "keccak")
-      run_suffix="keccak_round"
-      ;;
-   "state")
-      run_suffix="state_circuit_prover"
-      ;;
-   *)
-      echo "No proper value"
-      exit 1
-      ;;
+    "all")
+        echo "To be implemented"
+        exit 1
+        ;;
+    "evm")
+        run_suffix="evm_circuit_prover"
+        ;;
+    "keccak")
+        run_suffix="keccak_round"
+        ;;
+    "state")
+        run_suffix="state_circuit_prover"
+        ;;
+    *)
+        echo "No proper value"
+        exit 1
+        ;;
 esac
 
 cd $target_dir;
 logfile=$_date--${circuit}_bench-$k.proverlog
 
-export PATH=$PATH:/usr/local/go/bin
 DEGREE=$k ~/.cargo/bin/cargo test --profile bench bench_${run_suffix} -p circuit-benchmarks --features benches  -- --nocapture > "$target_dir/$logfile" 2>&1

--- a/.github/proverCiScripts/misc/route53.template
+++ b/.github/proverCiScripts/misc/route53.template
@@ -1,0 +1,11 @@
+{
+            "Comment": "UPSERT prover record ",
+            "Changes": [{
+            "Action": "UPSERT",
+                        "ResourceRecordSet": {
+                                    "Name": "prover.cirunners.internal",
+                                    "Type": "A",
+                                    "TTL": 60,
+                                 "ResourceRecords": [{ "Value": "CHANGEME"}]
+}}]
+}

--- a/.github/proverCiScripts/shutdownProver.sh
+++ b/.github/proverCiScripts/shutdownProver.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 #set -e 
-#set -xx
+#set -x
 
-aws ec2 stop-instances --instance-ids i-0f92100cb5a0ff7d5 --profile cirunner
+profile="cirunner"
+provers_vpc_id="vpc-09fb44da782f32abb"
+
+running_prover=$(aws ec2 describe-instances --profile $profile --filters Name=tag:Name,Values=[proverbench-multiAZ] Name=instance-state-name,Values=[running] Name=network-interface.vpc-id,Values=[$provers_vpc_id] --query "Reservations[*].Instances[*][InstanceId]" --output text)
+
+aws ec2 stop-instances --profile $profile --instance-ids $running_prover
+
 sleep 30

--- a/.github/proverCiScripts/wakeUpProver.sh
+++ b/.github/proverCiScripts/wakeUpProver.sh
@@ -2,30 +2,54 @@
 #set -e 
 #set -x
 
+profile="cirunner"
+provers_vpc_id="vpc-09fb44da782f32abb"
+dns_ipaddr=$(dig prover.cirunners.internal +short)
+zone_id=$(aws route53 --profile $profile list-hosted-zones --query 'HostedZones[?Name==`cirunners.internal.`].[Id]' --output text | awk -F \/ '{ print $3 }')
+route53_dir=".github/proverCiScripts/misc"
+
 sshprover () {
-ssh -o ConnectTimeout=5 prover << EOF
-export PATH=$PATH:/usr/local/go/bin
-EOF
+    ssh -o ConnectTimeout=5 prover
 }
 
-#get prover state and boot if state=stopped
-state=$(aws ec2 describe-instance-status --instance-id i-0f92100cb5a0ff7d5 --profile cirunner | jq .'InstanceStatuses | .[0] | .InstanceState | .Name')
+# Get running provers IDs
+provers_running=$(aws ec2 describe-instances --profile $profile --filters Name=tag:Name,Values=[proverbench-multiAZ] Name=instance-state-name,Values=[running] Name=network-interface.vpc-id,Values=[$provers_vpc_id] --query "Reservations[*].Instances[*][InstanceId]" --output text)
+provers_running_num=$(echo $provers_running | wc -w)
 
-if [[ "$state" == '"running"' ]];then
-	echo "i am up and running"
+if [ $provers_running_num -gt 1 ]; then
+    echo "More than 1 provers running"
+    exit 1
+elif [ $provers_running_num -eq 0 ]; then
+    # Get provers IDs and start first available
+    provers=$(aws ec2 describe-instances --profile $profile --filters Name=tag:Name,Values=[proverbench-multiAZ] Name=network-interface.vpc-id,Values=[$provers_vpc_id] --query "Reservations[*].Instances[*][InstanceId]" --output text | xargs)
 else
-	echo "Prover is stopped, starting..."
-	aws ec2 start-instances --instance-ids i-0f92100cb5a0ff7d5 --profile cirunner
+    provers=$provers_running
+    single_prover_running=true
 fi
 
-#wait until prover is accessible
-while true
-  do
+for prover in $provers; do
+    [ ! -z $single_prover_running ] || aws ec2 start-instances --profile $profile --instance-ids $prover
+    if [ $? -eq 0 ]; then
+        ipaddr=$(aws ec2 describe-instances --profile $profile --instance-ids $prover --query "Reservations[*].Instances[*].NetworkInterfaces[*].[PrivateIpAddress]" --output text)
+        if [ $ipaddr != $dns_ipaddr ]; then
+            cp $route53_dir/route53.template{,.json}
+            sed -i "s/CHANGEME/$ipaddr/" $route53_dir/route53.template.json
+            # TTL=60 so sleep for 60+1
+            aws route53 change-resource-record-sets --profile $profile --hosted-zone-id $zone_id --change-batch file://$route53_dir/route53.template.json
+            sleep 61
+            rm $route53_dir/route53.template.json
+        fi
+        break
+    fi
+    sleep 2
+done
+
+# Wait until prover is accessible
+while true; do
     sshprover
-    if [ $? -eq 0 ]
-      then
+    if [ $? -eq 0 ]; then
         break
     else
-      sleep 2
+        sleep 2
     fi
-  done
+done

--- a/.github/proverCiScripts/wakeUpProver.sh
+++ b/.github/proverCiScripts/wakeUpProver.sh
@@ -38,6 +38,7 @@ for prover in $provers; do
             aws route53 change-resource-record-sets --profile $profile --hosted-zone-id $zone_id --change-batch file://$route53_dir/route53.template.json
             sleep 61
             rm $route53_dir/route53.template.json
+	    ssh-keygen -f "/home/ubuntu/.ssh/known_hosts" -R "prover.cirunners.internal"
         fi
         break
     fi


### PR DESCRIPTION
This PR implements a redundant model with prover instances in multiple Availability Zones.

The idea for this implementation was born when AWS didn` t have enough available capacity to run the prover instance in a specific Availability Zone. With this approach, if a prover cannot be launched for any reason, a prover with similar specs will be launched in a different Availability Zone.