### PR TITLE
[Keccak] Optimization round: Reduce columns

### DIFF
--- a/keccak256/src/permutation/base_conversion.rs
+++ b/keccak256/src/permutation/base_conversion.rs
@@ -6,7 +6,6 @@ use halo2_proofs::{
 
 use super::tables::BaseInfo;
 use eth_types::Field;
-use itertools::Itertools;
 use std::convert::TryInto;
 
 #[derive(Clone, Debug)]
@@ -187,6 +186,7 @@ mod tests {
         pairing::bn256::Fr as Fp,
         plonk::{Advice, Circuit, Column, ConstraintSystem, Error},
     };
+    use itertools::Itertools;
     use num_bigint::BigUint;
     use pretty_assertions::assert_eq;
     #[test]

--- a/keccak256/src/permutation/base_conversion.rs
+++ b/keccak256/src/permutation/base_conversion.rs
@@ -6,6 +6,7 @@ use halo2_proofs::{
 
 use super::tables::BaseInfo;
 use eth_types::Field;
+use itertools::Itertools;
 use std::convert::TryInto;
 
 #[derive(Clone, Debug)]
@@ -29,14 +30,11 @@ impl<F: Field> BaseConversionConfig<F> {
         base_info: BaseInfo<F>,
         input_lane: Column<Advice>,
         parent_flag: Column<Advice>,
+        advices: [Column<Advice>; 5],
     ) -> Self {
         let q_running_sum = meta.selector();
         let q_lookup = meta.complex_selector();
-        let flag = meta.advice_column();
-        let input_coef = meta.advice_column();
-        let input_acc = meta.advice_column();
-        let output_coef = meta.advice_column();
-        let output_acc = meta.advice_column();
+        let [flag, input_coef, input_acc, output_coef, output_acc] = advices;
 
         meta.enable_equality(flag);
         meta.enable_equality(input_coef);
@@ -207,8 +205,14 @@ mod tests {
                 let table = FromBinaryTableConfig::configure(meta);
                 let lane = meta.advice_column();
                 let flag = meta.advice_column();
+                let advices = (0..5)
+                    .map(|_| meta.advice_column())
+                    .collect_vec()
+                    .try_into()
+                    .unwrap();
                 let base_info = table.get_base_info(false);
-                let conversion = BaseConversionConfig::configure(meta, base_info, lane, flag);
+                let conversion =
+                    BaseConversionConfig::configure(meta, base_info, lane, flag, advices);
                 Self {
                     lane,
                     flag,
@@ -317,8 +321,14 @@ mod tests {
                 let table = FromBase9TableConfig::configure(meta);
                 let lane = meta.advice_column();
                 let flag = meta.advice_column();
+                let advices = (0..5)
+                    .map(|_| meta.advice_column())
+                    .collect_vec()
+                    .try_into()
+                    .unwrap();
                 let base_info = table.get_base_info(false);
-                let conversion = BaseConversionConfig::configure(meta, base_info, lane, flag);
+                let conversion =
+                    BaseConversionConfig::configure(meta, base_info, lane, flag, advices);
                 Self {
                     lane,
                     flag,
@@ -424,8 +434,13 @@ mod tests {
                     .unwrap();
                 let flag = meta.advice_column();
                 let lane = meta.advice_column();
+                let advices = (0..5)
+                    .map(|_| meta.advice_column())
+                    .collect_vec()
+                    .try_into()
+                    .unwrap();
                 let bi = table.get_base_info(false);
-                let conversion = BaseConversionConfig::configure(meta, bi, lane, flag);
+                let conversion = BaseConversionConfig::configure(meta, bi, lane, flag, advices);
                 Self {
                     flag,
                     state,

--- a/keccak256/src/permutation/circuit.rs
+++ b/keccak256/src/permutation/circuit.rs
@@ -47,7 +47,7 @@ impl<F: Field> KeccakFConfig<F> {
         let fixed = [
             meta.fixed_column(),
             meta.fixed_column(),
-            meta.fixed_column()
+            meta.fixed_column(),
         ];
 
         // theta
@@ -80,8 +80,13 @@ impl<F: Field> KeccakFConfig<F> {
         let from_b9_table = FromBase9TableConfig::configure(meta);
         let base_info = from_b9_table.get_base_info(false);
         let base_conv_lane = meta.advice_column();
-        let base_conversion_config =
-            BaseConversionConfig::configure(meta, base_info, base_conv_lane, base_conv_activator);
+        let base_conversion_config = BaseConversionConfig::configure(
+            meta,
+            base_info,
+            base_conv_lane,
+            base_conv_activator,
+            state[0..5].try_into().unwrap(),
+        );
 
         // Mixing will make sure that the flag is binary constrained and that
         // the out state matches the expected result.

--- a/keccak256/src/permutation/circuit.rs
+++ b/keccak256/src/permutation/circuit.rs
@@ -44,10 +44,16 @@ impl<F: Field> KeccakFConfig<F> {
             .try_into()
             .unwrap();
 
+        let fixed = [
+            meta.fixed_column(),
+            meta.fixed_column(),
+            meta.fixed_column()
+        ];
+
         // theta
         let theta_config = ThetaConfig::configure(meta.selector(), meta, state);
         // rho
-        let rho_config = RhoConfig::configure(meta, state);
+        let rho_config = RhoConfig::configure(meta, state, fixed);
         // xi
         let xi_config = XiConfig::configure(meta.selector(), meta, state);
 

--- a/keccak256/src/permutation/circuit.rs
+++ b/keccak256/src/permutation/circuit.rs
@@ -97,6 +97,7 @@ impl<F: Field> KeccakFConfig<F> {
             round_ctant_b13,
             round_constants_b9,
             round_constants_b13,
+            state,
         );
 
         // Allocate the `out state correctness` gate selector

--- a/keccak256/src/permutation/mixing.rs
+++ b/keccak256/src/permutation/mixing.rs
@@ -94,7 +94,7 @@ impl<F: Field> MixingConfig<F> {
         let base_info = table.get_base_info(false);
         let base_conv_lane = meta.advice_column();
         let base_conv_config =
-            BaseConversionConfig::configure(meta, base_info, base_conv_lane, flag);
+            BaseConversionConfig::configure(meta, base_info, base_conv_lane, flag, state[0..5].try_into().unwrap());
 
         let iota_b13_config =
             IotaB13Config::configure(meta, state, round_ctant_b13, round_constants_b13);

--- a/keccak256/src/permutation/mixing.rs
+++ b/keccak256/src/permutation/mixing.rs
@@ -26,7 +26,6 @@ pub struct MixingConfig<F> {
     flag: Column<Advice>,
     q_flag: Selector,
     q_out_copy: Selector,
-    out_mixing: [Column<Advice>; 25],
 }
 
 impl<F: Field> MixingConfig<F> {
@@ -37,6 +36,7 @@ impl<F: Field> MixingConfig<F> {
         round_ctant_b13: Column<Advice>,
         round_constants_b9: Column<Instance>,
         round_constants_b13: Column<Instance>,
+        state: [Column<Advice>; 25],
     ) -> MixingConfig<F> {
         // Allocate space for the flag column from which we will copy to all of
         // the sub-configs.
@@ -74,17 +74,6 @@ impl<F: Field> MixingConfig<F> {
             ]
         });
 
-        // Allocate state columns and enable copy constraints for them.
-        let state: [Column<Advice>; 25] = (0..25)
-            .map(|_| {
-                let column = meta.advice_column();
-                meta.enable_equality(column);
-                column
-            })
-            .collect::<Vec<_>>()
-            .try_into()
-            .unwrap();
-
         // We don't mix -> Flag = false
         let iota_b9_config =
             IotaB9Config::configure(meta, state, round_ctant_b9, round_constants_b9);
@@ -93,24 +82,16 @@ impl<F: Field> MixingConfig<F> {
 
         let base_info = table.get_base_info(false);
         let base_conv_lane = meta.advice_column();
-        let base_conv_config =
-            BaseConversionConfig::configure(meta, base_info, base_conv_lane, flag, state[0..5].try_into().unwrap());
+        let base_conv_config = BaseConversionConfig::configure(
+            meta,
+            base_info,
+            base_conv_lane,
+            flag,
+            state[0..5].try_into().unwrap(),
+        );
 
         let iota_b13_config =
             IotaB13Config::configure(meta, state, round_ctant_b13, round_constants_b13);
-
-        // Allocate out_mixing columns and enable copy constraints for them.
-        // Offset = 0 (Non mixing)
-        // Offset = 1 (Mixing)
-        let out_mixing: [Column<Advice>; 25] = (0..25)
-            .map(|_| {
-                let column = meta.advice_column();
-                meta.enable_equality(column);
-                column
-            })
-            .collect::<Vec<_>>()
-            .try_into()
-            .unwrap();
 
         let q_out_copy = meta.selector();
 
@@ -121,9 +102,9 @@ impl<F: Field> MixingConfig<F> {
             let flag = meta.query_advice(flag, Rotation::cur());
 
             // Multiply by flag and negated_flag the out mixing results.
-            let left_side = meta.query_advice(out_mixing[0], Rotation::cur()) * negated_flag;
-            let right_side = meta.query_advice(out_mixing[0], Rotation::next()) * flag;
-            let out_state = meta.query_advice(state[0], Rotation::cur());
+            let left_side = meta.query_advice(state[0], Rotation::cur()) * negated_flag;
+            let right_side = meta.query_advice(state[0], Rotation::next()) * flag;
+            let out_state = meta.query_advice(state[0], Rotation(2));
 
             // We add the results of the mixing gate if/else branches multiplied
             // by it's corresponding flags so that we always
@@ -141,7 +122,6 @@ impl<F: Field> MixingConfig<F> {
             flag,
             q_flag,
             q_out_copy,
-            out_mixing,
         }
     }
 
@@ -203,9 +183,9 @@ impl<F: Field> MixingConfig<F> {
                 negated_flag.copy_advice(|| "witness is_mixing", &mut region, self.flag, 1)?;
 
                 // Copy-constrain both out states.
-                self.copy_state(&mut region, 0, self.out_mixing, out_non_mixing_circ)?;
+                self.copy_state(&mut region, 0, self.state, out_non_mixing_circ)?;
 
-                self.copy_state(&mut region, 1, self.out_mixing, out_mixing_circ)?;
+                self.copy_state(&mut region, 1, self.state, out_mixing_circ)?;
 
                 let out_state: [AssignedCell<F, F>; 25] = {
                     let mut out_vec: Vec<AssignedCell<F, F>> = vec![];
@@ -213,7 +193,7 @@ impl<F: Field> MixingConfig<F> {
                         let out_cell = region.assign_advice(
                             || format!("assign out_state [{}]", idx),
                             self.state[idx],
-                            0,
+                            2,
                             || Ok(*lane),
                         )?;
                         out_vec.push(out_cell);
@@ -381,6 +361,15 @@ mod tests {
                 let round_ctant_b13 = meta.advice_column();
                 meta.enable_equality(round_ctant_b13);
                 let round_constants_b13 = meta.instance_column();
+                let state: [Column<Advice>; 25] = (0..25)
+                    .map(|_| {
+                        let col = meta.advice_column();
+                        meta.enable_equality(col);
+                        col
+                    })
+                    .collect_vec()
+                    .try_into()
+                    .unwrap();
 
                 MyConfig {
                     mixing_conf: MixingConfig::configure(
@@ -390,6 +379,7 @@ mod tests {
                         round_ctant_b13,
                         round_constants_b9,
                         round_constants_b13,
+                        state,
                     ),
                     table,
                 }

--- a/keccak256/src/permutation/rho.rs
+++ b/keccak256/src/permutation/rho.rs
@@ -41,8 +41,12 @@ impl<F: Field> RhoConfig<F> {
             fixed,
         );
 
-        let overflow_check_config =
-            OverflowCheckConfig::configure(meta, &step2_range_table, &step3_range_table);
+        let overflow_check_config = OverflowCheckConfig::configure(
+            meta,
+            &step2_range_table,
+            &step3_range_table,
+            state[5..7].try_into().unwrap(),
+        );
         Self {
             lane_config,
             overflow_check_config,

--- a/keccak256/src/permutation/rho.rs
+++ b/keccak256/src/permutation/rho.rs
@@ -7,7 +7,7 @@ use crate::permutation::{
 use eth_types::Field;
 use halo2_proofs::{
     circuit::{AssignedCell, Layouter},
-    plonk::{Advice, Column, ConstraintSystem, Error},
+    plonk::{Advice, Column, ConstraintSystem, Error, Fixed},
 };
 use std::convert::TryInto;
 
@@ -22,15 +22,24 @@ pub struct RhoConfig<F> {
 }
 
 impl<F: Field> RhoConfig<F> {
-    pub fn configure(meta: &mut ConstraintSystem<F>, state: [Column<Advice>; 25]) -> Self {
+    pub fn configure(
+        meta: &mut ConstraintSystem<F>,
+        state: [Column<Advice>; 25],
+        fixed: [Column<Fixed>; 3],
+    ) -> Self {
         state.iter().for_each(|col| meta.enable_equality(*col));
         let base13_to_9_table = Base13toBase9TableConfig::configure(meta);
         let special_chunk_table = SpecialChunkTableConfig::configure(meta);
         let step2_range_table = RangeCheckConfig::<F, STEP2_RANGE>::configure(meta);
         let step3_range_table = RangeCheckConfig::<F, STEP3_RANGE>::configure(meta);
 
-        let lane_config =
-            LaneRotateConversionConfig::configure(meta, &base13_to_9_table, &special_chunk_table);
+        let lane_config = LaneRotateConversionConfig::configure(
+            meta,
+            &base13_to_9_table,
+            &special_chunk_table,
+            state[0..5].try_into().unwrap(),
+            fixed,
+        );
 
         let overflow_check_config =
             OverflowCheckConfig::configure(meta, &step2_range_table, &step3_range_table);
@@ -138,7 +147,13 @@ mod tests {
                     .try_into()
                     .unwrap();
 
-                let rho_config = RhoConfig::configure(meta, state);
+                let fixed = [
+                    meta.fixed_column(),
+                    meta.fixed_column(),
+                    meta.fixed_column(),
+                ];
+
+                let rho_config = RhoConfig::configure(meta, state, fixed);
 
                 let q_enable = meta.selector();
                 meta.create_gate("Check states", |meta| {

--- a/keccak256/src/permutation/rho_checks.rs
+++ b/keccak256/src/permutation/rho_checks.rs
@@ -138,23 +138,18 @@ impl<F: Field> LaneRotateConversionConfig<F> {
         meta: &mut ConstraintSystem<F>,
         base13_to_9_table: &Base13toBase9TableConfig<F>,
         special_chunk_table: &SpecialChunkTableConfig<F>,
+        advices: [Column<Advice>; 5],
+        fixed: [Column<Fixed>; 3],
     ) -> Self {
         let q_normal = meta.complex_selector();
         let q_special = meta.complex_selector();
-        let input_coef = meta.advice_column();
-        let input_pob = meta.fixed_column();
-        let input_acc = meta.advice_column();
-        let output_coef = meta.advice_column();
-        let output_pob = meta.fixed_column();
-        let output_acc = meta.advice_column();
-        let overflow_detector = meta.advice_column();
-
-        let constant = meta.fixed_column();
-        meta.enable_constant(constant);
+        let [input_coef, input_acc, output_coef, output_acc, overflow_detector] = advices;
+        let [input_pob, output_pob, constant] = fixed;
 
         meta.enable_equality(input_acc);
         meta.enable_equality(output_acc);
         meta.enable_equality(overflow_detector);
+        meta.enable_constant(constant);
 
         // | coef | 13**x | acc       |
         // |------|-------|-----------|

--- a/keccak256/src/permutation/rho_checks.rs
+++ b/keccak256/src/permutation/rho_checks.rs
@@ -383,10 +383,9 @@ pub struct SumConfig<F> {
 }
 impl<F: Field> SumConfig<F> {
     // We assume the input columns are all copiable
-    pub fn configure(meta: &mut ConstraintSystem<F>) -> Self {
+    pub fn configure(meta: &mut ConstraintSystem<F>, advices: [Column<Advice>; 2]) -> Self {
         let q_enable = meta.selector();
-        let x = meta.advice_column();
-        let sum = meta.advice_column();
+        let [x, sum] = advices;
 
         meta.enable_equality(x);
         meta.enable_equality(sum);
@@ -443,12 +442,13 @@ impl<F: Field> OverflowCheckConfig<F> {
         meta: &mut ConstraintSystem<F>,
         step2_range_table: &RangeCheckConfig<F, STEP2_RANGE>,
         step3_range_table: &RangeCheckConfig<F, STEP3_RANGE>,
+        advices: [Column<Advice>; 2],
     ) -> Self {
-        let sum_config = SumConfig::configure(meta);
+        let sum_config = SumConfig::configure(meta, advices);
 
         let q_step2 = meta.complex_selector();
         let q_step3 = meta.complex_selector();
-        let acc = meta.advice_column();
+        let acc = advices[0];
         meta.enable_equality(acc);
 
         meta.lookup("Overflow check step2", |meta| {

--- a/keccak256/src/permutation/rho_checks.rs
+++ b/keccak256/src/permutation/rho_checks.rs
@@ -438,11 +438,10 @@ impl<F: Field> SumConfig<F> {
 
 #[derive(Debug, Clone)]
 pub struct OverflowCheckConfig<F> {
-    q_enable: Selector,
-    step2_sum_config: SumConfig<F>,
-    step3_sum_config: SumConfig<F>,
-    step2_acc: Column<Advice>,
-    step3_acc: Column<Advice>,
+    q_step2: Selector,
+    q_step3: Selector,
+    sum_config: SumConfig<F>,
+    acc: Column<Advice>,
 }
 impl<F: Field> OverflowCheckConfig<F> {
     pub fn configure(
@@ -450,33 +449,29 @@ impl<F: Field> OverflowCheckConfig<F> {
         step2_range_table: &RangeCheckConfig<F, STEP2_RANGE>,
         step3_range_table: &RangeCheckConfig<F, STEP3_RANGE>,
     ) -> Self {
-        let step2_sum_config = SumConfig::configure(meta);
-        let step3_sum_config = SumConfig::configure(meta);
+        let sum_config = SumConfig::configure(meta);
 
-        let q_enable = meta.complex_selector();
-        let step2_acc = meta.advice_column();
-        let step3_acc = meta.advice_column();
-        meta.enable_equality(step2_acc);
-        meta.enable_equality(step3_acc);
+        let q_step2 = meta.complex_selector();
+        let q_step3 = meta.complex_selector();
+        let acc = meta.advice_column();
+        meta.enable_equality(acc);
 
-        meta.lookup("Overflow step 2", |meta| {
-            let q_enable = meta.query_selector(q_enable);
-            let step2_acc = meta.query_advice(step2_acc, Rotation::cur());
-            vec![(q_enable * step2_acc, step2_range_table.range)]
+        meta.lookup("Overflow check step2", |meta| {
+            let q_step2 = meta.query_selector(q_step2);
+            let acc = meta.query_advice(acc, Rotation::cur());
+            vec![(q_step2 * acc, step2_range_table.range)]
         });
-
-        meta.lookup("Overflow step 3", |meta| {
-            let q_enable = meta.query_selector(q_enable);
-            let step3_acc = meta.query_advice(step3_acc, Rotation::cur());
-            vec![(q_enable * step3_acc, step3_range_table.range)]
+        meta.lookup("Overflow check step3", |meta| {
+            let q_step3 = meta.query_selector(q_step3);
+            let acc = meta.query_advice(acc, Rotation::cur());
+            vec![(q_step3 * acc, step3_range_table.range)]
         });
 
         Self {
-            q_enable,
-            step2_sum_config,
-            step3_sum_config,
-            step2_acc,
-            step3_acc,
+            q_step2,
+            q_step3,
+            sum_config,
+            acc,
         }
     }
     pub fn assign_region(
@@ -485,16 +480,17 @@ impl<F: Field> OverflowCheckConfig<F> {
         step2_cells: Vec<AssignedCell<F, F>>,
         step3_cells: Vec<AssignedCell<F, F>>,
     ) -> Result<(), Error> {
-        let step2_sum = self.step2_sum_config.assign_region(layouter, step2_cells)?;
-        let step3_sum = self.step3_sum_config.assign_region(layouter, step3_cells)?;
+        let step2_sum = self.sum_config.assign_region(layouter, step2_cells)?;
+        let step3_sum = self.sum_config.assign_region(layouter, step3_cells)?;
         layouter.assign_region(
             || "Overflow range check",
             |mut region| {
                 let offset = 0;
-                self.q_enable.enable(&mut region, offset)?;
-                // Copy constrain Steps 2 and 3 sums to `step2_acc` and `step3_acc` columns.
-                step2_sum.copy_advice(|| "Step2 sum", &mut region, self.step2_acc, offset)?;
-                step3_sum.copy_advice(|| "Step3 sum", &mut region, self.step3_acc, offset)?;
+                self.q_step2.enable(&mut region, offset)?;
+                step2_sum.copy_advice(|| "Step2 sum", &mut region, self.acc, offset)?;
+                let offset = 1;
+                self.q_step3.enable(&mut region, offset)?;
+                step3_sum.copy_advice(|| "Step3 sum", &mut region, self.acc, offset)?;
 
                 Ok(())
             },


### PR DESCRIPTION
By @therealyingtong's advice: We should create columns outside of the configurations instead of inside.

Before optimization:
```
Num advice columns: 102
Num fixed columns: 24
Num instance columns: 2
Num lookups: 6
Num gates: 19
Max advice rows 11087 - lane rotate conversion
num polys: 110
max_gate_degree_poly: 6 - 
```

After optimization:

```
Num advice columns: 31
Num fixed columns: 23
Num instance columns: 2
Num lookups: 6
Num gates: 18
Max advice rows 19042 - Constraint out_state and out_mixing
num polys: 109
max_gate_degree_poly: 6 - 
```
Most column creations happen in mixing (50 columns created) and base conversion (10 columns created). 

Comes with a cost of row increment. Since now rows are stacked together.

Related issue: #489