### PR TITLE
[keccak] Reduce Advice column usage in permutation circuit

### DIFF
--- a/keccak256/src/permutation/circuit.rs
+++ b/keccak256/src/permutation/circuit.rs
@@ -73,8 +73,14 @@ impl<F: Field> KeccakFConfig<F> {
         // Base conversion config.
         let from_b9_table = FromBase9TableConfig::configure(meta);
         let base_info = from_b9_table.get_base_info(false);
-        let base_conversion_config =
-            StateBaseConversion::configure(meta, state, base_info, base_conv_activator);
+        let base_conv_lane = meta.advice_column();
+        let base_conversion_config = StateBaseConversion::configure(
+            meta,
+            state,
+            base_info,
+            base_conv_lane,
+            base_conv_activator,
+        );
 
         // Mixing will make sure that the flag is binary constrained and that
         // the out state matches the expected result.

--- a/keccak256/src/permutation/mixing.rs
+++ b/keccak256/src/permutation/mixing.rs
@@ -92,7 +92,9 @@ impl<F: Field> MixingConfig<F> {
         let absorb_config = AbsorbConfig::configure(meta, state);
 
         let base_info = table.get_base_info(false);
-        let base_conv_config = StateBaseConversion::configure(meta, state, base_info, flag);
+        let base_conv_lane = meta.advice_column();
+        let base_conv_config =
+            StateBaseConversion::configure(meta, state, base_info, base_conv_lane, flag);
 
         let iota_b13_config =
             IotaB13Config::configure(meta, state, round_ctant_b13, round_constants_b13);

--- a/keccak256/src/permutation/rho_checks.rs
+++ b/keccak256/src/permutation/rho_checks.rs
@@ -121,8 +121,6 @@ use std::marker::PhantomData;
 
 #[derive(Debug, Clone)]
 pub struct LaneRotateConversionConfig<F> {
-    rotation: u32,
-    lane_idx: usize,
     q_normal: Selector,
     q_special: Selector,
     input_coef: Column<Advice>,
@@ -138,18 +136,9 @@ pub struct LaneRotateConversionConfig<F> {
 impl<F: Field> LaneRotateConversionConfig<F> {
     pub fn configure(
         meta: &mut ConstraintSystem<F>,
-        lane_idx: usize,
-        lane: Column<Advice>,
         base13_to_9_table: &Base13toBase9TableConfig<F>,
         special_chunk_table: &SpecialChunkTableConfig<F>,
     ) -> Self {
-        meta.enable_equality(lane);
-        let rotation = {
-            let x = lane_idx / 5;
-            let y = lane_idx % 5;
-            ROTATION_CONSTANTS[x][y]
-        };
-
         let q_normal = meta.complex_selector();
         let q_special = meta.complex_selector();
         let input_coef = meta.advice_column();
@@ -228,8 +217,6 @@ impl<F: Field> LaneRotateConversionConfig<F> {
             ]
         });
         Self {
-            rotation,
-            lane_idx,
             q_normal,
             q_special,
             input_coef,
@@ -247,6 +234,7 @@ impl<F: Field> LaneRotateConversionConfig<F> {
         &self,
         layouter: &mut impl Layouter<F>,
         lane_base_13: AssignedCell<F, F>,
+        lane_idx: usize,
     ) -> Result<
         (
             AssignedCell<F, F>,
@@ -255,15 +243,20 @@ impl<F: Field> LaneRotateConversionConfig<F> {
         ),
         Error,
     > {
+        let rotation = {
+            let x = lane_idx / 5;
+            let y = lane_idx % 5;
+            ROTATION_CONSTANTS[x][y]
+        };
         let (conversions, special) = RhoLane::new(
-            f_to_biguint(lane_base_13.value().copied().unwrap_or_default()),
-            self.rotation,
+            f_to_biguint(*lane_base_13.value().unwrap_or(&F::zero())),
+            rotation,
         )
         .get_full_witness();
         layouter.assign_region(
             || "lane rotate conversion",
             |mut region| {
-                let slices = slice_lane(self.rotation);
+                let slices = slice_lane(rotation);
                 let (step2_od, step3_od) = {
                     let mut step2_od: Vec<AssignedCell<F, F>> = vec![];
                     let mut step3_od: Vec<AssignedCell<F, F>> = vec![];
@@ -362,7 +355,7 @@ impl<F: Field> LaneRotateConversionConfig<F> {
                         || "Special output power of base",
                         self.output_pob,
                         offset,
-                        || Ok(F::from(B9 as u64).pow(&[self.rotation.into(), 0, 0, 0])),
+                        || Ok(F::from(B9 as u64).pow(&[rotation.into(), 0, 0, 0])),
                     )?;
                     region.assign_advice(
                         || "Special output acc pre",
@@ -454,13 +447,9 @@ pub struct OverflowCheckConfig<F> {
 impl<F: Field> OverflowCheckConfig<F> {
     pub fn configure(
         meta: &mut ConstraintSystem<F>,
-        cols_to_copy: Vec<Column<Advice>>,
         step2_range_table: &RangeCheckConfig<F, STEP2_RANGE>,
         step3_range_table: &RangeCheckConfig<F, STEP3_RANGE>,
     ) -> Self {
-        for &col in cols_to_copy.iter() {
-            meta.enable_equality(col);
-        }
         let step2_sum_config = SumConfig::configure(meta);
         let step3_sum_config = SumConfig::configure(meta);
 

--- a/keccak256/src/permutation/state_conversion.rs
+++ b/keccak256/src/permutation/state_conversion.rs
@@ -21,10 +21,10 @@ impl<F: Field> StateBaseConversion<F> {
         meta: &mut ConstraintSystem<F>,
         state: [Column<Advice>; 25],
         bi: BaseInfo<F>,
+        lane: Column<Advice>,
         flag: Column<Advice>,
     ) -> Self {
         meta.enable_equality(flag);
-        let lane = meta.advice_column();
         let bcc = BaseConversionConfig::configure(meta, bi.clone(), lane, flag);
 
         Self { bi, bcc, state }
@@ -73,6 +73,7 @@ mod tests {
         struct MyConfig<F> {
             flag: Column<Advice>,
             state: [Column<Advice>; 25],
+            lane: Column<Advice>,
             table: FromBinaryTableConfig<F>,
             conversion: StateBaseConversion<F>,
         }
@@ -85,11 +86,13 @@ mod tests {
                     .try_into()
                     .unwrap();
                 let flag = meta.advice_column();
+                let lane = meta.advice_column();
                 let bi = table.get_base_info(false);
-                let conversion = StateBaseConversion::configure(meta, state, bi, flag);
+                let conversion = StateBaseConversion::configure(meta, state, bi, lane, flag);
                 Self {
                     flag,
                     state,
+                    lane,
                     table,
                     conversion,
                 }


### PR DESCRIPTION
## Advice columns collapsing

### StateBaseConversion - BaseConversion

We were previosly using 25 `BaseConversionConfig`s inside of a single
`StateBaseConversion` config.
Indeed, we can reach the same result and have 25 different regions for
each BaseConversionConfig without the need to have 25 different
instanciations.

This is important since each one of them adds 6 Advice columns and 2
Selector columns.

The after and before sum of columns for the permutation circuits shows a
decent reduction of almost a half of the columns in usage.

Before results for `test_state_base_conversion`:
```
Num advice columns: 151
Num fixed columns: 53
Num instance columns: 0
Num lookups: 25
Num gates: 50
num polys: 50
max_degree_poly: 3 - 
max_degree_lookup_input: 3 - lookup input 'Lookup i/o_coeff at Base conversion table'
max_degree_lookup: 1 - lookup table 'Lookup i/o_coeff at Base conversion table'
```

After results for `test_state_base_conversion`:
```
Num advice columns: 32
Num fixed columns: 5
Num instance columns: 0
Num lookups: 1
Num gates: 2
num polys: 2
max_degree_poly: 3 - 
max_degree_lookup_input: 3 - lookup input 'Lookup i/o_coeff at Base conversion table'
max_degree_lookup: 1 - lookup table 'Lookup i/o_coeff at Base conversion table'
```

### Rho - LaneRotateConversionConfig



As a consequence of https://github.com/appliedzkp/zkevm-circuits/commit/f507d16dd74fbf5f4ca0f52b26cc8dbb2660e55b and continuing the work on https://github.com/appliedzkp/zkevm-circuits/issues/489 this reduces
the `RhoConfig` to use a simple `LaneRotateConversionConfig` which gets
assigned 25 times witnesses generating 25 different `Region`s instead of
duplicating columns over and over.

This is important since each one of them adds 5 `Advice` columns, 2
`Fixed` columns and 2 Selector columns.

Before results for `test_rho_gate`:
```
Num advice columns: 156
Num fixed columns: 135
Num instance columns: 0
Num lookups: 52
Num gates: 52
num polys: 77
max_degree_poly: 3 - delta_acc === - coef * power_of_base
max_degree_lookup_input: 2 - lookup input 'b13 -> b9 table'
max_degree_lookup: 1 - lookup table 'b13 -> b9 table'
```

After results for `test_rho_gate`:
```
Num advice columns: 36
Num fixed columns: 15
Num instance columns: 0
Num lookups: 4
Num gates: 4
num polys: 5
max_degree_poly: 3 - delta_acc === - coef * power_of_base
max_degree_lookup_input: 2 - lookup input 'b13 -> b9 table'
max_degree_lookup: 1 - lookup table 'b13 -> b9 table'
```
