### PR TITLE
[Keccak] Remove unused code for the entire crate

### DIFF
--- a/keccak256/src/permutation.rs
+++ b/keccak256/src/permutation.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 #![allow(clippy::type_complexity)]
 #![allow(clippy::too_many_arguments)]
 pub(crate) mod absorb;

--- a/keccak256/src/permutation/absorb.rs
+++ b/keccak256/src/permutation/absorb.rs
@@ -17,7 +17,6 @@ pub struct AbsorbConfig<F> {
 }
 
 impl<F: Field> AbsorbConfig<F> {
-    pub const OFFSET: usize = 2;
     // We assume state is recieved in base-9.
     // Rows are assigned as:
     // 1) STATE (25 columns) (offset -1)

--- a/keccak256/src/permutation/base_conversion.rs
+++ b/keccak256/src/permutation/base_conversion.rs
@@ -15,7 +15,6 @@ pub(crate) struct BaseConversionConfig<F> {
     // Flag is copied from the parent flag. Parent flag is assumed to be binary
     // constrained.
     flag: Column<Advice>,
-    input_lane: Column<Advice>,
     input_coef: Column<Advice>,
     input_acc: Column<Advice>,
     output_coef: Column<Advice>,
@@ -83,7 +82,6 @@ impl<F: Field> BaseConversionConfig<F> {
             q_lookup,
             base_info,
             flag,
-            input_lane,
             input_coef,
             input_acc,
             output_coef,

--- a/keccak256/src/permutation/circuit.rs
+++ b/keccak256/src/permutation/circuit.rs
@@ -74,13 +74,8 @@ impl<F: Field> KeccakFConfig<F> {
         let from_b9_table = FromBase9TableConfig::configure(meta);
         let base_info = from_b9_table.get_base_info(false);
         let base_conv_lane = meta.advice_column();
-        let base_conversion_config = StateBaseConversion::configure(
-            meta,
-            state,
-            base_info,
-            base_conv_lane,
-            base_conv_activator,
-        );
+        let base_conversion_config =
+            StateBaseConversion::configure(meta, base_info, base_conv_lane, base_conv_activator);
 
         // Mixing will make sure that the flag is binary constrained and that
         // the out state matches the expected result.

--- a/keccak256/src/permutation/mixing.rs
+++ b/keccak256/src/permutation/mixing.rs
@@ -360,13 +360,6 @@ mod tests {
             table: FromBase9TableConfig<F>,
         }
 
-        impl<F: Field> MyConfig<F> {
-            pub fn load(&self, layouter: &mut impl Layouter<F>) -> Result<(), Error> {
-                self.table.load(layouter)?;
-                Ok(())
-            }
-        }
-
         impl<F: Field> Circuit<F> for MyCircuit<F> {
             type Config = MyConfig<F>;
             type FloorPlanner = SimpleFloorPlanner;

--- a/keccak256/src/permutation/mixing.rs
+++ b/keccak256/src/permutation/mixing.rs
@@ -94,7 +94,7 @@ impl<F: Field> MixingConfig<F> {
         let base_info = table.get_base_info(false);
         let base_conv_lane = meta.advice_column();
         let base_conv_config =
-            StateBaseConversion::configure(meta, state, base_info, base_conv_lane, flag);
+            StateBaseConversion::configure(meta, base_info, base_conv_lane, flag);
 
         let iota_b13_config =
             IotaB13Config::configure(meta, state, round_ctant_b13, round_constants_b13);

--- a/keccak256/src/permutation/rho.rs
+++ b/keccak256/src/permutation/rho.rs
@@ -13,7 +13,6 @@ use std::convert::TryInto;
 
 #[derive(Debug, Clone)]
 pub struct RhoConfig<F> {
-    state: [Column<Advice>; 25],
     lane_config: LaneRotateConversionConfig<F>,
     overflow_check_config: OverflowCheckConfig<F>,
     base13_to_9_table: Base13toBase9TableConfig<F>,
@@ -24,6 +23,7 @@ pub struct RhoConfig<F> {
 
 impl<F: Field> RhoConfig<F> {
     pub fn configure(meta: &mut ConstraintSystem<F>, state: [Column<Advice>; 25]) -> Self {
+        state.iter().for_each(|col| meta.enable_equality(*col));
         let base13_to_9_table = Base13toBase9TableConfig::configure(meta);
         let special_chunk_table = SpecialChunkTableConfig::configure(meta);
         let step2_range_table = RangeCheckConfig::<F, STEP2_RANGE>::configure(meta);
@@ -35,7 +35,6 @@ impl<F: Field> RhoConfig<F> {
         let overflow_check_config =
             OverflowCheckConfig::configure(meta, &step2_range_table, &step3_range_table);
         Self {
-            state,
             lane_config,
             overflow_check_config,
             base13_to_9_table,
@@ -105,7 +104,9 @@ mod tests {
     use crate::keccak_arith::*;
     use halo2_proofs::circuit::Layouter;
     use halo2_proofs::pairing::bn256::Fr as Fp;
+    use halo2_proofs::plonk::Selector;
     use halo2_proofs::plonk::{Advice, Column, ConstraintSystem, Error};
+    use halo2_proofs::poly::Rotation;
     use halo2_proofs::{circuit::SimpleFloorPlanner, dev::MockProver, plonk::Circuit};
     use itertools::Itertools;
     use std::convert::TryInto;
@@ -117,8 +118,15 @@ mod tests {
             in_state: [F; 25],
             out_state: [F; 25],
         }
+
+        #[derive(Clone)]
+        struct MyConfig<F> {
+            q_enable: Selector,
+            rho_config: RhoConfig<F>,
+            state: [Column<Advice>; 25],
+        }
         impl<F: Field> Circuit<F> for MyCircuit<F> {
-            type Config = RhoConfig<F>;
+            type Config = MyConfig<F>;
             type FloorPlanner = SimpleFloorPlanner;
 
             fn without_witnesses(&self) -> Self {
@@ -127,16 +135,32 @@ mod tests {
 
             fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
                 let state: [Column<Advice>; 25] = (0..25)
-                    .map(|_| {
-                        let col = meta.advice_column();
-                        meta.enable_equality(col);
-                        col
-                    })
+                    .map(|_| meta.advice_column())
                     .collect::<Vec<_>>()
                     .try_into()
                     .unwrap();
 
-                RhoConfig::configure(meta, state)
+                let rho_config = RhoConfig::configure(meta, state);
+
+                let q_enable = meta.selector();
+                meta.create_gate("Check states", |meta| {
+                    let q_enable = meta.query_selector(q_enable);
+                    state
+                        .iter()
+                        .map(|col| {
+                            let final_state = meta.query_advice(col.clone(), Rotation::cur());
+                            let expected_final_state =
+                                meta.query_advice(col.clone(), Rotation::next());
+                            q_enable.clone() * (final_state - expected_final_state)
+                        })
+                        .collect::<Vec<_>>()
+                });
+
+                MyConfig {
+                    q_enable,
+                    rho_config,
+                    state,
+                }
             }
 
             fn synthesize(
@@ -144,7 +168,7 @@ mod tests {
                 config: Self::Config,
                 mut layouter: impl Layouter<F>,
             ) -> Result<(), Error> {
-                config.load(&mut layouter)?;
+                config.rho_config.load(&mut layouter)?;
                 let state = layouter.assign_region(
                     || "assign input state",
                     |mut region| {
@@ -169,7 +193,37 @@ mod tests {
                         Ok(state)
                     },
                 )?;
-                config.assign_rotation_checks(&mut layouter, &state)?;
+                let out_state = config
+                    .rho_config
+                    .assign_rotation_checks(&mut layouter, &state)?;
+                layouter.assign_region(
+                    || "check final states",
+                    |mut region| {
+                        config.q_enable.enable(&mut region, 0)?;
+                        out_state.iter().enumerate().for_each(|(idx, cell)| {
+                            cell.copy_advice(
+                                || "out_state obtained",
+                                &mut region,
+                                config.state[idx],
+                                0,
+                            )
+                            .unwrap();
+                        });
+
+                        self.out_state.iter().enumerate().for_each(|(idx, &value)| {
+                            region
+                                .assign_advice(
+                                    || format!("lane {}", idx),
+                                    config.state[idx],
+                                    1,
+                                    || Ok(value),
+                                )
+                                .unwrap();
+                        });
+
+                        Ok(())
+                    },
+                )?;
 
                 Ok(())
             }

--- a/keccak256/src/permutation/rho.rs
+++ b/keccak256/src/permutation/rho.rs
@@ -148,9 +148,8 @@ mod tests {
                     state
                         .iter()
                         .map(|col| {
-                            let final_state = meta.query_advice(col.clone(), Rotation::cur());
-                            let expected_final_state =
-                                meta.query_advice(col.clone(), Rotation::next());
+                            let final_state = meta.query_advice(*col, Rotation::cur());
+                            let expected_final_state = meta.query_advice(*col, Rotation::next());
                             q_enable.clone() * (final_state - expected_final_state)
                         })
                         .collect::<Vec<_>>()

--- a/keccak256/src/permutation/state_conversion.rs
+++ b/keccak256/src/permutation/state_conversion.rs
@@ -22,7 +22,7 @@ impl<F: Field> StateBaseConversion<F> {
         flag: Column<Advice>,
     ) -> Self {
         meta.enable_equality(flag);
-        let bcc = BaseConversionConfig::configure(meta, bi.clone(), lane, flag);
+        let bcc = BaseConversionConfig::configure(meta, bi, lane, flag);
 
         Self { bcc }
     }

--- a/keccak256/src/permutation/state_conversion.rs
+++ b/keccak256/src/permutation/state_conversion.rs
@@ -10,16 +10,13 @@ use std::convert::TryInto;
 
 #[derive(Debug, Clone)]
 pub(crate) struct StateBaseConversion<F> {
-    bi: BaseInfo<F>,
     bcc: BaseConversionConfig<F>,
-    state: [Column<Advice>; 25],
 }
 
 impl<F: Field> StateBaseConversion<F> {
     /// Side effect: parent flag is enabled
     pub(crate) fn configure(
         meta: &mut ConstraintSystem<F>,
-        state: [Column<Advice>; 25],
         bi: BaseInfo<F>,
         lane: Column<Advice>,
         flag: Column<Advice>,
@@ -27,7 +24,7 @@ impl<F: Field> StateBaseConversion<F> {
         meta.enable_equality(flag);
         let bcc = BaseConversionConfig::configure(meta, bi.clone(), lane, flag);
 
-        Self { bi, bcc, state }
+        Self { bcc }
     }
 
     pub(crate) fn assign_region(
@@ -73,7 +70,6 @@ mod tests {
         struct MyConfig<F> {
             flag: Column<Advice>,
             state: [Column<Advice>; 25],
-            lane: Column<Advice>,
             table: FromBinaryTableConfig<F>,
             conversion: StateBaseConversion<F>,
         }
@@ -88,11 +84,10 @@ mod tests {
                 let flag = meta.advice_column();
                 let lane = meta.advice_column();
                 let bi = table.get_base_info(false);
-                let conversion = StateBaseConversion::configure(meta, state, bi, lane, flag);
+                let conversion = StateBaseConversion::configure(meta, bi, lane, flag);
                 Self {
                     flag,
                     state,
-                    lane,
                     table,
                     conversion,
                 }

--- a/keccak256/src/permutation/tables.rs
+++ b/keccak256/src/permutation/tables.rs
@@ -226,6 +226,7 @@ impl<F: Field> BaseInfo<F> {
     }
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct FromBinaryTableConfig<F> {
     base2: TableColumn,
@@ -234,6 +235,7 @@ pub struct FromBinaryTableConfig<F> {
     _marker: PhantomData<F>,
 }
 
+#[allow(dead_code)]
 impl<F: Field> FromBinaryTableConfig<F> {
     pub(crate) fn load(&self, layouter: &mut impl Layouter<F>) -> Result<(), Error> {
         layouter.assign_table(

--- a/keccak256/src/permutation/tables.rs
+++ b/keccak256/src/permutation/tables.rs
@@ -182,16 +182,6 @@ impl<F: Field> BaseInfo<F> {
         F::from(self.output_base as u64).pow(&[self.num_chunks as u64, 0, 0, 0])
     }
 
-    pub fn slice_count(self) -> usize {
-        // Just want the `self.max_chunks.div_ceil(self.num_chunks)`
-        (0..self.max_chunks)
-            .chunks(self.num_chunks)
-            .into_iter()
-            .map(|_| 0)
-            .collect_vec()
-            .len()
-    }
-
     pub fn compute_coefs(&self, input: F) -> Result<(Vec<F>, Vec<F>, F), Error> {
         // big-endian
         let input_chunks: Vec<u8> = {

--- a/keccak256/src/permutation/theta.rs
+++ b/keccak256/src/permutation/theta.rs
@@ -17,7 +17,6 @@ pub struct ThetaConfig<F> {
 }
 
 impl<F: Field> ThetaConfig<F> {
-    pub const OFFSET: usize = 2;
     pub fn configure(
         q_enable: Selector,
         meta: &mut ConstraintSystem<F>,

--- a/keccak256/src/permutation/xi.rs
+++ b/keccak256/src/permutation/xi.rs
@@ -16,7 +16,6 @@ pub struct XiConfig<F> {
 }
 
 impl<F: Field> XiConfig<F> {
-    pub const OFFSET: usize = 2;
     // We assume state is recieved in base-9.
     pub fn configure(
         q_enable: Selector,


### PR DESCRIPTION
Resolves: #512 which is something that we have been carrying over for some time.

It also fixes the `Rho` tests by enforcing equality with a gate between the out_state obtained and the expected one.