### PR TITLE
Give state_circuit create_proof the correct instance to avoid Invalid Instance Error

### DIFF
--- a/circuit-benchmarks/src/state_circuit.rs
+++ b/circuit-benchmarks/src/state_circuit.rs
@@ -40,6 +40,8 @@ mod tests {
         // Create a proof
         let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
 
+        let instance = empty_circuit.instance();
+        let instances: Vec<&[Fr]> = instance.iter().map(|v| v.as_slice()).collect();
         // Bench proof generation time
         let proof_message = format!("State Proof generation with {} degree", DEGREE);
         let start2 = start_timer!(|| proof_message);
@@ -47,7 +49,7 @@ mod tests {
             &general_params,
             &pk,
             &[empty_circuit],
-            &[&[]],
+            &[instances.as_slice()],
             rng,
             &mut transcript,
         )
@@ -64,7 +66,7 @@ mod tests {
             &verifier_params,
             pk.get_vk(),
             strategy,
-            &[&[]],
+            &[instances.as_slice()],
             &mut verifier_transcript,
         )
         .expect("failed to verify bench circuit");

--- a/prover/src/compute_proof.rs
+++ b/prover/src/compute_proof.rs
@@ -80,7 +80,9 @@ pub async fn compute_proof(
 
         // create a proof
         let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
-        create_proof(params, &pk, &[circuit], &[], rng, &mut transcript)?;
+        let instance = circuit.instance();
+        let instances: Vec<&[Fr]> = instance.iter().map(|v| v.as_slice()).collect();
+        create_proof(params, &pk, &[circuit], &[instances.as_slice()], rng, &mut transcript)?;
         state_proof = transcript.finalize();
     }
 

--- a/prover/src/compute_proof.rs
+++ b/prover/src/compute_proof.rs
@@ -82,7 +82,14 @@ pub async fn compute_proof(
         let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
         let instance = circuit.instance();
         let instances: Vec<&[Fr]> = instance.iter().map(|v| v.as_slice()).collect();
-        create_proof(params, &pk, &[circuit], &[instances.as_slice()], rng, &mut transcript)?;
+        create_proof(
+            params,
+            &pk,
+            &[circuit],
+            &[instances.as_slice()],
+            rng,
+            &mut transcript,
+        )?;
         state_proof = transcript.finalize();
     }
 


### PR DESCRIPTION
state_circuit does not need instance several days ago, now it is failed to pass the check in create_proof().
```rust
    for instance in instances.iter() {
        if instance.len() != pk.vk.cs.num_instance_columns {
            return Err(Error::InvalidInstances);
        }
    }
```
So just give the correct instances to pass the test.
Not sure if it's a good fix. 


A question here is: Now it takes more than 32Gb mem to run a benchmark test of a degree-18 state circuit, not finished as my machine has 32Gb mem only. And ~24Gb and ~6600s to finish a degree-17 test. Are these the correct perf data now? Maybe I should upgrade my machine to 16core/64Gb ? 


Signed-off-by: smtmfft <smtmfft@taikocha.in>