### PR TITLE
fix log gas by adding static cost

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution/logs.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/logs.rs
@@ -155,7 +155,8 @@ impl<F: Field> ExecutionGadget<F> for LogGadget<F> {
             },
         );
 
-        let gas_cost = GasCost::LOG.as_u64().expr() * topic_count.clone()
+        let gas_cost = GasCost::LOG.as_u64().expr()
+            + GasCost::LOG.as_u64().expr() * topic_count.clone()
             + 8.expr() * from_bytes::expr(&msize.cells)
             + memory_expansion.gas_cost();
         // State transition
@@ -407,8 +408,10 @@ mod test {
             memory_expansion_gas_cost(curr_memory_word_size, next_memory_word_size);
         let topic_count = topics.len();
         // dynamic calculate topic_count
-        let gas_cost =
-            GasCost::LOG.as_u64() * topic_count as u64 + 8 * msize.as_u64() + memory_expension_gas;
+        let gas_cost = GasCost::LOG.as_u64()
+            + GasCost::LOG.as_u64() * topic_count as u64
+            + 8 * msize.as_u64()
+            + memory_expension_gas;
         let codes = [
             OpcodeId::LOG0,
             OpcodeId::LOG1,


### PR DESCRIPTION
when handling #476 , found that `SameContextGadget::construct` won't add op code constant gas into gas cost now,  this PR adds log static gas in op code for now.! 
while in spec `instruction::step_state_transition_in_same_context ` still sum constant and dynamic gas.  https://github.com/appliedzkp/zkevm-specs/blob/master/src/zkevm_specs/evm/instruction.py#L245