### PR TITLE
fix multi copy step data index

### DIFF
--- a/bus-mapping/src/circuit_input_builder/execution.rs
+++ b/bus-mapping/src/circuit_input_builder/execution.rs
@@ -144,6 +144,7 @@ pub enum CopyDetails {
     Code(U256),
     /// The bytes are being copied to a Log.
     /// Call's state change's persistance and tx_id are provided.
+    /// the data start index when enter this copy step
     Log((bool, usize, usize)),
 }
 

--- a/bus-mapping/src/circuit_input_builder/execution.rs
+++ b/bus-mapping/src/circuit_input_builder/execution.rs
@@ -144,7 +144,7 @@ pub enum CopyDetails {
     Code(U256),
     /// The bytes are being copied to a Log.
     /// Call's state change's persistance and tx_id are provided.
-    Log((bool, usize)),
+    Log((bool, usize, usize)),
 }
 
 /// Auxiliary data of Execution step

--- a/zkevm-circuits/src/evm_circuit/execution/copy_to_log.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/copy_to_log.rs
@@ -337,7 +337,6 @@ pub mod test {
             .zip(buffer.iter().copied())
             .collect();
 
-        //let mut data_start_index = 0;
         let mut copied = 0;
         while copied < length {
             let (step, rw_offset) = make_log_copy_step(

--- a/zkevm-circuits/src/evm_circuit/execution/copy_to_log.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/copy_to_log.rs
@@ -31,6 +31,8 @@ pub(crate) struct CopyToLogGadget<F> {
     is_persistent: Cell<F>,
     // The tx id
     tx_id: Cell<F>,
+    // the log data start index fetched from last step
+    data_start_index: Cell<F>,
     // Buffer reader gadget
     buffer_reader: BufferReaderGadget<F, MAX_COPY_BYTES, N_BYTES_MEMORY_ADDRESS>,
     // The comparison gadget between num bytes copied and bytes_left
@@ -48,6 +50,7 @@ impl<F: Field> ExecutionGadget<F> for CopyToLogGadget<F> {
         let src_addr_end = cb.query_cell();
         let is_persistent = cb.query_bool();
         let tx_id = cb.query_cell();
+        let data_start_index = cb.query_cell();
         let buffer_reader = BufferReaderGadget::construct(cb, src_addr.expr(), src_addr_end.expr());
 
         // Copy bytes from src and dst
@@ -68,7 +71,7 @@ impl<F: Field> ExecutionGadget<F> for CopyToLogGadget<F> {
                 cb.tx_log_lookup(
                     tx_id.expr(),
                     TxLogFieldTag::Data,
-                    i.expr(),
+                    data_start_index.expr() + i.expr(),
                     buffer_reader.byte(i),
                 )
             });
@@ -119,6 +122,7 @@ impl<F: Field> ExecutionGadget<F> for CopyToLogGadget<F> {
             src_addr_end,
             is_persistent,
             tx_id,
+            data_start_index,
             buffer_reader,
             finish_gadget,
         }
@@ -141,8 +145,10 @@ impl<F: Field> ExecutionGadget<F> for CopyToLogGadget<F> {
             step.aux_data.unwrap()
         };
 
-        let (is_persistent, tx_id) = match aux.copy_details() {
-            CopyDetails::Log((is_persistent, tx_id)) => (is_persistent, tx_id),
+        let (is_persistent, tx_id, data_start_index) = match aux.copy_details() {
+            CopyDetails::Log((is_persistent, tx_id, data_index)) => {
+                (is_persistent, tx_id, data_index)
+            }
             _ => unreachable!("the data copy is not related to a LOG op"),
         };
 
@@ -156,7 +162,8 @@ impl<F: Field> ExecutionGadget<F> for CopyToLogGadget<F> {
             .assign(region, offset, Some(F::from(is_persistent as u64)))?;
         self.tx_id
             .assign(region, offset, Some(F::from(tx_id as u64)))?;
-
+        self.data_start_index
+            .assign(region, offset, Some(F::from(data_start_index as u64)))?;
         // Retrieve the bytes and selectors
 
         let mut rw_idx = 0;
@@ -220,6 +227,7 @@ pub mod test {
         src_addr: u64,
         src_addr_end: u64,
         bytes_left: usize,
+        data_start_index: usize,
         program_counter: u64,
         stack_pointer: usize,
         memory_size: u64,
@@ -261,7 +269,7 @@ pub mod test {
                         tx_id,
                         log_id,
                         field_tag: TxLogFieldTag::Data,
-                        index: idx.try_into().unwrap(),
+                        index: data_start_index + idx,
                         value: Word::from(byte),
                     });
                     rw_offset += 1;
@@ -277,7 +285,7 @@ pub mod test {
             Default::default(),
             bytes_left as u64,
             src_addr_end,
-            CopyDetails::Log((is_persistent, tx_id)),
+            CopyDetails::Log((is_persistent, tx_id, data_start_index)),
         );
 
         let memory_indices: Vec<(RwTableTag, usize)> = (memory_idx_start
@@ -329,6 +337,7 @@ pub mod test {
             .zip(buffer.iter().copied())
             .collect();
 
+        //let mut data_start_index = 0;
         let mut copied = 0;
         while copied < length {
             let (step, rw_offset) = make_log_copy_step(
@@ -336,6 +345,7 @@ pub mod test {
                 src_addr + copied as u64,
                 buffer_addr_end,
                 length - copied,
+                copied,
                 program_counter,
                 stack_pointer,
                 memory_size,

--- a/zkevm-circuits/src/evm_circuit/execution/logs.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/logs.rs
@@ -383,7 +383,7 @@ mod test {
                     tx_id,
                     log_id: log_id.try_into().unwrap(),
                     field_tag: TxLogFieldTag::Topic,
-                    index: idx.try_into().unwrap(),
+                    index: idx,
                     value: *topic,
                 });
             }

--- a/zkevm-circuits/src/evm_circuit/execution/logs.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/logs.rs
@@ -130,6 +130,7 @@ impl<F: Field> ExecutionGadget<F> for LogGadget<F> {
                 let next_src_addr_end = cb.query_cell();
                 let next_is_persistent = cb.query_bool();
                 let next_tx_id = cb.query_cell();
+                let next_data_start_index = cb.query_cell();
 
                 cb.require_equal(
                     "next_src_addr = memory_offset",
@@ -152,6 +153,10 @@ impl<F: Field> ExecutionGadget<F> for LogGadget<F> {
                     is_persistent.expr(),
                 );
                 cb.require_equal("next_tx_id = tx_id", next_tx_id.expr(), tx_id.expr());
+                cb.require_zero(
+                    "next_data_start_index starts with 0",
+                    next_data_start_index.expr(),
+                );
             },
         );
 

--- a/zkevm-circuits/src/evm_circuit/witness.rs
+++ b/zkevm-circuits/src/evm_circuit/witness.rs
@@ -509,9 +509,9 @@ pub enum Rw {
         log_id: u64, // pack this can index together into address?
         field_tag: TxLogFieldTag,
         // topic index (0..4) if field_tag is TxLogFieldTag:Topic
-        // byte index (0..32) if field_tag is TxLogFieldTag:Data
+        // byte index if field_tag is TxLogFieldTag:Data
         // 0 for other field tags
-        index: u8,
+        index: usize,
 
         // when it is topic field, value can be word type
         value: Word,

--- a/zkevm-circuits/src/evm_circuit/witness.rs
+++ b/zkevm-circuits/src/evm_circuit/witness.rs
@@ -757,7 +757,7 @@ impl Rw {
                 Some(U256::from(*stack_pointer as u64).to_address())
             }
             Self::TxLog { log_id, index, .. } => {
-                Some((U256::from(*index as u64) + (U256::from(*log_id) << 8)).to_address())
+                Some(U256([*index as u64, *log_id, 0, 0]).to_address())
             }
             Self::CallContext { .. } | Self::TxRefund { .. } | Self::TxReceipt { .. } => None,
         }

--- a/zkevm-circuits/src/evm_circuit/witness.rs
+++ b/zkevm-circuits/src/evm_circuit/witness.rs
@@ -757,7 +757,7 @@ impl Rw {
                 Some(U256::from(*stack_pointer as u64).to_address())
             }
             Self::TxLog { log_id, index, .. } => {
-                Some(U256([*index as u64, *log_id, 0, 0]).to_address())
+                Some((U256::from(*index as u64) + (U256::from(*log_id) << 8)).to_address())
             }
             Self::CallContext { .. } | Self::TxRefund { .. } | Self::TxReceipt { .. } => None,
         }


### PR DESCRIPTION
this PR  can be part of #476 when doing multiple  copy step in buss mapping ,  for `TxLogFieldTag::Data` index should start from zero and consecutively increasing in multi copy log steps.  i.e.  total copies size is 66 bytes, data index should be monotone increasing by 1 from 0 across all three copy steps.  

| step      | data_start_index |copy range |
| ----------- | ----------- |------- |
| CopyStep1    | 0         | 0 --> 31    |
| CopyStep2   | 32       |32 --> 63  |
| CopyStep2   | 64       |64 -> 65    |.   

while old is as below though `Data` value is correct !  
| step     | data_start_index |copy range |
| ----------- | ----------- |------- |
| CopyStep1    | 0       | 0 --> 31    |
| CopyStep2   | 0       | 0 --> 31   |
| CopyStep2   | 0       | 0 --> 31    |.     

found in issue #511 