### PR TITLE
[Presentation][WIP] Radical keccak

### DIFF
--- a/keccak256/src/permutation.rs
+++ b/keccak256/src/permutation.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::type_complexity)]
 #![allow(clippy::too_many_arguments)]
 pub(crate) mod absorb;
+pub(crate) mod add;
 pub(crate) mod base_conversion;
 pub mod circuit;
 pub(crate) mod iota;

--- a/keccak256/src/permutation.rs
+++ b/keccak256/src/permutation.rs
@@ -4,6 +4,7 @@ pub(crate) mod absorb;
 pub(crate) mod add;
 pub(crate) mod base_conversion;
 pub mod circuit;
+pub(crate) mod flag;
 pub(crate) mod iota;
 pub(crate) mod mixing;
 pub(crate) mod pi;

--- a/keccak256/src/permutation/absorb.rs
+++ b/keccak256/src/permutation/absorb.rs
@@ -1,15 +1,11 @@
 use crate::arith_helpers::*;
 use crate::common::*;
 use crate::gate_helpers::*;
-use crate::permutation::{add::AddConfig, base_conversion::BaseConversionConfig};
+use crate::permutation::add::AddConfig;
 use eth_types::Field;
-use halo2_proofs::circuit::{AssignedCell, Layouter, Region};
-use halo2_proofs::{
-    plonk::{Advice, Column, ConstraintSystem, Error, Expression, Selector},
-    poly::Rotation,
-};
-use itertools::Itertools;
-use std::{convert::TryInto, marker::PhantomData};
+use halo2_proofs::circuit::{AssignedCell, Layouter};
+use halo2_proofs::plonk::{Advice, Column, Error};
+use std::convert::TryInto;
 
 // TODO: should do proper base conv here
 pub(crate) fn apply_absorb<F: Field>(

--- a/keccak256/src/permutation/absorb.rs
+++ b/keccak256/src/permutation/absorb.rs
@@ -1,5 +1,7 @@
 use crate::arith_helpers::*;
 use crate::common::*;
+use crate::gate_helpers::*;
+use crate::permutation::{add::AddConfig, base_conversion::BaseConversionConfig};
 use eth_types::Field;
 use halo2_proofs::circuit::{AssignedCell, Layouter, Region};
 use halo2_proofs::{
@@ -9,344 +11,45 @@ use halo2_proofs::{
 use itertools::Itertools;
 use std::{convert::TryInto, marker::PhantomData};
 
-#[derive(Clone, Debug)]
-pub struct AbsorbConfig<F> {
-    q_mixing: Selector,
-    state: [Column<Advice>; 25],
-    _marker: PhantomData<F>,
-}
-
-impl<F: Field> AbsorbConfig<F> {
-    // We assume state is recieved in base-9.
-    // Rows are assigned as:
-    // 1) STATE (25 columns) (offset -1)
-    // 2) NEXT_INPUTS (17 columns) + is_mixing flag (1 column) (offset +0)
-    // (current rotation)
-    // 3) OUT_STATE (25 columns) (offset +1)
-    pub fn configure(
-        meta: &mut ConstraintSystem<F>,
-        state: [Column<Advice>; 25],
-    ) -> AbsorbConfig<F> {
-        // def absorb(state: List[List[int], next_input: List[List[int]):
-        //     for x in range(5):
-        //         for y in range(5):
-        //             # state[x][y] has 2*a + b + 3*c already, now add 2*d to
-        // make it 2*a + b + 3*c + 2*d             # coefficient in 0~8
-        //             state[x][y] += 2 * next_input[x][y]
-        //     return state
-
-        // Declare the q_mixing.
-        let q_mixing = meta.selector();
-        state
-            .iter()
-            .for_each(|column| meta.enable_equality(*column));
-
-        meta.create_gate("absorb", |meta| {
-            // We do a trick which consists on multiplying an internal selector
-            // which is always active by the actual `is_mixing` flag
-            // which will then enable or disable the gate.
-            let q_enable = {
-                // We query the flag value from the `state` `Advice` column at
-                // rotation curr and position = `NEXT_INPUTS_LANES + 1`
-                // and multiply to it the active selector so that we avoid the
-                // `PoisonedConstraints` and each gate equation
-                // can be satisfied while enforcing the correct gate logic.
-                //
-                // This is boolean-constrained outside of `AbsorbConfig` by `MixingConfig`.
-                let flag = meta.query_advice(state[NEXT_INPUTS_LANES], Rotation::cur());
-                // Note also that we want to enable the gate when `is_mixing` is
-                // true. (flag = 1). See the flag computation above.
-                meta.query_selector(q_mixing) * flag
-            };
-
-            (0..NEXT_INPUTS_LANES)
-                .map(|idx| {
-                    let val = meta.query_advice(state[idx], Rotation::prev())
-                        + (Expression::Constant(F::from(A4))
-                            * meta.query_advice(state[idx], Rotation::cur()));
-
-                    let next_lane = meta.query_advice(state[idx], Rotation::next());
-
-                    q_enable.clone() * (val - next_lane)
-                })
-                .collect::<Vec<_>>()
-        });
-
-        AbsorbConfig {
-            q_mixing,
-            state,
-            _marker: PhantomData,
-        }
-    }
-
-    fn assign_next_inp_and_flag(
-        &self,
-        region: &mut Region<F>,
-        offset: usize,
-        flag: AssignedCell<F, F>,
-        next_input: [F; NEXT_INPUTS_LANES],
-    ) -> Result<AssignedCell<F, F>, Error> {
-        // Generate next_input in base-9.
-        let mut next_mixing = state_to_biguint::<F, NEXT_INPUTS_LANES>(next_input);
-        for (x, y) in (0..5).cartesian_product(0..5) {
-            // Assign only first 17 values.
-            if x >= 3 && y >= 1 {
-                break;
-            }
-            next_mixing[(x, y)] = convert_b2_to_b9(next_mixing[(x, y)].clone().try_into().unwrap())
-        }
-        let next_input = state_bigint_to_field::<F, NEXT_INPUTS_LANES>(next_mixing);
-
-        // Assign next_mixing.
-        for (idx, lane) in next_input.iter().enumerate() {
-            region.assign_advice(
-                || format!("assign next_input {}", idx),
-                self.state[idx],
-                offset,
-                || Ok(*lane),
-            )?;
-        }
-
-        // Assign flag at last column(17th).
-        let flag_assig_cell = flag.copy_advice(
-            || format!("assign next_input {}", NEXT_INPUTS_LANES),
-            region,
-            self.state[NEXT_INPUTS_LANES],
-            offset,
-        )?;
-
-        Ok(flag_assig_cell)
-    }
-
-    /// Doc this $
-    pub fn copy_state_flag_next_inputs(
-        &self,
-        layouter: &mut impl Layouter<F>,
-        in_state: &[AssignedCell<F, F>; 25],
-        out_state: [F; 25],
-        // Passed in base-2 and converted internally after witnessing it.
-        next_input: [F; NEXT_INPUTS_LANES],
-        flag: AssignedCell<F, F>,
-    ) -> Result<([AssignedCell<F, F>; 25], AssignedCell<F, F>), Error> {
-        layouter.assign_region(
-            || "Absorb state assignations",
-            |mut region| {
-                let mut offset = 0;
-                // State at offset + 0
-                for (idx, in_state) in in_state.iter().enumerate() {
-                    in_state.copy_advice(
-                        || format!("assign state {}", idx),
-                        &mut region,
-                        self.state[idx],
-                        offset,
-                    )?;
-                }
-
-                offset += 1;
-                // Enable `q_mixing` at `offset + 1`
-                self.q_mixing.enable(&mut region, offset)?;
-
-                // Assign `next_inputs` and flag.
-                let flag =
-                    self.assign_next_inp_and_flag(&mut region, offset, flag.clone(), next_input)?;
-
-                offset += 1;
-                // Assign out_state at offset + 2
-                let mut state: Vec<AssignedCell<F, F>> = Vec::with_capacity(25);
-                for (idx, lane) in out_state.iter().enumerate() {
-                    let assig_cell = region.assign_advice(
-                        || format!("assign state {}", idx),
-                        self.state[idx],
-                        offset,
-                        || Ok(*lane),
-                    )?;
-                    state.push(assig_cell);
-                }
-                let out_state: [AssignedCell<F, F>; 25] = state
-                    .try_into()
-                    .expect("Unexpected into_slice conversion err");
-
-                Ok((out_state, flag))
-            },
-        )
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::common::State;
-    use crate::keccak_arith::KeccakFArith;
-    use halo2_proofs::circuit::Layouter;
-    use halo2_proofs::pairing;
-    use halo2_proofs::plonk::{Advice, Column, ConstraintSystem, Error};
-    use halo2_proofs::{circuit::SimpleFloorPlanner, dev::MockProver, plonk::Circuit};
-    use itertools::Itertools;
-    use pairing::bn256::Fr as Fp;
-    use pairing::group::ff::PrimeField;
-    use pretty_assertions::assert_eq;
-    use std::convert::TryInto;
-    use std::marker::PhantomData;
-
-    #[test]
-    fn test_absorb_gate() {
-        #[derive(Default)]
-        struct MyCircuit<F> {
-            in_state: [F; 25],
-            out_state: [F; 25],
-            next_input: [F; NEXT_INPUTS_LANES],
-            is_mixing: bool,
-            _marker: PhantomData<F>,
-        }
-        impl<F: Field> Circuit<F> for MyCircuit<F>
-        where
-            F: PrimeField<Repr = [u8; 32]>,
-        {
-            type Config = AbsorbConfig<F>;
-            type FloorPlanner = SimpleFloorPlanner;
-
-            fn without_witnesses(&self) -> Self {
-                Self::default()
-            }
-
-            fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
-                let state: [Column<Advice>; 25] = (0..25)
-                    .map(|_| {
-                        let column = meta.advice_column();
-                        meta.enable_equality(column);
-                        column
-                    })
-                    .collect::<Vec<_>>()
-                    .try_into()
-                    .unwrap();
-
-                AbsorbConfig::configure(meta, state)
-            }
-
-            fn synthesize(
-                &self,
-                config: Self::Config,
-                mut layouter: impl Layouter<F>,
-            ) -> Result<(), Error> {
-                let val: F = (self.is_mixing as u64).into();
-                let flag: AssignedCell<F, F> = layouter.assign_region(
-                    || "witness_is_mixing_flag",
-                    |mut region| {
-                        let offset = 1;
-                        region.assign_advice(
-                            || "assign is_mixing",
-                            config.state[NEXT_INPUTS_LANES + 1],
-                            offset,
-                            || Ok(val),
-                        )
+// TODO: should do proper base conv here
+pub(crate) fn apply_absorb<F: Field>(
+    add: &AddConfig<F>,
+    layouter: &mut impl Layouter<F>,
+    next_input_col: Column<Advice>,
+    state: &[AssignedCell<F, F>; 25],
+    next_input: &[Option<F>; NEXT_INPUTS_LANES],
+) -> Result<[AssignedCell<F, F>; 25], Error> {
+    let next_input_b9 = layouter.assign_region(
+        || "next input words",
+        |mut region| {
+            let mut next_input_b9: Vec<AssignedCell<F, F>> = vec![];
+            for (offset, input) in next_input.iter().enumerate() {
+                let cell = region.assign_advice(
+                    || "next input words",
+                    next_input_col,
+                    offset,
+                    || {
+                        input
+                            .map(|input| {
+                                let input = f_to_biguint(input);
+                                let input =
+                                    convert_b2_to_b9(*input.to_u64_digits().first().unwrap());
+                                biguint_to_f(&input)
+                            })
+                            .ok_or(Error::Synthesis)
                     },
                 )?;
-
-                // Witness `in_state`.
-                let in_state: [AssignedCell<F, F>; 25] = layouter.assign_region(
-                    || "Witness input state",
-                    |mut region| {
-                        let mut state: Vec<AssignedCell<F, F>> = Vec::with_capacity(25);
-                        for (idx, val) in self.in_state.iter().enumerate() {
-                            let cell = region.assign_advice(
-                                || "witness input state",
-                                config.state[idx],
-                                0,
-                                || Ok(*val),
-                            )?;
-                            state.push(cell)
-                        }
-
-                        Ok(state.try_into().unwrap())
-                    },
-                )?;
-
-                config.copy_state_flag_next_inputs(
-                    &mut layouter,
-                    &in_state,
-                    self.out_state,
-                    self.next_input,
-                    flag,
-                )?;
-
-                Ok(())
+                next_input_b9.push(cell);
             }
-        }
+            Ok(next_input_b9)
+        },
+    )?;
 
-        let input1: State = [
-            [1, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0],
-        ];
-
-        let input2: State = [
-            [2, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0],
-        ];
-
-        // Convert the input to base9 as the gadget already expects it like this
-        // since it's always the output of IotaB9.
-        let mut in_state = StateBigInt::from(input1);
-        for (x, y) in (0..5).cartesian_product(0..5) {
-            in_state[(x, y)] = convert_b2_to_b9(input1[x][y])
-        }
-
-        let in_state = state_bigint_to_field(in_state);
-        let out_state =
-            state_bigint_to_field(KeccakFArith::absorb(&StateBigInt::from(input1), &input2));
-
-        let next_input = state_bigint_to_field(StateBigInt::from(input2));
-
-        // With flag set to true, the gate should trigger.
-        {
-            // With the correct input and output witnesses, the proof should
-            // pass.
-            let circuit = MyCircuit::<Fp> {
-                in_state,
-                out_state,
-                next_input,
-                is_mixing: true,
-                _marker: PhantomData,
-            };
-
-            let prover = MockProver::<Fp>::run(9, &circuit, vec![]).unwrap();
-
-            assert_eq!(prover.verify(), Ok(()));
-
-            // With wrong input and/or output witnesses, the proof should fail
-            // to be verified.
-            let circuit = MyCircuit::<Fp> {
-                in_state,
-                out_state: in_state,
-                next_input,
-                is_mixing: true,
-                _marker: PhantomData,
-            };
-
-            let prover = MockProver::<Fp>::run(9, &circuit, vec![]).unwrap();
-
-            assert!(prover.verify().is_err());
-        }
-
-        // With flag set to `false`, the gate shouldn't trigger.
-        // And so we can pass any witness data and the proof should pass.
-        {
-            let circuit = MyCircuit::<Fp> {
-                in_state,
-                out_state: in_state,
-                next_input,
-                is_mixing: false,
-                _marker: PhantomData,
-            };
-
-            let prover = MockProver::<Fp>::run(9, &circuit, vec![]).unwrap();
-
-            assert_eq!(prover.verify(), Ok(()));
-        }
+    let mut out_state: Vec<AssignedCell<F, F>> = vec![];
+    for (i, input) in next_input_b9.iter().enumerate() {
+        let out_lane =
+            add.add_advice_mul_const(layouter, state[i].clone(), input.clone(), F::from(A4))?;
+        out_state.push(out_lane);
     }
+    Ok(out_state.try_into().unwrap())
 }

--- a/keccak256/src/permutation/absorb.rs
+++ b/keccak256/src/permutation/absorb.rs
@@ -25,14 +25,15 @@ pub(crate) fn apply_absorb<F: Field>(
                     next_input_col,
                     offset,
                     || {
-                        input
+                        Ok(input
                             .map(|input| {
                                 let input = f_to_biguint(input);
-                                let input =
-                                    convert_b2_to_b9(*input.to_u64_digits().first().unwrap());
+                                let input = convert_b2_to_b9(
+                                    *input.to_u64_digits().first().unwrap_or(&0u64),
+                                );
                                 biguint_to_f(&input)
                             })
-                            .ok_or(Error::Synthesis)
+                            .unwrap_or(F::zero()))
                     },
                 )?;
                 next_input_b9.push(cell);
@@ -46,6 +47,9 @@ pub(crate) fn apply_absorb<F: Field>(
         let out_lane =
             add.add_advice_mul_const(layouter, state[i].clone(), input.clone(), F::from(A4))?;
         out_state.push(out_lane);
+    }
+    for i in NEXT_INPUTS_LANES..25 {
+        out_state.push(state[i].clone());
     }
     Ok(out_state.try_into().unwrap())
 }

--- a/keccak256/src/permutation/add.rs
+++ b/keccak256/src/permutation/add.rs
@@ -97,14 +97,15 @@ impl<F: Field> AddConfig<F> {
             },
         )
     }
-    /// input += x
-    pub fn add_advice(
+    /// input += v * x
+    pub fn add_advice_mul_const(
         &self,
         layouter: &mut impl Layouter<F>,
         input: AssignedCell<F, F>,
         x: AssignedCell<F, F>,
+        v: F,
     ) -> Result<AssignedCell<F, F>, Error> {
-        self.add_generic(layouter, input, Some(x), None)
+        self.add_generic(layouter, input, Some(x), Some(v))
     }
     /// input -= x
     pub fn sub_advice(

--- a/keccak256/src/permutation/add.rs
+++ b/keccak256/src/permutation/add.rs
@@ -27,6 +27,7 @@ impl<F: Field> AddConfig<F> {
         let q_enable = meta.selector();
         meta.enable_equality(x);
         meta.enable_equality(input);
+        meta.enable_constant(fixed);
 
         meta.create_gate("add", |meta| {
             let q_enable = meta.query_selector(q_enable);
@@ -188,6 +189,11 @@ impl<F: Field> AddConfig<F> {
         outcome: Option<AssignedCell<F, F>>,
     ) -> Result<AssignedCell<F, F>, Error> {
         let len = xs.len();
-        self.linear_combine(layouter, xs, (0..len).map(|_| F::one()).collect_vec(), outcome)
+        self.linear_combine(
+            layouter,
+            xs,
+            (0..len).map(|_| F::one()).collect_vec(),
+            outcome,
+        )
     }
 }

--- a/keccak256/src/permutation/add.rs
+++ b/keccak256/src/permutation/add.rs
@@ -11,38 +11,39 @@ use std::marker::PhantomData;
 #[derive(Clone, Debug)]
 pub struct AddConfig<F> {
     q_enable: Selector,
-    input: Column<Advice>,
-    x: Column<Advice>,
-    fixed: Column<Fixed>,
+    io: Column<Advice>,
+    left: Column<Advice>,
+    right: Column<Advice>,
     _marker: PhantomData<F>,
 }
 
 impl<F: Field> AddConfig<F> {
     pub fn configure(
         meta: &mut ConstraintSystem<F>,
-        input: Column<Advice>,
-        x: Column<Advice>,
+        advices: [Column<Advice>; 3],
         fixed: Column<Fixed>,
     ) -> Self {
         let q_enable = meta.selector();
-        meta.enable_equality(x);
-        meta.enable_equality(input);
+        let [io, left, right] = advices;
+        meta.enable_equality(io);
+        meta.enable_equality(left);
+        meta.enable_equality(right);
         meta.enable_constant(fixed);
 
         meta.create_gate("add", |meta| {
             let q_enable = meta.query_selector(q_enable);
-            let x = meta.query_advice(x, Rotation::cur());
-            let input_next = meta.query_advice(input, Rotation::next());
-            let input = meta.query_advice(input, Rotation::cur());
-            let fixed = meta.query_fixed(fixed, Rotation::cur());
-            vec![q_enable * (input_next - input - x * fixed)]
+            let input = meta.query_advice(io, Rotation::cur());
+            let output = meta.query_advice(io, Rotation::next());
+            let left = meta.query_advice(left, Rotation::cur());
+            let right = meta.query_advice(right, Rotation::cur());
+            vec![q_enable * (output - input - left * right)]
         });
 
         Self {
             q_enable,
-            input,
-            x,
-            fixed,
+            io,
+            left,
+            right,
             _marker: PhantomData,
         }
     }
@@ -51,7 +52,8 @@ impl<F: Field> AddConfig<F> {
         &self,
         layouter: &mut impl Layouter<F>,
         input: AssignedCell<F, F>,
-        x: Option<AssignedCell<F, F>>,
+        left: Option<AssignedCell<F, F>>,
+        right: Option<AssignedCell<F, F>>,
         value: Option<F>,
     ) -> Result<AssignedCell<F, F>, Error> {
         layouter.assign_region(
@@ -59,34 +61,51 @@ impl<F: Field> AddConfig<F> {
             |mut region| {
                 let offset = 0;
                 self.q_enable.enable(&mut region, offset)?;
-                input.copy_advice(|| "input", &mut region, self.input, offset)?;
-                let x = match &x {
+                input.copy_advice(|| "input", &mut region, self.io, offset)?;
+                let x = match &left {
                     Some(x) => {
                         // copy x to use as a flag
-                        (*x).copy_advice(|| "x", &mut region, self.x, offset)?;
-                        x.clone()
+                        (*x).copy_advice(|| "left adv", &mut region, self.left, offset)?
                     }
                     None => {
                         // constrain advice to 1 for a simple add.
-                        let x = region.assign_advice(|| "x", self.x, offset, || Ok(F::one()))?;
-                        region.constrain_constant(x.cell(), F::one())?;
-                        x
+                        region.assign_advice_from_constant(
+                            || "left const",
+                            self.right,
+                            offset,
+                            F::one(),
+                        )?
                     }
                 };
-                let value = match value {
-                    Some(value) => {
-                        region.assign_fixed(|| "fixed value", self.fixed, offset, || Ok(value))?
+                if let Some(right) = &right {
+                    if value.is_some() {
+                        panic!("right and value can't be both some");
                     }
+                    right.copy_advice(|| "right adv", &mut region, self.right, offset)?;
+                }
+
+                let value = match value {
+                    Some(value) => region.assign_advice_from_constant(
+                        || "fixed value",
+                        self.right,
+                        offset,
+                        value,
+                    )?,
                     None => {
                         // constrain fixed to 1 for a simple add.
-                        region.assign_fixed(|| "1", self.fixed, offset, || Ok(F::one()))?
+                        region.assign_advice_from_constant(
+                            || "fixed value",
+                            self.right,
+                            offset,
+                            F::one(),
+                        )?
                     }
                 };
 
                 let offset = 1;
                 region.assign_advice(
                     || "input + x",
-                    self.input,
+                    self.io,
                     offset,
                     || {
                         Ok(input.value().cloned().ok_or(Error::Synthesis)?
@@ -105,7 +124,7 @@ impl<F: Field> AddConfig<F> {
         x: AssignedCell<F, F>,
         v: F,
     ) -> Result<AssignedCell<F, F>, Error> {
-        self.add_generic(layouter, input, Some(x), Some(v))
+        self.add_generic(layouter, input, Some(x), None, Some(v))
     }
     /// input -= x
     pub fn sub_advice(
@@ -114,7 +133,7 @@ impl<F: Field> AddConfig<F> {
         input: AssignedCell<F, F>,
         x: AssignedCell<F, F>,
     ) -> Result<AssignedCell<F, F>, Error> {
-        self.add_generic(layouter, input, Some(x), Some(-F::one()))
+        self.add_generic(layouter, input, Some(x), None, Some(-F::one()))
     }
     /// input += v
     pub fn add_fixed(
@@ -123,54 +142,96 @@ impl<F: Field> AddConfig<F> {
         input: AssignedCell<F, F>,
         value: F,
     ) -> Result<AssignedCell<F, F>, Error> {
-        self.add_generic(layouter, input, None, Some(value))
+        self.add_generic(layouter, input, None, None, Some(value))
     }
     /// input += flag * v
     /// No boolean check on the flag, we assume the flag is checked before
     /// copied to here
-    pub fn conditional_add(
+    pub fn conditional_add_const(
         &self,
         layouter: &mut impl Layouter<F>,
         input: AssignedCell<F, F>,
         flag: AssignedCell<F, F>,
         value: F,
     ) -> Result<AssignedCell<F, F>, Error> {
-        self.add_generic(layouter, input, Some(flag), Some(value))
+        self.add_generic(layouter, input, Some(flag), None, Some(value))
     }
-    pub fn linear_combine(
+    /// input += flag * x
+    /// No boolean check on the flag, we assume the flag is checked before
+    /// copied to here
+    pub fn conditional_add_advice(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        input: AssignedCell<F, F>,
+        flag: AssignedCell<F, F>,
+        x: AssignedCell<F, F>,
+    ) -> Result<AssignedCell<F, F>, Error> {
+        self.add_generic(layouter, input, Some(flag), Some(x), None)
+    }
+    fn linear_combine_generic(
         &self,
         layouter: &mut impl Layouter<F>,
         xs: Vec<AssignedCell<F, F>>,
-        vs: Vec<F>,
+        ys: Option<Vec<AssignedCell<F, F>>>,
+        vs: Option<Vec<F>>,
         outcome: Option<AssignedCell<F, F>>,
     ) -> Result<AssignedCell<F, F>, Error> {
-        debug_assert_eq!(xs.len(), vs.len());
+        debug_assert_eq!(
+            ys.is_some(),
+            vs.is_some(),
+            "They can't both some or both none"
+        );
+        if let Some(ref vs) = vs {
+            debug_assert_eq!(xs.len(), vs.len());
+        }
+        if let Some(ref ys) = ys {
+            debug_assert_eq!(xs.len(), ys.len());
+        }
         layouter.assign_region(
             || "linear combine",
             |mut region| {
-                // | offset |        input |        x |   fixed |
+                // | offset |        input |        x |   y |
                 // | ------ | -----------: | -------: | ------: |
-                // | 0      |            0 |       x0 |      v0 |
-                // | 1      |         x0v0 |       x1 |      v1 |
-                // | 2      | x0v0 + x1v1  |       x2 |      v2 |
+                // | 0      |            0 |       x0 |      y0 |
+                // | 1      |         x0y0 |       x1 |      y1 |
+                // | 2      |  x0y0 + x1y1 |       x2 |      y2 |
                 // | ...    |          ... |      ... |     ... |
-                // | N - 1  |              |  x_(N-1) | v_(N-1) |
+                // | N - 1  |              |  x_(N-1) | y_(N-1) |
                 // | N      |    (sum)     |          |         |
-                let mut acc =
-                    region.assign_advice(|| "input 0", self.input, 0, || Ok(F::zero()))?;
+                let mut acc = region.assign_advice(|| "input 0", self.io, 0, || Ok(F::zero()))?;
                 region.constrain_constant(acc.cell(), F::zero())?;
                 let mut sum = F::zero();
                 for (offset, x) in xs.iter().enumerate() {
                     self.q_enable.enable(&mut region, offset)?;
-                    x.copy_advice(|| "x", &mut region, self.x, offset)?;
-                    let v = region.assign_fixed(|| "v", self.fixed, offset, || Ok(vs[offset]))?;
+                    x.copy_advice(|| "x", &mut region, self.left, offset)?;
+                    let right = {
+                        match &vs {
+                            Some(vs) => region.assign_advice_from_constant(
+                                || "v",
+                                self.right,
+                                offset,
+                                vs[offset],
+                            )?,
+                            None => match &ys {
+                                Some(ys) => ys[offset].copy_advice(
+                                    || "y",
+                                    &mut region,
+                                    self.right,
+                                    offset,
+                                )?,
+                                None => {
+                                    unreachable!()
+                                }
+                            },
+                        }
+                    };
                     acc = region.assign_advice(
                         || "accumulation",
-                        self.input,
+                        self.io,
                         offset + 1,
                         || {
                             sum += x.value().cloned().ok_or(Error::Synthesis)?
-                                * v.value().cloned().ok_or(Error::Synthesis)?;
+                                * right.value().cloned().ok_or(Error::Synthesis)?;
                             Ok(sum)
                         },
                     )?;
@@ -183,6 +244,26 @@ impl<F: Field> AddConfig<F> {
         )
     }
 
+    pub fn linear_combine_consts(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        xs: Vec<AssignedCell<F, F>>,
+        vs: Vec<F>,
+        outcome: Option<AssignedCell<F, F>>,
+    ) -> Result<AssignedCell<F, F>, Error> {
+        self.linear_combine_generic(layouter, xs, None, Some(vs), outcome)
+    }
+
+    pub fn linear_combine_advices(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        xs: Vec<AssignedCell<F, F>>,
+        ys: Vec<AssignedCell<F, F>>,
+        outcome: Option<AssignedCell<F, F>>,
+    ) -> Result<AssignedCell<F, F>, Error> {
+        self.linear_combine_generic(layouter, xs, Some(ys), None, outcome)
+    }
+
     pub fn running_sum(
         &self,
         layouter: &mut impl Layouter<F>,
@@ -190,7 +271,7 @@ impl<F: Field> AddConfig<F> {
         outcome: Option<AssignedCell<F, F>>,
     ) -> Result<AssignedCell<F, F>, Error> {
         let len = xs.len();
-        self.linear_combine(
+        self.linear_combine_consts(
             layouter,
             xs,
             (0..len).map(|_| F::one()).collect_vec(),

--- a/keccak256/src/permutation/add.rs
+++ b/keccak256/src/permutation/add.rs
@@ -1,0 +1,156 @@
+use eth_types::Field;
+use halo2_proofs::circuit::AssignedCell;
+use halo2_proofs::circuit::Layouter;
+use halo2_proofs::{
+    plonk::{Advice, Column, ConstraintSystem, Error, Fixed, Selector},
+    poly::Rotation,
+};
+use std::marker::PhantomData;
+
+#[derive(Clone, Debug)]
+pub struct AddConfig<F> {
+    q_enable: Selector,
+    input: Column<Advice>,
+    x: Column<Advice>,
+    fixed: Column<Fixed>,
+    _marker: PhantomData<F>,
+}
+
+impl<F: Field> AddConfig<F> {
+    pub fn configure(
+        meta: &mut ConstraintSystem<F>,
+        input: Column<Advice>,
+        x: Column<Advice>,
+        fixed: Column<Fixed>,
+    ) -> Self {
+        let q_enable = meta.selector();
+        meta.enable_equality(x);
+        meta.enable_equality(input);
+
+        meta.create_gate("add", |meta| {
+            let q_enable = meta.query_selector(q_enable);
+            let x = meta.query_advice(x, Rotation::cur());
+            let input_next = meta.query_advice(input, Rotation::next());
+            let input = meta.query_advice(input, Rotation::cur());
+            let fixed = meta.query_fixed(fixed, Rotation::cur());
+            vec![q_enable * (input_next - input - x * fixed)]
+        });
+
+        Self {
+            q_enable,
+            input,
+            x,
+            fixed,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn add_advice(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        input: AssignedCell<F, F>,
+        x: AssignedCell<F, F>,
+    ) -> Result<AssignedCell<F, F>, Error> {
+        layouter.assign_region(
+            || "add advice",
+            |mut region| {
+                let offset = 0;
+                self.q_enable.enable(&mut region, offset)?;
+                input.copy_advice(|| "input", &mut region, self.input, offset)?;
+                x.copy_advice(|| "x", &mut region, self.x, offset)?;
+
+                // constrain fixed to 1 for a simple add.
+                region.assign_fixed(|| "1", self.fixed, offset, || Ok(F::one()))?;
+
+                let offset = 1;
+                region.assign_advice(
+                    || "input + x",
+                    self.input,
+                    offset,
+                    || {
+                        Ok(input.value().cloned().ok_or(Error::Synthesis)?
+                            + x.value().cloned().ok_or(Error::Synthesis)?)
+                    },
+                )
+            },
+        )
+    }
+    pub fn add_fixed(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        input: AssignedCell<F, F>,
+        value: F,
+    ) -> Result<AssignedCell<F, F>, Error> {
+        layouter.assign_region(
+            || "add fixed",
+            |mut region| {
+                let offset = 0;
+                self.q_enable.enable(&mut region, offset)?;
+                input.copy_advice(|| "input", &mut region, self.input, offset)?;
+
+                {
+                    // constrain advice to 1 for a simple add.
+                    let x = region.assign_advice(|| "x", self.x, offset, || Ok(F::one()))?;
+                    region.constrain_constant(x.cell(), F::one())?;
+                }
+                region.assign_fixed(|| "fixed value", self.fixed, offset, || Ok(value))?;
+
+                let offset = 1;
+                region.assign_advice(
+                    || "input + x",
+                    self.input,
+                    offset,
+                    || Ok(input.value().cloned().ok_or(Error::Synthesis)? + value),
+                )
+            },
+        )
+    }
+    pub fn linear_combine<const N: usize>(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        xs: [AssignedCell<F, F>; N],
+        vs: [F; N],
+    ) -> Result<AssignedCell<F, F>, Error> {
+        layouter.assign_region(
+            || "linear combine",
+            |mut region| {
+                // | offset |        input |        x |   fixed |
+                // | ------ | -----------: | -------: | ------: |
+                // | 0      |            0 |       x0 |      v0 |
+                // | 1      |         x0v0 |       x1 |      v1 |
+                // | 2      | x0v0 + x1v1  |       x2 |      v2 |
+                // | ...    |          ... |      ... |     ... |
+                // | N - 1  |              |  x_(N-1) | v_(N-1) |
+                // | N      |    (sum)     |          |         |
+                let mut acc =
+                    region.assign_advice(|| "input 0", self.input, 0, || Ok(F::zero()))?;
+                region.constrain_constant(acc.cell(), F::zero())?;
+                let mut sum = F::zero();
+                for offset in 0..N {
+                    self.q_enable.enable(&mut region, offset)?;
+                    let x = xs[offset].copy_advice(|| "x", &mut region, self.x, offset)?;
+                    let v = region.assign_fixed(|| "v", self.fixed, offset, || Ok(vs[offset]))?;
+                    acc = region.assign_advice(
+                        || "accumulation",
+                        self.input,
+                        offset + 1,
+                        || {
+                            sum += x.value().cloned().ok_or(Error::Synthesis)?
+                                * v.value().cloned().ok_or(Error::Synthesis)?;
+                            Ok(sum)
+                        },
+                    )?;
+                }
+                Ok(acc)
+            },
+        )
+    }
+
+    pub fn running_sum<const N: usize>(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        xs: [AssignedCell<F, F>; N],
+    ) -> Result<AssignedCell<F, F>, Error> {
+        self.linear_combine(layouter, xs, [F::one(); N])
+    }
+}

--- a/keccak256/src/permutation/add.rs
+++ b/keccak256/src/permutation/add.rs
@@ -140,6 +140,7 @@ impl<F: Field> AddConfig<F> {
         layouter: &mut impl Layouter<F>,
         xs: Vec<AssignedCell<F, F>>,
         vs: Vec<F>,
+        outcome: Option<AssignedCell<F, F>>,
     ) -> Result<AssignedCell<F, F>, Error> {
         debug_assert_eq!(xs.len(), vs.len());
         layouter.assign_region(
@@ -172,6 +173,9 @@ impl<F: Field> AddConfig<F> {
                         },
                     )?;
                 }
+                if let Some(outcome) = &outcome {
+                    region.constrain_equal(outcome.cell(), acc.cell())?;
+                }
                 Ok(acc)
             },
         )
@@ -181,8 +185,9 @@ impl<F: Field> AddConfig<F> {
         &self,
         layouter: &mut impl Layouter<F>,
         xs: Vec<AssignedCell<F, F>>,
+        outcome: Option<AssignedCell<F, F>>,
     ) -> Result<AssignedCell<F, F>, Error> {
         let len = xs.len();
-        self.linear_combine(layouter, xs, (0..len).map(|_| F::one()).collect_vec())
+        self.linear_combine(layouter, xs, (0..len).map(|_| F::one()).collect_vec(), outcome)
     }
 }

--- a/keccak256/src/permutation/base_conversion.rs
+++ b/keccak256/src/permutation/base_conversion.rs
@@ -92,10 +92,10 @@ impl<F: Field> BaseConversionConfig<F> {
             },
         )?;
         self.add
-            .linear_combine(layouter, input_coef_cells, input_pobs, Some(input))?;
+            .linear_combine_consts(layouter, input_coef_cells, input_pobs, Some(input))?;
         let output_lane =
             self.add
-                .linear_combine(layouter, output_coef_cells, output_pobs, None)?;
+                .linear_combine_consts(layouter, output_coef_cells, output_pobs, None)?;
 
         Ok(output_lane)
     }

--- a/keccak256/src/permutation/base_conversion.rs
+++ b/keccak256/src/permutation/base_conversion.rs
@@ -152,7 +152,7 @@ mod tests {
                 let table = FromBinaryTableConfig::configure(meta);
                 let lane = meta.advice_column();
                 meta.enable_equality(lane);
-                let advices: [Column<Advice>; 2] = (0..2)
+                let advices: [Column<Advice>; 3] = (0..3)
                     .map(|_| {
                         let col = meta.advice_column();
                         meta.enable_equality(col);
@@ -164,8 +164,13 @@ mod tests {
                 let base_info = table.get_base_info(false);
                 let fixed = meta.fixed_column();
                 meta.enable_constant(fixed);
-                let add = AddConfig::configure(meta, advices[0], advices[1], fixed);
-                let conversion = BaseConversionConfig::configure(meta, base_info, advices, &add);
+                let add = AddConfig::configure(meta, advices, fixed);
+                let conversion = BaseConversionConfig::configure(
+                    meta,
+                    base_info,
+                    advices[0..2].try_into().unwrap(),
+                    &add,
+                );
                 Self {
                     lane,
                     table,
@@ -260,7 +265,7 @@ mod tests {
                 let table = FromBase9TableConfig::configure(meta);
                 let lane = meta.advice_column();
                 meta.enable_equality(lane);
-                let advices: [Column<Advice>; 2] = (0..2)
+                let advices: [Column<Advice>; 3] = (0..3)
                     .map(|_| {
                         let col = meta.advice_column();
                         meta.enable_equality(col);
@@ -272,8 +277,13 @@ mod tests {
                 let base_info = table.get_base_info(false);
                 let fixed = meta.fixed_column();
                 meta.enable_constant(fixed);
-                let add = AddConfig::configure(meta, advices[0], advices[1], fixed);
-                let conversion = BaseConversionConfig::configure(meta, base_info, advices, &add);
+                let add = AddConfig::configure(meta, advices, fixed);
+                let conversion = BaseConversionConfig::configure(
+                    meta,
+                    base_info,
+                    advices[0..2].try_into().unwrap(),
+                    &add,
+                );
                 Self {
                     lane,
                     table,
@@ -367,7 +377,7 @@ mod tests {
                     .collect::<Vec<_>>()
                     .try_into()
                     .unwrap();
-                let advices: [Column<Advice>; 2] = (0..2)
+                let advices: [Column<Advice>; 3] = (0..3)
                     .map(|_| {
                         let col = meta.advice_column();
                         meta.enable_equality(col);
@@ -380,8 +390,13 @@ mod tests {
                 let fixed = meta.fixed_column();
                 meta.enable_equality(fixed);
                 meta.enable_constant(fixed);
-                let add = AddConfig::configure(meta, advices[0], advices[1], fixed);
-                let conversion = BaseConversionConfig::configure(meta, bi, advices, &add);
+                let add = AddConfig::configure(meta, advices, fixed);
+                let conversion = BaseConversionConfig::configure(
+                    meta,
+                    bi,
+                    advices[0..2].try_into().unwrap(),
+                    &add,
+                );
                 Self {
                     state,
                     table,

--- a/keccak256/src/permutation/circuit.rs
+++ b/keccak256/src/permutation/circuit.rs
@@ -64,19 +64,13 @@ impl<F: Field> KeccakFConfig<F> {
         // Base conversion config.
         let from_b9_table = FromBase9TableConfig::configure(meta);
         let base_info = from_b9_table.get_base_info(false);
-        let base_conv_lane = meta.advice_column();
-        let base_conversion_config = BaseConversionConfig::configure(
-            meta,
-            base_info,
-            base_conv_lane,
-            base_conv_activator,
-            state[0..5].try_into().unwrap(),
-        );
+        let base_conversion_config =
+            BaseConversionConfig::configure(meta, base_info, state[0..2].try_into().unwrap(), &add);
 
         // Mixing will make sure that the flag is binary constrained and that
         // the out state matches the expected result.
         let mixing_config =
-            MixingConfig::configure(meta, &from_b9_table, iota_config.clone(), state);
+            MixingConfig::configure(meta, &from_b9_table, iota_config.clone(), &add, state);
 
         // Allocate the `out state correctness` gate selector
         let q_out = meta.selector();
@@ -164,8 +158,7 @@ impl<F: Field> KeccakFConfig<F> {
                     },
                 )?;
 
-                self.base_conversion_config
-                    .assign_state(layouter, &state, activation_flag)?
+                self.base_conversion_config.assign_state(layouter, &state)?
             }
         }
 

--- a/keccak256/src/permutation/circuit.rs
+++ b/keccak256/src/permutation/circuit.rs
@@ -310,7 +310,7 @@ mod tests {
                     &mut layouter,
                     in_state,
                     self.out_state,
-                    self.is_mixing,
+                    Some(self.is_mixing),
                     self.next_mixing,
                 )?;
                 Ok(())

--- a/keccak256/src/permutation/circuit.rs
+++ b/keccak256/src/permutation/circuit.rs
@@ -56,7 +56,7 @@ impl<F: Field> KeccakFConfig<F> {
         let add = AddConfig::configure(meta, input, x, fixed[3]);
 
         // theta
-        let theta_config = ThetaConfig::configure(meta.selector(), meta, state);
+        let theta_config = ThetaConfig::configure(add.clone());
         // rho
         let rho_config = RhoConfig::configure(meta, state, fixed[0], add.clone());
         // xi
@@ -132,15 +132,7 @@ impl<F: Field> KeccakFConfig<F> {
         for round_idx in 0..PERMUTATION {
             // State in base-13
             // theta
-            state = {
-                // Apply theta outside circuit
-                let out_state =
-                    KeccakFArith::theta(&state_to_biguint(split_state_cells(state.clone())));
-                let out_state = state_bigint_to_field(out_state);
-                // assignment
-                self.theta_config
-                    .assign_state(layouter, &state, out_state)?
-            };
+            state = self.theta_config.assign_state(layouter, &state)?;
 
             // rho
             state = self.rho_config.assign_rotation_checks(layouter, &state)?;

--- a/keccak256/src/permutation/circuit.rs
+++ b/keccak256/src/permutation/circuit.rs
@@ -112,7 +112,7 @@ impl<F: Field> KeccakFConfig<F> {
         in_state: [AssignedCell<F, F>; 25],
         out_state: [F; 25],
         flag: Option<bool>,
-        next_mixing: Option<[F; NEXT_INPUTS_LANES]>,
+        next_mixing: [Option<F>; NEXT_INPUTS_LANES],
     ) -> Result<[AssignedCell<F, F>; 25], Error> {
         let mut state = in_state;
 

--- a/keccak256/src/permutation/circuit.rs
+++ b/keccak256/src/permutation/circuit.rs
@@ -53,15 +53,15 @@ impl<F: Field> KeccakFConfig<F> {
         let input = meta.advice_column();
         let x = meta.advice_column();
 
-        let add_config = AddConfig::configure(meta, input, x, fixed[3]);
+        let add = AddConfig::configure(meta, input, x, fixed[3]);
 
         // theta
         let theta_config = ThetaConfig::configure(meta.selector(), meta, state);
         // rho
-        let rho_config = RhoConfig::configure(meta, state, fixed[0..3].try_into().unwrap());
+        let rho_config = RhoConfig::configure(meta, state, fixed[0], add.clone());
         // xi
         let xi_config = XiConfig::configure(meta.selector(), meta, state);
-        let iota_config = IotaConfig::configure(add_config.clone());
+        let iota_config = IotaConfig::configure(add.clone());
 
         // Allocate space for the activation flag of the base_conversion.
         let base_conv_activator = meta.advice_column();

--- a/keccak256/src/permutation/circuit.rs
+++ b/keccak256/src/permutation/circuit.rs
@@ -1,7 +1,7 @@
 use crate::{
     common::{NEXT_INPUTS_LANES, PERMUTATION},
     permutation::{
-        add::AddConfig, base_conversion::BaseConversionConfig, iota::IotaConfig,
+        add::AddConfig, base_conversion::BaseConversionConfig, flag::FlagConfig, iota::IotaConfig,
         mixing::MixingConfig, pi::pi_gate_permutation, rho::RhoConfig,
         tables::FromBase9TableConfig, theta::assign_theta, xi::assign_xi,
     },
@@ -41,6 +41,7 @@ impl<F: Field> KeccakFConfig<F> {
         let fixed = meta.fixed_column();
 
         let add = AddConfig::configure(meta, state[0..3].try_into().unwrap(), fixed);
+        let flag = FlagConfig::configure(meta, state[0]);
 
         // rho
         let rho_config = RhoConfig::configure(meta, state, fixed, add.clone());
@@ -55,7 +56,7 @@ impl<F: Field> KeccakFConfig<F> {
         // Mixing will make sure that the flag is binary constrained and that
         // the out state matches the expected result.
         let mixing_config =
-            MixingConfig::configure(meta, &from_b9_table, iota_config.clone(), &add, state);
+            MixingConfig::configure(meta, &from_b9_table, iota_config.clone(), &add, state, flag);
 
         Self {
             add,

--- a/keccak256/src/permutation/circuit.rs
+++ b/keccak256/src/permutation/circuit.rs
@@ -60,7 +60,7 @@ impl<F: Field> KeccakFConfig<F> {
         // rho
         let rho_config = RhoConfig::configure(meta, state, fixed[0], add.clone());
         // xi
-        let xi_config = XiConfig::configure(meta.selector(), meta, state);
+        let xi_config = XiConfig::configure(add.clone());
         let iota_config = IotaConfig::configure(add.clone());
 
         // Allocate space for the activation flag of the base_conversion.
@@ -142,14 +142,7 @@ impl<F: Field> KeccakFConfig<F> {
             state = pi_gate_permutation(state.clone());
 
             // xi
-            state = {
-                // Apply xi outside circuit
-                let out_state =
-                    KeccakFArith::xi(&state_to_biguint(split_state_cells(state.clone())));
-                let out_state = state_bigint_to_field(out_state);
-                // assignment
-                self.xi_config.assign_state(layouter, &state, out_state)?
-            };
+            state = self.xi_config.assign_state(layouter, &state)?;
 
             // Last round before Mixing does not run IotaB9 nor BaseConversion
             if round_idx == PERMUTATION - 1 {

--- a/keccak256/src/permutation/circuit.rs
+++ b/keccak256/src/permutation/circuit.rs
@@ -111,7 +111,7 @@ impl<F: Field> KeccakFConfig<F> {
         layouter: &mut impl Layouter<F>,
         in_state: [AssignedCell<F, F>; 25],
         out_state: [F; 25],
-        flag: bool,
+        flag: Option<bool>,
         next_mixing: Option<[F; NEXT_INPUTS_LANES]>,
     ) -> Result<[AssignedCell<F, F>; 25], Error> {
         let mut state = in_state;

--- a/keccak256/src/permutation/flag.rs
+++ b/keccak256/src/permutation/flag.rs
@@ -1,0 +1,80 @@
+use eth_types::Field;
+use halo2_proofs::{
+    circuit::{AssignedCell, Layouter},
+    plonk::{Advice, Column, ConstraintSystem, Error, Expression, Selector},
+    poly::Rotation,
+};
+use std::marker::PhantomData;
+
+#[derive(Clone, Debug)]
+pub struct FlagConfig<F> {
+    flag: Column<Advice>,
+    q_enable: Selector,
+    _marker: PhantomData<F>,
+}
+
+impl<F: Field> FlagConfig<F> {
+    pub fn configure(meta: &mut ConstraintSystem<F>, flag: Column<Advice>) -> Self {
+        meta.enable_equality(flag);
+
+        let q_enable = meta.selector();
+
+        meta.create_gate("Ensure flag consistency", |meta| {
+            let q_enable = meta.query_selector(q_enable);
+
+            let f_positive = meta.query_advice(flag, Rotation::cur());
+            let f_negative = meta.query_advice(flag, Rotation::next());
+            let one = Expression::Constant(F::one());
+
+            [
+                (
+                    "f_pos must be 1 or 0",
+                    q_enable.clone() * (one.clone() - f_positive.clone()) * f_positive.clone(),
+                ),
+                (
+                    "f_neg must be 1 - f_pos",
+                    q_enable * (f_positive + f_negative - one),
+                ),
+            ]
+        });
+
+        Self {
+            flag,
+            q_enable,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn assign_flag(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        flag: Option<bool>,
+    ) -> Result<(AssignedCell<F, F>, AssignedCell<F, F>), Error> {
+        layouter.assign_region(
+            || "Flag and Negated flag assignation",
+            |mut region| {
+                self.q_enable.enable(&mut region, 0)?;
+                let positive = region.assign_advice(
+                    || "flag positive",
+                    self.flag,
+                    0,
+                    || {
+                        flag.map(|flag| F::from(flag as u64))
+                            .ok_or(Error::Synthesis)
+                    },
+                )?;
+                let negative = region.assign_advice(
+                    || "flag negative",
+                    self.flag,
+                    1,
+                    || {
+                        flag.map(|flag| F::from(!flag as u64))
+                            .ok_or(Error::Synthesis)
+                    },
+                )?;
+
+                Ok((positive, negative))
+            },
+        )
+    }
+}

--- a/keccak256/src/permutation/iota.rs
+++ b/keccak256/src/permutation/iota.rs
@@ -79,7 +79,7 @@ impl<F: Field> IotaConfig<F> {
         lane00: AssignedCell<F, F>,
         flag: AssignedCell<F, F>,
     ) -> Result<AssignedCell<F, F>, Error> {
-        self.add.conditional_add(
+        self.add.conditional_add_const(
             layouter,
             lane00,
             flag,
@@ -98,6 +98,6 @@ impl<F: Field> IotaConfig<F> {
         flag: AssignedCell<F, F>,
     ) -> Result<AssignedCell<F, F>, Error> {
         self.add
-            .conditional_add(layouter, lane00, flag, self.round_constant_b13)
+            .conditional_add_const(layouter, lane00, flag, self.round_constant_b13)
     }
 }

--- a/keccak256/src/permutation/iota.rs
+++ b/keccak256/src/permutation/iota.rs
@@ -1,22 +1,17 @@
 use crate::arith_helpers::{convert_b2_to_b13, convert_b2_to_b9, A4};
 use crate::common::{PERMUTATION, ROUND_CONSTANTS};
 use crate::gate_helpers::biguint_to_f;
+use crate::permutation::add::AddConfig;
 use eth_types::Field;
 use halo2_proofs::circuit::AssignedCell;
 use halo2_proofs::circuit::Layouter;
-use halo2_proofs::{
-    plonk::{Advice, Column, ConstraintSystem, Error, Fixed, Selector},
-    poly::Rotation,
-};
+use halo2_proofs::plonk::Error;
 use itertools::Itertools;
 use std::convert::TryInto;
 
 #[derive(Clone, Debug)]
 pub struct IotaConfig<F> {
-    q_enable: Selector,
-    lane00: Column<Advice>,
-    flag: Column<Advice>,
-    round_constant: Column<Fixed>,
+    add: AddConfig<F>,
     round_constant_b13: F,
     a4_times_round_constants_b9: [F; PERMUTATION],
 }
@@ -39,25 +34,7 @@ impl<F: Field> IotaConfig<F> {
     ///
     /// Otherwise, apply the round constant in base 13 to the state, which has
     /// been mixed with new input and converted form base 9 to base 13.
-    pub fn configure(
-        meta: &mut ConstraintSystem<F>,
-        lane00: Column<Advice>,
-        flag: Column<Advice>,
-        round_constant: Column<Fixed>,
-    ) -> Self {
-        let q_enable = meta.selector();
-        meta.enable_equality(lane00);
-        meta.enable_equality(flag);
-
-        meta.create_gate("iota", |meta| {
-            let q_enable = meta.query_selector(q_enable);
-            let flag = meta.query_advice(flag, Rotation::cur());
-            let lane00_next = meta.query_advice(lane00, Rotation::next());
-            let lane00 = meta.query_advice(lane00, Rotation::cur());
-            let round_constant = meta.query_fixed(round_constant, Rotation::cur());
-            vec![q_enable * (lane00_next - lane00 - flag * round_constant)]
-        });
-
+    pub fn configure(add: AddConfig<F>) -> Self {
         let round_constant_b13 =
             biguint_to_f::<F>(&convert_b2_to_b13(ROUND_CONSTANTS[PERMUTATION - 1]));
 
@@ -72,10 +49,7 @@ impl<F: Field> IotaConfig<F> {
             .unwrap();
 
         Self {
-            q_enable,
-            lane00,
-            flag,
-            round_constant,
+            add,
             round_constant_b13,
             a4_times_round_constants_b9,
         }
@@ -91,33 +65,8 @@ impl<F: Field> IotaConfig<F> {
         lane00: AssignedCell<F, F>,
         round: usize,
     ) -> Result<AssignedCell<F, F>, Error> {
-        layouter.assign_region(
-            || "IotaB9",
-            |mut region| {
-                let offset = 0;
-                self.q_enable.enable(&mut region, offset)?;
-                lane00.copy_advice(|| "lane 00", &mut region, self.lane00, offset)?;
-                // In the normal round, we must add round constant. constrain flag to 1.
-                let flag = region.assign_advice(|| "flag", self.flag, offset, || Ok(F::one()))?;
-                region.constrain_constant(flag.cell(), F::one())?;
-
-                let constant = self.a4_times_round_constants_b9[round];
-                region.assign_fixed(
-                    || "A4 * round_constant_b9",
-                    self.round_constant,
-                    offset,
-                    || Ok(constant),
-                )?;
-
-                let offset = 1;
-                region.assign_advice(
-                    || "lane 00 + A4 * round_constant_b9",
-                    self.lane00,
-                    offset,
-                    || Ok(lane00.value().cloned().unwrap_or_default() + constant),
-                )
-            },
-        )
+        self.add
+            .add_fixed(layouter, lane00, self.a4_times_round_constants_b9[round])
     }
 
     /// The 24-th round. Copy the flag `no_mixing` here.
@@ -130,34 +79,11 @@ impl<F: Field> IotaConfig<F> {
         lane00: AssignedCell<F, F>,
         flag: AssignedCell<F, F>,
     ) -> Result<AssignedCell<F, F>, Error> {
-        layouter.assign_region(
-            || "IotaB9",
-            |mut region| {
-                let offset = 0;
-                self.q_enable.enable(&mut region, offset)?;
-                lane00.copy_advice(|| "lane 00", &mut region, self.lane00, offset)?;
-                flag.copy_advice(|| "flag", &mut region, self.flag, offset)?;
-
-                let constant = self.a4_times_round_constants_b9[PERMUTATION - 1];
-                region.assign_fixed(
-                    || "A4 * round_constant_b9",
-                    self.round_constant,
-                    offset,
-                    || Ok(constant),
-                )?;
-
-                let offset = 1;
-                region.assign_advice(
-                    || "lane 00 + A4 * round_constant_b9",
-                    self.lane00,
-                    offset,
-                    || {
-                        let flag = flag.value().cloned().unwrap_or_default();
-                        let lane00 = lane00.value().cloned().unwrap_or_default();
-                        Ok(lane00 + flag * constant)
-                    },
-                )
-            },
+        self.add.conditional_add(
+            layouter,
+            lane00,
+            flag,
+            self.a4_times_round_constants_b9[PERMUTATION - 1],
         )
     }
 
@@ -171,33 +97,7 @@ impl<F: Field> IotaConfig<F> {
         lane00: AssignedCell<F, F>,
         flag: AssignedCell<F, F>,
     ) -> Result<AssignedCell<F, F>, Error> {
-        layouter.assign_region(
-            || "IotaB9",
-            |mut region| {
-                let offset = 0;
-                self.q_enable.enable(&mut region, offset)?;
-                lane00.copy_advice(|| "lane 00", &mut region, self.lane00, offset)?;
-                flag.copy_advice(|| "flag", &mut region, self.flag, offset)?;
-
-                region.assign_fixed(
-                    || "round_constant_b13",
-                    self.round_constant,
-                    offset,
-                    || Ok(self.round_constant_b13),
-                )?;
-
-                let offset = 1;
-                region.assign_advice(
-                    || "lane 00 + round_constant_b13",
-                    self.lane00,
-                    offset,
-                    || {
-                        let lane00 = lane00.value().cloned().unwrap_or_default();
-                        let flag = flag.value().cloned().unwrap_or_default();
-                        Ok(lane00 + flag * self.round_constant_b13)
-                    },
-                )
-            },
-        )
+        self.add
+            .conditional_add(layouter, lane00, flag, self.round_constant_b13)
     }
 }

--- a/keccak256/src/permutation/mixing.rs
+++ b/keccak256/src/permutation/mixing.rs
@@ -285,7 +285,7 @@ impl<F: Field> MixingConfig<F> {
 mod tests {
     use super::*;
     use crate::common::{State, ROUND_CONSTANTS};
-    use crate::permutation::iota::IotaConfig;
+    use crate::permutation::{iota::IotaConfig, add::AddConfig};
     use halo2_proofs::circuit::Layouter;
     use halo2_proofs::pairing::bn256::Fr as Fp;
     use halo2_proofs::plonk::{ConstraintSystem, Error};
@@ -332,7 +332,8 @@ mod tests {
                     .try_into()
                     .unwrap();
                 let fixed = meta.fixed_column();
-                let iota_config = IotaConfig::configure(meta, state[0], state[1], fixed);
+                let add = AddConfig::configure(meta, state[0], state[1], fixed);
+                let iota_config = IotaConfig::configure(add.clone());
 
                 MyConfig {
                     mixing_conf: MixingConfig::configure(meta, &table, iota_config, state),

--- a/keccak256/src/permutation/mixing.rs
+++ b/keccak256/src/permutation/mixing.rs
@@ -338,7 +338,7 @@ mod tests {
                 let iota_config = IotaConfig::configure(add.clone());
 
                 MyConfig {
-                    mixing_conf: MixingConfig::configure(meta, &table, iota_config, state),
+                    mixing_conf: MixingConfig::configure(meta, &table, iota_config, &add, state),
                     table,
                 }
             }
@@ -378,7 +378,7 @@ mod tests {
                     &mut layouter,
                     &in_state,
                     self.out_state,
-                    self.is_mixing,
+                    Some(self.is_mixing),
                     self.next_mixing,
                 )?;
 

--- a/keccak256/src/permutation/pi.rs
+++ b/keccak256/src/permutation/pi.rs
@@ -8,7 +8,7 @@ use std::convert::TryInto;
 /// It has no gates. We just have to permute the previous state into the correct
 /// order. The copy constrain in the next gate can then enforce the Pi step
 /// permutation.
-pub fn pi_gate_permutation<F: Field>(state: [AssignedCell<F, F>; 25]) -> [AssignedCell<F, F>; 25] {
+pub fn pi_gate_permutation<F: Field>(state: &[AssignedCell<F, F>; 25]) -> [AssignedCell<F, F>; 25] {
     let state: [AssignedCell<F, F>; 25] = (0..5)
         .cartesian_product(0..5)
         .map(|(x, y)| state[5 * ((x + 3 * y) % 5) + x].clone())

--- a/keccak256/src/permutation/rho.rs
+++ b/keccak256/src/permutation/rho.rs
@@ -156,7 +156,7 @@ mod tests {
                     .unwrap();
 
                 let fixed = meta.fixed_column();
-                let add = AddConfig::configure(meta, state[0], state[1], fixed);
+                let add = AddConfig::configure(meta, state[0..3].try_into().unwrap(), fixed);
 
                 let rho_config = RhoConfig::configure(meta, state, fixed, add);
 

--- a/keccak256/src/permutation/rho_checks.rs
+++ b/keccak256/src/permutation/rho_checks.rs
@@ -263,7 +263,7 @@ impl<F: Field> LaneRotateConversionConfig<F> {
                     ))
                 },
             )?;
-        let input_from_chunks = self.add.linear_combine(layouter, input_coefs, input_pobs)?;
+        let input_from_chunks = self.add.linear_combine(layouter, input_coefs, input_pobs, None)?;
         let diff = self
             .add
             .sub_advice(layouter, lane_base_13, input_from_chunks)?;
@@ -291,7 +291,7 @@ impl<F: Field> LaneRotateConversionConfig<F> {
 
         let output_lane = self
             .add
-            .linear_combine(layouter, output_coefs, output_pobs)?;
+            .linear_combine(layouter, output_coefs, output_pobs, None)?;
         Ok((output_lane, step2_od, step3_od))
     }
 }
@@ -339,8 +339,8 @@ impl<F: Field> OverflowCheckConfig<F> {
         step2_cells: Vec<AssignedCell<F, F>>,
         step3_cells: Vec<AssignedCell<F, F>>,
     ) -> Result<(), Error> {
-        let step2_sum = self.add.running_sum(layouter, step2_cells)?;
-        let step3_sum = self.add.running_sum(layouter, step3_cells)?;
+        let step2_sum = self.add.running_sum(layouter, step2_cells, None)?;
+        let step3_sum = self.add.running_sum(layouter, step3_cells, None)?;
         layouter.assign_region(
             || "Overflow range check",
             |mut region| {

--- a/keccak256/src/permutation/rho_checks.rs
+++ b/keccak256/src/permutation/rho_checks.rs
@@ -108,6 +108,7 @@ use crate::arith_helpers::*;
 use crate::common::ROTATION_CONSTANTS;
 use crate::gate_helpers::{biguint_to_f, f_to_biguint};
 use crate::permutation::{
+    add::AddConfig,
     rho_helpers::*,
     tables::{Base13toBase9TableConfig, RangeCheckConfig, SpecialChunkTableConfig},
 };
@@ -117,20 +118,15 @@ use halo2_proofs::{
     plonk::{Advice, Column, ConstraintSystem, Error, Fixed, Selector},
     poly::Rotation,
 };
-use std::marker::PhantomData;
 
 #[derive(Debug, Clone)]
 pub struct LaneRotateConversionConfig<F> {
     q_normal: Selector,
     q_special: Selector,
     input_coef: Column<Advice>,
-    input_pob: Column<Fixed>,
-    input_acc: Column<Advice>,
     output_coef: Column<Advice>,
-    output_pob: Column<Fixed>,
-    output_acc: Column<Advice>,
     pub overflow_detector: Column<Advice>,
-    _marker: PhantomData<F>,
+    add: AddConfig<F>,
 }
 
 impl<F: Field> LaneRotateConversionConfig<F> {
@@ -138,52 +134,16 @@ impl<F: Field> LaneRotateConversionConfig<F> {
         meta: &mut ConstraintSystem<F>,
         base13_to_9_table: &Base13toBase9TableConfig<F>,
         special_chunk_table: &SpecialChunkTableConfig<F>,
-        advices: [Column<Advice>; 5],
-        fixed: [Column<Fixed>; 3],
+        advices: [Column<Advice>; 3],
+        constant: Column<Fixed>,
+        add: AddConfig<F>,
     ) -> Self {
         let q_normal = meta.complex_selector();
         let q_special = meta.complex_selector();
-        let [input_coef, input_acc, output_coef, output_acc, overflow_detector] = advices;
-        let [input_pob, output_pob, constant] = fixed;
+        let [input_coef, output_coef, overflow_detector] = advices;
 
-        meta.enable_equality(input_acc);
-        meta.enable_equality(output_acc);
         meta.enable_equality(overflow_detector);
         meta.enable_constant(constant);
-
-        // | coef | 13**x | acc       |
-        // |------|-------|-----------|
-        // |  a   |  b    | c         |
-        // |  ... | ...   | c - a * b |
-        meta.create_gate("Running down input", |meta| {
-            let q_normal = meta.query_selector(q_normal);
-            let coef = meta.query_advice(input_coef, Rotation::cur());
-            let pob = meta.query_fixed(input_pob, Rotation::cur());
-            let acc = meta.query_advice(input_acc, Rotation::cur());
-            let acc_next = meta.query_advice(input_acc, Rotation::next());
-            vec![(
-                "delta_acc === - coef * power_of_base",
-                q_normal * (acc_next - acc + coef * pob),
-            )]
-        });
-        // | coef | 9**x  |    acc |
-        // |------|-------|--------|
-        // |  a   |  b    |      0 |
-        // |  ... | ...   |  a * b |
-        meta.create_gate("Running up for output", |meta| {
-            let q_normal = meta.query_selector(q_normal);
-            let q_special = meta.query_selector(q_special);
-            let coef = meta.query_advice(output_coef, Rotation::cur());
-            let pob = meta.query_fixed(output_pob, Rotation::cur());
-            let acc = meta.query_advice(output_acc, Rotation::cur());
-            let acc_next = meta.query_advice(output_acc, Rotation::next());
-            // delta_acc === coef * power_of_base
-            let poly = acc_next - acc - coef * pob;
-            vec![
-                ("check for q_normal", q_normal * poly.clone()),
-                ("check for q_special", q_special * poly),
-            ]
-        });
 
         meta.lookup("b13 -> b9 table", |meta| {
             let q_normal = meta.query_selector(q_normal);
@@ -200,12 +160,12 @@ impl<F: Field> LaneRotateConversionConfig<F> {
 
         meta.lookup("special chunk", |meta| {
             let q_special = meta.query_selector(q_special);
-            let input_acc = meta.query_advice(input_acc, Rotation::cur());
+            let input_coef = meta.query_advice(input_coef, Rotation::cur());
             let output_coef = meta.query_advice(output_coef, Rotation::cur());
 
             vec![
                 (
-                    q_special.clone() * input_acc,
+                    q_special.clone() * input_coef,
                     special_chunk_table.last_chunk,
                 ),
                 (q_special * output_coef, special_chunk_table.output_coef),
@@ -215,13 +175,9 @@ impl<F: Field> LaneRotateConversionConfig<F> {
             q_normal,
             q_special,
             input_coef,
-            input_pob,
-            input_acc,
             output_coef,
-            output_pob,
-            output_acc,
             overflow_detector,
-            _marker: PhantomData,
+            add,
         }
     }
 
@@ -248,185 +204,95 @@ impl<F: Field> LaneRotateConversionConfig<F> {
             rotation,
         )
         .get_full_witness();
-        layouter.assign_region(
-            || "lane rotate conversion",
-            |mut region| {
-                let slices = slice_lane(rotation);
-                let (step2_od, step3_od) = {
+        let slices = slice_lane(rotation);
+
+        let (input_coefs, input_pobs, output_coefs, output_pobs, step2_od, step3_od) = layouter
+            .assign_region(
+                || "lane rotate conversion",
+                |mut region| {
+                    let mut input_coefs: Vec<AssignedCell<F, F>> = vec![];
+                    let mut output_coefs: Vec<AssignedCell<F, F>> = vec![];
+                    let mut input_pobs: Vec<F> = vec![];
+                    let mut output_pobs: Vec<F> = vec![];
                     let mut step2_od: Vec<AssignedCell<F, F>> = vec![];
                     let mut step3_od: Vec<AssignedCell<F, F>> = vec![];
                     for (offset, (&(chunk_idx, step), conv)) in
                         slices.iter().zip(conversions.iter()).enumerate()
                     {
                         self.q_normal.enable(&mut region, offset)?;
-                        region.assign_advice(
+                        let input_coef = region.assign_advice(
                             || format!("Input Coef {}", chunk_idx),
                             self.input_coef,
                             offset,
                             || Ok(biguint_to_f::<F>(&conv.input.coef)),
                         )?;
-                        region.assign_fixed(
-                            || "Input power of base",
-                            self.input_pob,
-                            offset,
-                            || Ok(biguint_to_f::<F>(&conv.input.power_of_base)),
-                        )?;
-                        {
-                            let cell = region
-                                .assign_advice(
-                                    || "Input accumulator",
-                                    self.input_acc,
-                                    offset,
-                                    || Ok(biguint_to_f::<F>(&conv.input.pre_acc)),
-                                )?
-                                .cell();
-                            if offset == 0 {
-                                region.constrain_equal(lane_base_13.cell(), cell)?;
-                            }
-                        }
-                        region.assign_advice(
+                        input_coefs.push(input_coef);
+                        input_pobs.push(biguint_to_f::<F>(&conv.input.power_of_base));
+                        let output_coef = region.assign_advice(
                             || "Output Coef",
                             self.output_coef,
                             offset,
                             || Ok(biguint_to_f::<F>(&conv.output.coef)),
                         )?;
-                        region.assign_fixed(
-                            || "Output power of base",
-                            self.output_pob,
+                        output_coefs.push(output_coef);
+                        output_pobs.push(biguint_to_f::<F>(&conv.output.power_of_base));
+
+                        let od = region.assign_advice(
+                            || "Overflow detector",
+                            self.overflow_detector,
                             offset,
-                            || Ok(biguint_to_f::<F>(&conv.output.power_of_base)),
+                            || Ok(F::from(conv.overflow_detector.value as u64)),
                         )?;
-                        {
-                            let cell = region
-                                .assign_advice(
-                                    || "Output accumulator",
-                                    self.output_acc,
-                                    offset,
-                                    || Ok(biguint_to_f::<F>(&conv.output.pre_acc)),
-                                )?
-                                .cell();
-                            if offset == 0 {
-                                region.constrain_constant(cell, F::zero())?;
-                            }
-                        }
-                        let od = {
-                            let value = F::from(conv.overflow_detector.value as u64);
-                            let od = region.assign_advice(
-                                || "Overflow detector",
-                                self.overflow_detector,
-                                offset,
-                                || Ok(value),
-                            )?;
-                            if step == 1 {
-                                region.constrain_constant(od.cell(), F::zero())?;
-                            }
-                            od
-                        };
                         match step {
+                            1 => region.constrain_constant(od.cell(), F::zero())?,
                             2 => step2_od.push(od),
                             3 => step3_od.push(od),
-                            _ => {}
+                            4 => { // Do nothing
+                            }
+                            _ => unreachable!(),
                         }
                     }
-                    (step2_od, step3_od)
-                };
-                // special chunks
-                let output_lane = {
-                    let offset = slices.len();
-                    self.q_special.enable(&mut region, offset)?;
-                    region.assign_advice(
-                        || "Special Input acc",
-                        self.input_acc,
-                        offset,
-                        || Ok(biguint_to_f::<F>(&special.input)),
-                    )?;
-                    region.assign_advice(
-                        || "Special output coef",
-                        self.output_coef,
-                        offset,
-                        || Ok(F::from(special.output_coef as u64)),
-                    )?;
-                    region.assign_fixed(
-                        || "Special output power of base",
-                        self.output_pob,
-                        offset,
-                        || Ok(F::from(B9 as u64).pow(&[rotation.into(), 0, 0, 0])),
-                    )?;
-                    region.assign_advice(
-                        || "Special output acc pre",
-                        self.output_acc,
-                        offset,
-                        || Ok(biguint_to_f::<F>(&special.output_acc_pre)),
-                    )?;
-                    {
-                        let value = biguint_to_f::<F>(&special.output_acc_post);
-                        region.assign_advice(
-                            || "Special output acc post",
-                            self.output_acc,
-                            offset + 1,
-                            || Ok(value),
-                        )?
-                    }
-                };
-                Ok((output_lane, step2_od, step3_od))
-            },
-        )
-    }
-}
 
-#[derive(Debug, Clone)]
-pub struct SumConfig<F> {
-    q_enable: Selector,
-    x: Column<Advice>,
-    sum: Column<Advice>,
-    _marker: PhantomData<F>,
-}
-impl<F: Field> SumConfig<F> {
-    // We assume the input columns are all copiable
-    pub fn configure(meta: &mut ConstraintSystem<F>, advices: [Column<Advice>; 2]) -> Self {
-        let q_enable = meta.selector();
-        let [x, sum] = advices;
+                    Ok((
+                        input_coefs,
+                        input_pobs,
+                        output_coefs,
+                        output_pobs,
+                        step2_od,
+                        step3_od,
+                    ))
+                },
+            )?;
+        let input_from_chunks = self.add.linear_combine(layouter, input_coefs, input_pobs)?;
+        let diff = self
+            .add
+            .sub_advice(layouter, lane_base_13, input_from_chunks)?;
 
-        meta.enable_equality(x);
-        meta.enable_equality(sum);
-
-        meta.create_gate("sum", |meta| {
-            let q_enable = meta.query_selector(q_enable);
-            let x = meta.query_advice(x, Rotation::cur());
-            let sum_next = meta.query_advice(sum, Rotation::next());
-            let sum = meta.query_advice(sum, Rotation::cur());
-            vec![q_enable * (sum_next - sum - x)]
-        });
-        Self {
-            q_enable,
-            x,
-            sum,
-            _marker: PhantomData,
-        }
-    }
-    pub fn assign_region(
-        &self,
-        layouter: &mut impl Layouter<F>,
-        xs: Vec<AssignedCell<F, F>>,
-    ) -> Result<AssignedCell<F, F>, Error> {
-        debug_assert!(xs.len() > 1);
-        layouter.assign_region(
-            || "running sum",
+        let (final_output_coef, final_output_pob) = layouter.assign_region(
+            || "special chunks",
             |mut region| {
-                let mut sum = F::zero();
-                let mut offset = 0;
-                for xs_item in xs.iter() {
-                    self.q_enable.enable(&mut region, offset)?;
-                    xs_item.copy_advice(|| "x", &mut region, self.x, offset)?;
-                    region.assign_advice(|| "sum", self.sum, offset, || Ok(sum))?;
-                    sum += xs_item.value().copied().unwrap_or_default();
-                    offset += 1;
-                }
-                let sum = region.assign_advice(|| "last sum", self.sum, offset, || Ok(sum))?;
-
-                Ok(sum)
+                let offset = 0;
+                self.q_special.enable(&mut region, offset)?;
+                diff.copy_advice(|| "input lane diff", &mut region, self.input_coef, offset)?;
+                let output_coef = region.assign_advice(
+                    || "Special output coef",
+                    self.output_coef,
+                    offset,
+                    || Ok(F::from(special.output_coef as u64)),
+                )?;
+                let final_output_pob = F::from(B9 as u64).pow(&[rotation.into(), 0, 0, 0]);
+                Ok((output_coef, final_output_pob))
             },
-        )
+        )?;
+        let mut output_coefs = output_coefs.clone();
+        output_coefs.push(final_output_coef);
+        let mut output_pobs = output_pobs.clone();
+        output_pobs.push(final_output_pob);
+
+        let output_lane = self
+            .add
+            .linear_combine(layouter, output_coefs, output_pobs)?;
+        Ok((output_lane, step2_od, step3_od))
     }
 }
 
@@ -434,7 +300,7 @@ impl<F: Field> SumConfig<F> {
 pub struct OverflowCheckConfig<F> {
     q_step2: Selector,
     q_step3: Selector,
-    sum_config: SumConfig<F>,
+    add: AddConfig<F>,
     acc: Column<Advice>,
 }
 impl<F: Field> OverflowCheckConfig<F> {
@@ -442,13 +308,11 @@ impl<F: Field> OverflowCheckConfig<F> {
         meta: &mut ConstraintSystem<F>,
         step2_range_table: &RangeCheckConfig<F, STEP2_RANGE>,
         step3_range_table: &RangeCheckConfig<F, STEP3_RANGE>,
-        advices: [Column<Advice>; 2],
+        add: AddConfig<F>,
+        acc: Column<Advice>,
     ) -> Self {
-        let sum_config = SumConfig::configure(meta, advices);
-
         let q_step2 = meta.complex_selector();
         let q_step3 = meta.complex_selector();
-        let acc = advices[0];
         meta.enable_equality(acc);
 
         meta.lookup("Overflow check step2", |meta| {
@@ -465,7 +329,7 @@ impl<F: Field> OverflowCheckConfig<F> {
         Self {
             q_step2,
             q_step3,
-            sum_config,
+            add,
             acc,
         }
     }
@@ -475,8 +339,8 @@ impl<F: Field> OverflowCheckConfig<F> {
         step2_cells: Vec<AssignedCell<F, F>>,
         step3_cells: Vec<AssignedCell<F, F>>,
     ) -> Result<(), Error> {
-        let step2_sum = self.sum_config.assign_region(layouter, step2_cells)?;
-        let step3_sum = self.sum_config.assign_region(layouter, step3_cells)?;
+        let step2_sum = self.add.running_sum(layouter, step2_cells)?;
+        let step3_sum = self.add.running_sum(layouter, step3_cells)?;
         layouter.assign_region(
             || "Overflow range check",
             |mut region| {

--- a/keccak256/src/permutation/rho_checks.rs
+++ b/keccak256/src/permutation/rho_checks.rs
@@ -263,7 +263,7 @@ impl<F: Field> LaneRotateConversionConfig<F> {
                     ))
                 },
             )?;
-        let input_from_chunks = self.add.linear_combine(layouter, input_coefs, input_pobs, None)?;
+        let input_from_chunks = self.add.linear_combine_consts(layouter, input_coefs, input_pobs, None)?;
         let diff = self
             .add
             .sub_advice(layouter, lane_base_13, input_from_chunks)?;
@@ -291,7 +291,7 @@ impl<F: Field> LaneRotateConversionConfig<F> {
 
         let output_lane = self
             .add
-            .linear_combine(layouter, output_coefs, output_pobs, None)?;
+            .linear_combine_consts(layouter, output_coefs, output_pobs, None)?;
         Ok((output_lane, step2_od, step3_od))
     }
 }

--- a/keccak256/src/permutation/tables.rs
+++ b/keccak256/src/permutation/tables.rs
@@ -181,6 +181,21 @@ impl<F: Field> BaseInfo<F> {
     pub fn output_pob(&self) -> F {
         F::from(self.output_base as u64).pow(&[self.num_chunks as u64, 0, 0, 0])
     }
+    fn num_slices(&self) -> usize {
+        self.max_chunks / self.num_chunks
+    }
+    pub fn input_pobs(&self) -> Vec<F> {
+        (0..self.num_slices())
+            .map(|i| self.input_pob().pow(&[i as u64, 0, 0, 0]))
+            .rev()
+            .collect_vec()
+    }
+    pub fn output_pobs(&self) -> Vec<F> {
+        (0..self.num_slices())
+            .map(|i| self.input_pob().pow(&[i as u64, 0, 0, 0]))
+            .rev()
+            .collect_vec()
+    }
 
     pub fn compute_coefs(&self, input: F) -> Result<(Vec<F>, Vec<F>, F), Error> {
         // big-endian

--- a/keccak256/src/permutation/tables.rs
+++ b/keccak256/src/permutation/tables.rs
@@ -182,7 +182,7 @@ impl<F: Field> BaseInfo<F> {
         F::from(self.output_base as u64).pow(&[self.num_chunks as u64, 0, 0, 0])
     }
     fn num_slices(&self) -> usize {
-        self.max_chunks / self.num_chunks
+        ((self.max_chunks as f32) / (self.num_chunks as f32)).ceil() as usize
     }
     pub fn input_pobs(&self) -> Vec<F> {
         (0..self.num_slices())
@@ -192,7 +192,7 @@ impl<F: Field> BaseInfo<F> {
     }
     pub fn output_pobs(&self) -> Vec<F> {
         (0..self.num_slices())
-            .map(|i| self.input_pob().pow(&[i as u64, 0, 0, 0]))
+            .map(|i| self.output_pob().pow(&[i as u64, 0, 0, 0]))
             .rev()
             .collect_vec()
     }

--- a/keccak256/src/permutation/theta.rs
+++ b/keccak256/src/permutation/theta.rs
@@ -36,7 +36,7 @@ pub fn assign_theta<F: Field>(
                 theta_col_sums[(x + 1) % 5].clone(),
             ];
             let vs = vec![F::one(), F::one(), F::from(B13 as u64)];
-            let new_lane = add.linear_combine(layouter, cells, vs, None)?;
+            let new_lane = add.linear_combine_consts(layouter, cells, vs, None)?;
             Ok(new_lane)
         })
         .into_iter()

--- a/keccak256/src/permutation/theta.rs
+++ b/keccak256/src/permutation/theta.rs
@@ -15,8 +15,11 @@ pub fn assign_theta<F: Field>(
 ) -> Result<[AssignedCell<F, F>; 25], Error> {
     let theta_col_sums: Result<Vec<AssignedCell<F, F>>, Error> = (0..5)
         .map(|x| {
-            let col_sum =
-                add.running_sum(layouter, (0..5).map(|y| state[5 * x + y].clone()).collect())?;
+            let col_sum = add.running_sum(
+                layouter,
+                (0..5).map(|y| state[5 * x + y].clone()).collect(),
+                None,
+            )?;
             Ok(col_sum)
         })
         .into_iter()
@@ -33,7 +36,7 @@ pub fn assign_theta<F: Field>(
                 theta_col_sums[(x + 1) % 5].clone(),
             ];
             let vs = vec![F::one(), F::one(), F::from(B13 as u64)];
-            let new_lane = add.linear_combine(layouter, cells, vs)?;
+            let new_lane = add.linear_combine(layouter, cells, vs, None)?;
             Ok(new_lane)
         })
         .into_iter()

--- a/keccak256/src/permutation/theta.rs
+++ b/keccak256/src/permutation/theta.rs
@@ -86,7 +86,7 @@ mod tests {
                 let fixed = meta.fixed_column();
 
                 let lane = advices[0];
-                let add = AddConfig::configure(meta, advices[1], advices[2], fixed);
+                let add = AddConfig::configure(meta, advices, fixed);
                 Self { lane, add }
             }
         }

--- a/keccak256/src/permutation/xi.rs
+++ b/keccak256/src/permutation/xi.rs
@@ -69,7 +69,7 @@ mod tests {
                 let fixed = meta.fixed_column();
 
                 let lane = advices[0];
-                let add = AddConfig::configure(meta, advices[1], advices[2], fixed);
+                let add = AddConfig::configure(meta, advices, fixed);
                 Self { lane, add }
             }
         }

--- a/keccak256/src/permutation/xi.rs
+++ b/keccak256/src/permutation/xi.rs
@@ -22,7 +22,7 @@ pub fn assign_xi<F: Field>(
                 state[5 * ((x + 2) % 5) + y].clone(),
             ];
             let vs = vec![F::from(A1), F::from(A2), F::from(A3)];
-            let new_lane = add.linear_combine(layouter, cells, vs)?;
+            let new_lane = add.linear_combine(layouter, cells, vs, None)?;
             Ok(new_lane)
         })
         .into_iter()

--- a/keccak256/src/permutation/xi.rs
+++ b/keccak256/src/permutation/xi.rs
@@ -22,7 +22,7 @@ pub fn assign_xi<F: Field>(
                 state[5 * ((x + 2) % 5) + y].clone(),
             ];
             let vs = vec![F::from(A1), F::from(A2), F::from(A3)];
-            let new_lane = add.linear_combine(layouter, cells, vs, None)?;
+            let new_lane = add.linear_combine_consts(layouter, cells, vs, None)?;
             Ok(new_lane)
         })
         .into_iter()


### PR DESCRIPTION
During working on the idea of simplifying iota. I realized this is a good primitive gate that can replace almost all the non-lookup gates. 

~~`adv__input(next) = adv__input + adv__x * fixed__value`~~
update:
```
adv__input(next) = adv__input + adv__left * adv_right
```
We can do simple addition or subtraction on advice value or fixed value. We can do a simple running sum or even a linear combination of advice columns and fixed columns. All with this gate.

In this PR we replaced the iota, rho, theta, and xi with this gate. Compared to the iota PR, this PR reduced the number of gates from 14 to 9 and num polys from 105 to 51. The cost is that it increases max advice rows from 19042 to 28993.

Together with tag trick in lookup, the value of this might be figuring out what's the thinnest and longest possible shape we can have. Widen it is always easy by just cloning the primitive gate and applying it to different columns. Then we have more room for short-thin tradeoffs to optimize.

In the extreme thin case, 
- this gates takes 2 advice cols and 1 fixed
- base conversions: we want to use as many rows as possible, so they are not tag trick stackable. There are "from 2", "from 9", "from 13", each needs 3 table columns. So 9 fixed columns in total for them.
- tag trick stackable tables are range checks and special chunk lookup. With tag we need 3 fixed columns.
- Need at least 3 advice columns to work with the lookups above.
- 1 fixed column is required by "constrain_constant" function.

so 3 advice columns and 14 fixed columns. 

