### PR TITLE
Fix flakiness in begin_tx_gadget_rand

### DIFF
--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -29,3 +29,11 @@ lazy_static! {
         address!("0x000000000000000000000000000000000cafe555"),
     ];
 }
+
+pub fn eth(x: u64) -> Word {
+    Word::from(x) * Word::from(10u64.pow(18))
+}
+
+pub fn gwei(x: u64) -> Word {
+    Word::from(x) * Word::from(10u64.pow(9))
+}

--- a/mock/src/test_ctx.rs
+++ b/mock/src/test_ctx.rs
@@ -1,6 +1,6 @@
 //! Mock types and functions to generate Test enviroments for ZKEVM tests
 
-use crate::{MockAccount, MockBlock, MockTransaction};
+use crate::{eth, MockAccount, MockBlock, MockTransaction};
 use eth_types::{
     geth_types::{Account, BlockConstants, GethData},
     Block, Bytecode, Error, GethExecTrace, Transaction, Word,
@@ -13,7 +13,7 @@ use itertools::Itertools;
 /// required to build the circuit inputs.
 ///
 /// It is specifically used to generate Test cases with very precise information
-/// details about any specific part of a block. That includes of course, it's
+/// details about any specific part of a block. That includes of course, its
 /// transactions too and the accounts involved in all of them.
 ///
 /// The intended way to interact with the structure is through the fn `new`
@@ -238,11 +238,9 @@ pub mod helpers {
         |accs| {
             accs[0]
                 .address(MOCK_ACCOUNTS[0])
-                .balance(Word::from(10u64.pow(19)))
+                .balance(eth(10))
                 .code(code);
-            accs[1]
-                .address(MOCK_ACCOUNTS[1])
-                .balance(Word::from(10u64.pow(19)));
+            accs[1].address(MOCK_ACCOUNTS[1]).balance(eth(10));
         }
     }
 

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -286,6 +286,7 @@ mod test {
     use mock::TestContext;
 
     lazy_static! {
+        static ref TEN_ETHER: Word = Word::from(10u64.pow(19));
         static ref POINT_ONE_ETHER: Word = Word::from(10u64.pow(17));
         static ref MINIMAL_GAS: Word =
             Word::from(GasCost::TX.as_u64() + 2 * OpcodeId::PUSH32.constant_gas_cost().as_u64());
@@ -318,7 +319,7 @@ mod test {
                     .address(to)
                     .balance(Word::from(10u64.pow(10)))
                     .code(code);
-                accs[1].address(from).balance(Word::from(10u64.pow(19)));
+                accs[1].address(from).balance(*TEN_ETHER);
             },
             |mut txs, _accs| {
                 txs[0]
@@ -391,7 +392,10 @@ mod test {
     #[test]
     fn begin_tx_gadget_rand() {
         let random_amount = Word::from_little_endian(&rand_bytes(32)) % *POINT_ONE_ETHER;
-        let random_gas_price = Word::from(rand_range(0..47619047619047u64));
+
+        let max_gas_price = 476_054_460_630_296u64;
+        assert_eq!(Word::from(max_gas_price), *TEN_ETHER / *MINIMAL_GAS);
+        let random_gas_price = Word::from(rand_range(0..max_gas_price));
 
         // If this test fails, we want these values to appear in the CI logs.
         dbg!(random_amount, random_gas_price);


### PR DESCRIPTION
Previously, `begin_tx_gadget_rand` would fail if the random gas amount in line https://github.com/appliedzkp/zkevm-circuits/compare/main...scroll-tech:fix/begin_tx_tests?expand=1#diff-8f5984af7a71d8fdfb2862e9655564673740a1d72df468ede0f01dbbd3ffba98L418 was large enough, e.g. https://github.com/appliedzkp/zkevm-circuits/runs/6361915474?check_suite_focus=true#step:6:1259

I also fixed some test values and comments so that they matched one another.