### PR TITLE
add value_prev to state circuit; make rw table of evm state & state circuit identical

### DIFF
--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -147,7 +147,7 @@ pub mod test {
             witness::{Block, BlockContext, Bytecode, RwMap, Transaction},
             EvmCircuit,
         },
-        rw_table::RwTable,
+        rw_table::RwTableRlc,
         util::Expr,
     };
     use bus_mapping::evm::OpcodeId;
@@ -188,7 +188,7 @@ pub mod test {
     #[derive(Clone)]
     pub struct TestCircuitConfig<F> {
         tx_table: [Column<Advice>; 4],
-        rw_table: RwTable,
+        rw_table: RwTableRlc,
         bytecode_table: [Column<Advice>; 5],
         block_table: [Column<Advice>; 3],
         evm_circuit: EvmCircuit<F>,
@@ -243,7 +243,10 @@ pub mod test {
                 || "rw table",
                 |mut region| {
                     rws.check_rw_counter_sanity();
-                    self.rw_table.assign(&mut region, randomness, rws)?;
+                    // TODO: fix this after cs.challenge() is implemented in halo2
+                    let randomness_phase_next = randomness;
+                    self.rw_table
+                        .assign(&mut region, randomness, rws, randomness_phase_next)?;
                     Ok(())
                 },
             )
@@ -399,7 +402,7 @@ pub mod test {
 
         fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
             let tx_table = [(); 4].map(|_| meta.advice_column());
-            let rw_table = RwTable::construct(meta);
+            let rw_table = RwTableRlc::construct(meta);
             let bytecode_table = [(); 5].map(|_| meta.advice_column());
             let block_table = [(); 3].map(|_| meta.advice_column());
 

--- a/zkevm-circuits/src/evm_circuit/witness.rs
+++ b/zkevm-circuits/src/evm_circuit/witness.rs
@@ -22,7 +22,11 @@ use halo2_proofs::arithmetic::{BaseExt, FieldExt};
 use halo2_proofs::pairing::bn256::Fr;
 use itertools::Itertools;
 use sha3::{Digest, Keccak256};
-use std::{collections::HashMap, convert::TryInto, iter};
+use std::{
+    collections::HashMap,
+    convert::TryInto,
+    iter::{self},
+};
 
 #[derive(Debug, Default, Clone)]
 pub struct Block<F> {
@@ -427,6 +431,41 @@ impl RwMap {
         });
         sorted
     }
+
+    // check rw_counter is continous and starting from 1
+    pub fn check_rw_counter_sanity(&self) {
+        for (idx, rw_counter) in self
+            .0
+            .values()
+            .flatten()
+            .map(|r| r.rw_counter())
+            .sorted()
+            .enumerate()
+        {
+            debug_assert_eq!(idx, rw_counter - 1);
+        }
+    }
+    pub fn table_assignments<F>(&self, randomness: F) -> Vec<RwRow<F>>
+    where
+        F: Field,
+    {
+        let mut rows: Vec<Rw> = self.0.values().flatten().cloned().collect();
+
+        rows.sort_by_key(|row| {
+            (
+                row.tag() as u64,
+                row.field_tag().unwrap_or_default(),
+                row.id().unwrap_or_default(),
+                row.address().unwrap_or_default(),
+                row.storage_key().unwrap_or_default(),
+                row.rw_counter(),
+            )
+        });
+
+        rows.into_iter()
+            .map(|r| r.table_assignment(randomness))
+            .collect()
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -527,39 +566,20 @@ pub enum Rw {
         value: u64,
     },
 }
-#[derive(Default, Clone, Copy)]
-pub struct RwRow<F: FieldExt> {
-    pub rw_counter: F,
-    pub is_write: F,
-    pub tag: F,
-    pub key1: F,
-    pub key2: F,
-    pub key3: F,
-    pub key4: F,
+#[derive(Default, Clone, Copy, Debug)]
+pub struct RwRow<F> {
+    pub rw_counter: u64,
+    pub is_write: bool,
+    pub tag: RwTableTag,
+    pub id: u64,
+    pub address: Address,
+    pub field_tag: u64,
+    pub storage_key: U256,
     pub value: F,
     pub value_prev: F,
     pub aux1: F,
     pub aux2: F,
 }
-
-impl<F: FieldExt> From<[F; 11]> for RwRow<F> {
-    fn from(row: [F; 11]) -> Self {
-        Self {
-            rw_counter: row[0],
-            is_write: row[1],
-            tag: row[2],
-            key1: row[3],
-            key2: row[4],
-            key3: row[5],
-            key4: row[6],
-            value: row[7],
-            value_prev: row[8],
-            aux1: row[9],
-            aux2: row[10],
-        }
-    }
-}
-
 impl Rw {
     pub fn tx_access_list_value_pair(&self) -> (bool, bool) {
         match self {
@@ -656,16 +676,13 @@ impl Rw {
 
     pub fn table_assignment<F: Field>(&self, randomness: F) -> RwRow<F> {
         RwRow {
-            rw_counter: F::from(self.rw_counter() as u64),
-            is_write: F::from(self.is_write() as u64),
-            tag: F::from(self.tag() as u64),
-            key1: F::from(self.id().unwrap_or_default() as u64),
-            key2: self.address().unwrap_or_default().to_scalar().unwrap(),
-            key3: F::from(self.field_tag().unwrap_or_default() as u64),
-            key4: RandomLinearCombination::random_linear_combine(
-                self.storage_key().unwrap_or_default().to_le_bytes(),
-                randomness,
-            ),
+            rw_counter: self.rw_counter() as u64,
+            is_write: self.is_write(),
+            tag: self.tag(),
+            id: self.id().unwrap_or_default() as u64,
+            address: self.address().unwrap_or_default(),
+            field_tag: self.field_tag().unwrap_or_default() as u64,
+            storage_key: self.storage_key().unwrap_or_default(),
             value: self.value_assignment(randomness),
             value_prev: self.value_prev_assignment(randomness).unwrap_or_default(),
             aux1: F::zero(), // only used for AccountStorage::tx_id, which moved to key1.

--- a/zkevm-circuits/src/evm_circuit/witness.rs
+++ b/zkevm-circuits/src/evm_circuit/witness.rs
@@ -446,7 +446,7 @@ impl RwMap {
         }
     }
 
-    pub fn table_assignments<F>(&self, randomness: F) -> Vec<RwRow<F>>
+    pub fn table_assignments<F>(&self, _randomness: F) -> Vec<Rw>
     where
         F: Field,
     {
@@ -462,10 +462,7 @@ impl RwMap {
                 row.rw_counter(),
             )
         });
-
-        rows.into_iter()
-            .map(|r| r.table_assignment(randomness))
-            .collect()
+        rows
     }
 }
 
@@ -586,7 +583,7 @@ impl<F: Field> RwRow<F> {
         let values = [
             F::from(self.rw_counter),
             F::from(self.is_write),
-            (F::from(self.tag)),
+            (F::from(self.tag as u64)),
             (F::from(self.id)),
             (self.address.to_scalar().unwrap()),
             (F::from(self.field_tag)),

--- a/zkevm-circuits/src/rw_table.rs
+++ b/zkevm-circuits/src/rw_table.rs
@@ -6,15 +6,54 @@ use halo2_proofs::{
     poly::Rotation,
 };
 
+use crate::evm_circuit::util::rlc;
 use crate::evm_circuit::{
     table::LookupTable,
     util::RandomLinearCombination,
     witness::{RwMap, RwRow},
 };
 
+#[derive(Clone, Copy)]
+pub struct RwTableRlc {
+    // TODO: change to instance col?
+    pub rlc: Column<Advice>,
+}
+
+impl<F: Field> LookupTable<F> for RwTableRlc {
+    fn table_exprs(&self, meta: &mut VirtualCells<F>) -> Vec<Expression<F>> {
+        vec![meta.query_advice(self.rlc, Rotation::cur())]
+    }
+}
+impl RwTableRlc {
+    pub fn construct<F: Field>(meta: &mut ConstraintSystem<F>) -> Self {
+        Self {
+            rlc: meta.advice_column(),
+        }
+    }
+    pub fn assign<F: Field>(
+        &self,
+        region: &mut Region<'_, F>,
+        randomness: F,
+        rw_map: &RwMap,
+        randomness_next_phase: F,
+    ) -> Result<(), Error> {
+        for (offset, row) in rw_map.table_assignments(randomness).iter().enumerate() {
+            let value = row.rlc(randomness, randomness_next_phase);
+            region.assign_advice(
+                || "assign rw row on rw table",
+                self.rlc,
+                offset,
+                || Ok(value),
+            )?;
+        }
+        Ok(())
+    }
+}
+
 /// The rw table shared between evm circuit and state circuit
 #[derive(Clone, Copy)]
 pub struct RwTable {
+    pub rlc: Column<Advice>,
     pub rw_counter: Column<Advice>,
     pub is_write: Column<Advice>,
     pub tag: Column<Advice>,
@@ -28,26 +67,10 @@ pub struct RwTable {
     pub aux2: Column<Advice>,
 }
 
-impl<F: Field> LookupTable<F> for RwTable {
-    fn table_exprs(&self, meta: &mut VirtualCells<F>) -> Vec<Expression<F>> {
-        vec![
-            meta.query_advice(self.rw_counter, Rotation::cur()),
-            meta.query_advice(self.is_write, Rotation::cur()),
-            meta.query_advice(self.tag, Rotation::cur()),
-            meta.query_advice(self.id, Rotation::cur()),
-            meta.query_advice(self.address, Rotation::cur()),
-            meta.query_advice(self.field_tag, Rotation::cur()),
-            meta.query_advice(self.storage_key, Rotation::cur()),
-            meta.query_advice(self.value, Rotation::cur()),
-            meta.query_advice(self.value_prev, Rotation::cur()),
-            meta.query_advice(self.aux1, Rotation::cur()),
-            meta.query_advice(self.aux2, Rotation::cur()),
-        ]
-    }
-}
 impl RwTable {
     pub fn construct<F: Field>(meta: &mut ConstraintSystem<F>) -> Self {
         Self {
+            rlc: meta.advice_column(),
             rw_counter: meta.advice_column(),
             is_write: meta.advice_column(),
             tag: meta.advice_column(),
@@ -62,17 +85,47 @@ impl RwTable {
         }
     }
 
+    fn rlc_expr<F: Field>(
+        &self,
+        meta: &mut VirtualCells<F>,
+        power_of_randomness: &[Expression<F>],
+    ) -> Expression<F> {
+        rlc::expr(
+            &[
+                meta.query_advice(self.rw_counter, Rotation::cur()),
+                meta.query_advice(self.is_write, Rotation::cur()),
+                meta.query_advice(self.tag, Rotation::cur()),
+                meta.query_advice(self.id, Rotation::cur()),
+                meta.query_advice(self.address, Rotation::cur()),
+                meta.query_advice(self.field_tag, Rotation::cur()),
+                meta.query_advice(self.storage_key, Rotation::cur()),
+                meta.query_advice(self.value, Rotation::cur()),
+                meta.query_advice(self.value_prev, Rotation::cur()),
+                meta.query_advice(self.aux1, Rotation::cur()),
+                meta.query_advice(self.aux2, Rotation::cur()),
+            ],
+            power_of_randomness,
+        )
+    }
     pub fn assign<F: Field>(
         &self,
         region: &mut Region<'_, F>,
         randomness: F,
-        rw_map: &RwMap,
-    ) -> Result<Vec<RwRow<F>>, Error> {
-        let rows = rw_map.table_assignments(randomness);
+        rows: &[RwRow<F>],
+    ) -> Result<(), Error> {
         for (offset, row) in rows.iter().enumerate() {
             self.assign_row(region, offset, randomness, row)?;
         }
-        Ok(rows)
+        for (offset, row) in rows.iter().enumerate() {
+            let value = row.rlc(randomness, randomness);
+            region.assign_advice(
+                || "assign rw row on rw table",
+                self.rlc,
+                offset,
+                || Ok(value),
+            )?;
+        }
+        Ok(())
     }
     pub fn assign_row<F: Field>(
         &self,

--- a/zkevm-circuits/src/rw_table.rs
+++ b/zkevm-circuits/src/rw_table.rs
@@ -1,12 +1,16 @@
 #![allow(missing_docs)]
+use eth_types::{Field, ToLittleEndian, ToScalar};
 use halo2_proofs::{
-    arithmetic::FieldExt,
     circuit::Region,
     plonk::{Advice, Column, ConstraintSystem, Error, Expression, VirtualCells},
     poly::Rotation,
 };
 
-use crate::evm_circuit::{table::LookupTable, witness::RwRow};
+use crate::evm_circuit::{
+    table::LookupTable,
+    util::RandomLinearCombination,
+    witness::{RwMap, RwRow},
+};
 
 /// The rw table shared between evm circuit and state circuit
 #[derive(Clone, Copy)]
@@ -14,26 +18,26 @@ pub struct RwTable {
     pub rw_counter: Column<Advice>,
     pub is_write: Column<Advice>,
     pub tag: Column<Advice>,
-    pub key1: Column<Advice>,
-    pub key2: Column<Advice>,
-    pub key3: Column<Advice>,
-    pub key4: Column<Advice>,
+    pub id: Column<Advice>,
+    pub address: Column<Advice>,
+    pub field_tag: Column<Advice>,
+    pub storage_key: Column<Advice>,
     pub value: Column<Advice>,
     pub value_prev: Column<Advice>,
     pub aux1: Column<Advice>,
     pub aux2: Column<Advice>,
 }
 
-impl<F: FieldExt> LookupTable<F> for RwTable {
+impl<F: Field> LookupTable<F> for RwTable {
     fn table_exprs(&self, meta: &mut VirtualCells<F>) -> Vec<Expression<F>> {
         vec![
             meta.query_advice(self.rw_counter, Rotation::cur()),
             meta.query_advice(self.is_write, Rotation::cur()),
             meta.query_advice(self.tag, Rotation::cur()),
-            meta.query_advice(self.key1, Rotation::cur()),
-            meta.query_advice(self.key2, Rotation::cur()),
-            meta.query_advice(self.key3, Rotation::cur()),
-            meta.query_advice(self.key4, Rotation::cur()),
+            meta.query_advice(self.id, Rotation::cur()),
+            meta.query_advice(self.address, Rotation::cur()),
+            meta.query_advice(self.field_tag, Rotation::cur()),
+            meta.query_advice(self.storage_key, Rotation::cur()),
             meta.query_advice(self.value, Rotation::cur()),
             meta.query_advice(self.value_prev, Rotation::cur()),
             meta.query_advice(self.aux1, Rotation::cur()),
@@ -42,35 +46,55 @@ impl<F: FieldExt> LookupTable<F> for RwTable {
     }
 }
 impl RwTable {
-    pub fn construct<F: FieldExt>(meta: &mut ConstraintSystem<F>) -> Self {
+    pub fn construct<F: Field>(meta: &mut ConstraintSystem<F>) -> Self {
         Self {
             rw_counter: meta.advice_column(),
             is_write: meta.advice_column(),
             tag: meta.advice_column(),
-            key1: meta.advice_column(),
-            key2: meta.advice_column(),
-            key3: meta.advice_column(),
-            key4: meta.advice_column(),
+            id: meta.advice_column(),
+            address: meta.advice_column(),
+            field_tag: meta.advice_column(),
+            storage_key: meta.advice_column(),
             value: meta.advice_column(),
             value_prev: meta.advice_column(),
             aux1: meta.advice_column(),
             aux2: meta.advice_column(),
         }
     }
-    pub fn assign<F: FieldExt>(
+
+    pub fn assign<F: Field>(
+        &self,
+        region: &mut Region<'_, F>,
+        randomness: F,
+        rw_map: &RwMap,
+    ) -> Result<Vec<RwRow<F>>, Error> {
+        let rows = rw_map.table_assignments(randomness);
+        for (offset, row) in rows.iter().enumerate() {
+            self.assign_row(region, offset, randomness, row)?;
+        }
+        Ok(rows)
+    }
+    pub fn assign_row<F: Field>(
         &self,
         region: &mut Region<'_, F>,
         offset: usize,
+        randomness: F,
         row: &RwRow<F>,
     ) -> Result<(), Error> {
         for (column, value) in [
-            (self.rw_counter, row.rw_counter),
-            (self.is_write, row.is_write),
-            (self.tag, row.tag),
-            (self.key1, row.key1),
-            (self.key2, row.key2),
-            (self.key3, row.key3),
-            (self.key4, row.key4),
+            (self.rw_counter, F::from(row.rw_counter)),
+            (self.is_write, F::from(row.is_write)),
+            (self.tag, F::from(row.tag as u64)),
+            (self.id, F::from(row.id)),
+            (self.address, (row.address.to_scalar().unwrap())),
+            (self.field_tag, F::from(row.field_tag)),
+            (
+                self.storage_key,
+                RandomLinearCombination::random_linear_combine(
+                    row.storage_key.to_le_bytes(),
+                    randomness,
+                ),
+            ),
             (self.value, row.value),
             (self.value_prev, row.value_prev),
             (self.aux1, row.aux1),

--- a/zkevm-circuits/src/rw_table.rs
+++ b/zkevm-circuits/src/rw_table.rs
@@ -38,7 +38,9 @@ impl RwTableRlc {
         randomness_next_phase: F,
     ) -> Result<(), Error> {
         for (offset, row) in rw_map.table_assignments(randomness).iter().enumerate() {
-            let value = row.rlc(randomness, randomness_next_phase);
+            let value = row
+                .table_assignment(randomness)
+                .rlc(randomness, randomness_next_phase);
             region.assign_advice(
                 || "assign rw row on rw table",
                 self.rlc,

--- a/zkevm-circuits/src/state_circuit.rs
+++ b/zkevm-circuits/src/state_circuit.rs
@@ -13,17 +13,18 @@ use crate::{
         param::N_BYTES_WORD,
         table::RwTableTag,
         util::RandomLinearCombination,
-        witness::{Rw, RwMap, RwRow},
+        witness::{Rw, RwMap},
     },
-    rw_table::RwTable,
 };
 use binary_number::{Chip as BinaryNumberChip, Config as BinaryNumberConfig};
 use constraint_builder::{ConstraintBuilder, Queries};
 use eth_types::{Address, Field, ToLittleEndian};
 use gadgets::is_zero::{IsZeroChip, IsZeroConfig, IsZeroInstruction};
 use halo2_proofs::{
-    circuit::{Layouter, Region, SimpleFloorPlanner},
-    plonk::{Circuit, Column, ConstraintSystem, Error, Expression, Fixed, Instance, VirtualCells},
+    circuit::{Layouter, SimpleFloorPlanner},
+    plonk::{
+        Advice, Circuit, Column, ConstraintSystem, Error, Expression, Fixed, Instance, VirtualCells,
+    },
     poly::Rotation,
 };
 use lexicographic_ordering::{
@@ -43,17 +44,18 @@ const N_LIMBS_ID: usize = 2;
 /// Config for StateCircuit
 #[derive(Clone)]
 pub struct StateConfig<F, const QUICK_CHECK: bool> {
-    // Figure out why you get errors when this is Selector.
+    selector: Column<Fixed>, // Figure out why you get errors when this is Selector.
     // https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/407
-    selector: Column<Fixed>,
-    rw_table: RwTable,
-    tag_bits: BinaryNumberConfig<RwTableTag, 4>,
-    rw_counter_mpi: MpiConfig<u32, N_LIMBS_RW_COUNTER>,
-    id_mpi: MpiConfig<u32, N_LIMBS_ID>,
-    address_mpi: MpiConfig<Address, N_LIMBS_ACCOUNT_ADDRESS>,
-    storage_key_rlc: RlcConfig<N_BYTES_WORD>,
+    rw_counter: MpiConfig<u32, N_LIMBS_RW_COUNTER>,
+    is_write: Column<Advice>,
+    tag: BinaryNumberConfig<RwTableTag, 4>,
+    id: MpiConfig<u32, N_LIMBS_ID>,
     is_id_unchanged: IsZeroConfig<F>,
+    address: MpiConfig<Address, N_LIMBS_ACCOUNT_ADDRESS>,
+    field_tag: Column<Advice>,
+    storage_key: RlcConfig<N_BYTES_WORD>,
     is_storage_key_unchanged: IsZeroConfig<F>,
+    value: Column<Advice>,
     lookups: LookupsConfig<QUICK_CHECK>,
     power_of_randomness: [Column<Instance>; N_BYTES_WORD - 1],
     lexicographic_ordering: LexicographicOrderingConfig<F>,
@@ -74,7 +76,7 @@ pub type StateCircuitLight<F, const N_ROWS: usize> = StateCircuitBase<F, true, N
 #[derive(Default)]
 pub struct StateCircuitBase<F, const QUICK_CHECK: bool, const N_ROWS: usize> {
     pub(crate) randomness: F,
-    pub(crate) rows: Vec<RwRow<F>>,
+    pub(crate) rows: Vec<Rw>,
     #[cfg(test)]
     overrides: HashMap<(test::AdviceColumn, isize), F>,
 }
@@ -107,64 +109,6 @@ impl<F: Field, const QUICK_CHECK: bool, const N_ROWS: usize>
             .map(|exp| vec![self.randomness.pow(&[exp, 0, 0, 0]); N_ROWS])
             .collect()
     }
-    #[allow(clippy::too_many_arguments)]
-    fn assign_row(
-        &self,
-        config: &StateConfig<F, QUICK_CHECK>,
-        region: &mut Region<F>,
-        tag_chip: &binary_number::Chip<F, RwTableTag, 4_usize>,
-        is_storage_key_unchanged: &IsZeroChip<F>,
-        is_id_unchanged: &IsZeroChip<F>,
-        lexicographic_ordering_chip: &LexicographicOrderingChip<F>,
-        offset: usize,
-        row: RwRow<F>,
-        prev_row: Option<RwRow<F>>,
-    ) -> Result<(), Error> {
-        region.assign_fixed(|| "selector", config.selector, offset, || Ok(F::one()))?;
-
-        config
-        tag_chip.assign(region, offset, &row.tag)?;
-            .rw_counter_mpi
-            .assign(region, offset, row.rw_counter as u32)?;
-        config.id_mpi.assign(region, offset, row.id as u32)?;
-        config.address_mpi.assign(region, offset, row.address)?;
-        config
-            .storage_key_rlc
-            .assign(region, offset, self.randomness, row.storage_key)?;
-
-        if offset != 0 {
-            lexicographic_ordering_chip.assign(region, offset, &row, &prev_row.unwrap())?;
-
-            // assign storage key diff
-            let cur_storage_key = RandomLinearCombination::random_linear_combine(
-                row.storage_key.to_le_bytes(),
-                self.randomness,
-            );
-            let prev_storage_key = RandomLinearCombination::random_linear_combine(
-                prev_row.unwrap_or_default().storage_key.to_le_bytes(),
-                self.randomness,
-            );
-            is_storage_key_unchanged.assign(
-                region,
-                offset,
-                Some(cur_storage_key - prev_storage_key),
-            )?;
-
-            // assign id diff
-            let id_change =
-                F::from(row.id as u64) - F::from(prev_row.unwrap_or_default().id as u64);
-            is_id_unchanged.assign(region, offset, Some(id_change))?;
-            let _storage_key_change = RandomLinearCombination::random_linear_combine(
-                row.storage_key.to_le_bytes(),
-                self.randomness,
-            ) - RandomLinearCombination::random_linear_combine(
-                prev_row.unwrap_or_default().storage_key.to_le_bytes(),
-                self.randomness,
-            );
-        }
-
-        Ok(())
-    }
 }
 
 impl<F: Field, const QUICK_CHECK: bool, const N_ROWS: usize> Circuit<F>
@@ -184,30 +128,24 @@ where
         let lookups = LookupsChip::configure(meta);
         let power_of_randomness = [0; N_BYTES_WORD - 1].map(|_| meta.instance_column());
 
-        let rw_table = RwTable::construct(meta);
-        let is_storage_key_unchanged_column = meta.advice_column();
-        let is_id_unchanged_column = meta.advice_column();
-        let id_mpi = MpiChip::configure(meta, rw_table.id, selector, lookups);
-        let address_mpi = MpiChip::configure(meta, rw_table.address, selector, lookups);
-        let storage_key_rlc = RlcChip::configure(
-            meta,
-            selector,
-            rw_table.storage_key,
-            lookups,
-            power_of_randomness,
-        );
-        let rw_counter_mpi = MpiChip::configure(meta, rw_table.rw_counter, selector, lookups);
+        let [is_write, field_tag, value, is_id_unchanged_column, is_storage_key_unchanged_column] =
+            [0; 5].map(|_| meta.advice_column());
 
-        let tag_bits = BinaryNumberChip::configure(meta, selector);
+        let tag = BinaryNumberChip::configure(meta, selector);
+
+        let id = MpiChip::configure(meta, selector, lookups);
+        let address = MpiChip::configure(meta, selector, lookups);
+        let storage_key = RlcChip::configure(meta, selector, lookups, power_of_randomness);
+        let rw_counter = MpiChip::configure(meta, selector, lookups);
 
         let lexicographic_ordering = LexicographicOrderingChip::configure(
             meta,
-            tag_bits,
-            rw_table.field_tag,
-            id_mpi.limbs,
-            address_mpi.limbs,
-            storage_key_rlc.bytes,
-            rw_counter_mpi.limbs,
+            tag,
+            field_tag,
+            id.limbs,
+            address.limbs,
+            storage_key.bytes,
+            rw_counter.limbs,
             lookups,
         );
 
@@ -215,8 +153,8 @@ where
             meta,
             |meta| meta.query_fixed(lexicographic_ordering.selector, Rotation::cur()),
             |meta| {
-                meta.query_advice(rw_table.id, Rotation::cur())
-                    - meta.query_advice(rw_table.id, Rotation::prev())
+                meta.query_advice(id.value, Rotation::cur())
+                    - meta.query_advice(id.value, Rotation::prev())
             },
             is_id_unchanged_column,
         );
@@ -224,22 +162,24 @@ where
             meta,
             |meta| meta.query_fixed(lexicographic_ordering.selector, Rotation::cur()),
             |meta| {
-                meta.query_advice(rw_table.storage_key, Rotation::cur())
-                    - meta.query_advice(rw_table.storage_key, Rotation::prev())
+                meta.query_advice(storage_key.encoded, Rotation::cur())
+                    - meta.query_advice(storage_key.encoded, Rotation::prev())
             },
             is_storage_key_unchanged_column,
         );
 
         let config = Self::Config {
             selector,
-            rw_table,
-            lexicographic_ordering,
-            address_mpi,
-            tag_bits,
-            id_mpi,
-            rw_counter_mpi,
-            storage_key_rlc,
+            rw_counter,
+            is_write,
+            tag,
+            id,
             is_id_unchanged,
+            address,
+            field_tag,
+            storage_key,
+            value,
+            lexicographic_ordering,
             is_storage_key_unchanged,
             lookups,
             power_of_randomness,
@@ -271,34 +211,79 @@ where
         let lexicographic_ordering_chip =
             LexicographicOrderingChip::construct(config.lexicographic_ordering.clone());
 
-        let tag_chip = BinaryNumberChip::construct(config.tag_bits);
+        let tag_chip = BinaryNumberChip::construct(config.tag);
 
         layouter.assign_region(
             || "rw table",
             |mut region| {
-                config
-                    .rw_table
-                    .assign(&mut region, self.randomness, &self.rows)?;
                 let padding_length = N_ROWS - self.rows.len();
-                let padding = (1..=padding_length)
-                    .map(|rw_counter| (Rw::Start { rw_counter }).table_assignment(self.randomness));
+                let padding = (1..=padding_length).map(|rw_counter| Rw::Start { rw_counter });
 
                 let rows = padding.chain(self.rows.iter().cloned());
                 let prev_rows = once(None).chain(rows.clone().map(Some));
 
                 for (offset, (row, prev_row)) in rows.zip(prev_rows).enumerate() {
                     log::trace!("state citcuit assign offset:{} row:{:#?}", offset, row);
-                    self.assign_row(
-                        &config,
-                        &mut region,
-                        &tag_chip,
-                        &is_storage_key_unchanged,
-                        &is_id_unchanged,
-                        &lexicographic_ordering_chip,
+                    region.assign_fixed(|| "selector", config.selector, offset, || Ok(F::one()))?;
+                    config
+                        .rw_counter
+                        .assign(&mut region, offset, row.rw_counter() as u32)?;
+                    region.assign_advice(
+                        || "is_write",
+                        config.is_write,
                         offset,
-                        row,
-                        prev_row,
+                        || Ok(if row.is_write() { F::one() } else { F::zero() }),
                     )?;
+                    tag_chip.assign(&mut region, offset, &row.tag())?;
+                    if let Some(id) = row.id() {
+                        config.id.assign(&mut region, offset, id as u32)?;
+                    }
+                    if let Some(address) = row.address() {
+                        config.address.assign(&mut region, offset, address)?;
+                    }
+                    if let Some(field_tag) = row.field_tag() {
+                        region.assign_advice(
+                            || "field_tag",
+                            config.field_tag,
+                            offset,
+                            || Ok(F::from(field_tag as u64)),
+                        )?;
+                    }
+                    if let Some(storage_key) = row.storage_key() {
+                        config.storage_key.assign(
+                            &mut region,
+                            offset,
+                            self.randomness,
+                            storage_key,
+                        )?;
+                    }
+                    region.assign_advice(
+                        || "value",
+                        config.value,
+                        offset,
+                        || Ok(row.value_assignment(self.randomness)),
+                    )?;
+
+                    if let Some(prev_row) = prev_row {
+                        lexicographic_ordering_chip.assign(&mut region, offset, &row, &prev_row)?;
+
+                        let id_change = F::from(row.id().unwrap_or_default() as u64)
+                            - F::from(prev_row.id().unwrap_or_default() as u64);
+                        is_id_unchanged.assign(&mut region, offset, Some(id_change))?;
+
+                        let storage_key_change = RandomLinearCombination::random_linear_combine(
+                            row.storage_key().unwrap_or_default().to_le_bytes(),
+                            self.randomness,
+                        ) - RandomLinearCombination::random_linear_combine(
+                            prev_row.storage_key().unwrap_or_default().to_le_bytes(),
+                            self.randomness,
+                        );
+                        is_storage_key_unchanged.assign(
+                            &mut region,
+                            offset,
+                            Some(storage_key_change),
+                        )?;
+                    }
                 }
 
                 #[cfg(test)]
@@ -322,25 +307,24 @@ fn queries<F: Field, const QUICK_CHECK: bool>(
 ) -> Queries<F> {
     Queries {
         selector: meta.query_fixed(c.selector, Rotation::cur()),
-        rw_counter: MpiQueries::new(meta, c.rw_counter_mpi),
-        is_write: meta.query_advice(c.rw_table.is_write, Rotation::cur()),
         lexicographic_ordering_selector: meta
             .query_fixed(c.lexicographic_ordering.selector, Rotation::cur()),
-        aux2: meta.query_advice(c.rw_table.aux2, Rotation::cur()),
-        tag: c.tag_bits.value(Rotation::cur())(meta),
+        rw_counter: MpiQueries::new(meta, c.rw_counter),
+        is_write: meta.query_advice(c.is_write, Rotation::cur()),
+        tag: c.tag.value(Rotation::cur())(meta),
         tag_bits: c
-            .tag_bits
+            .tag
             .bits
             .map(|bit| meta.query_advice(bit, Rotation::cur())),
-        //prev_tag: meta.query_advice(c.rw_table.tag, Rotation::prev()),
-        id: MpiQueries::new(meta, c.id_mpi),
+        //aux2: meta.query_advice(c.rw_table.aux2, Rotation::cur()),
+        id: MpiQueries::new(meta, c.id),
         is_id_unchanged: c.is_id_unchanged.is_zero_expression.clone(),
-        address: MpiQueries::new(meta, c.address_mpi),
-        field_tag: meta.query_advice(c.rw_table.field_tag, Rotation::cur()),
-        storage_key: RlcQueries::new(meta, c.storage_key_rlc),
-        value: meta.query_advice(c.rw_table.value, Rotation::cur()),
-        value_at_prev_rotation: meta.query_advice(c.rw_table.value, Rotation::prev()),
-        value_prev: meta.query_advice(c.rw_table.value_prev, Rotation::cur()),
+        address: MpiQueries::new(meta, c.address),
+        field_tag: meta.query_advice(c.field_tag, Rotation::cur()),
+        storage_key: RlcQueries::new(meta, c.storage_key),
+        value: meta.query_advice(c.value, Rotation::cur()),
+        //value_at_prev_rotation: meta.query_advice(c.rw_table.value, Rotation::prev()),
+        //value_prev: meta.query_advice(c.rw_table.value_prev, Rotation::cur()),
         lookups: LookupsQueries::new(meta, c.lookups),
         power_of_randomness: c
             .power_of_randomness
@@ -351,6 +335,6 @@ fn queries<F: Field, const QUICK_CHECK: bool>(
             .upper_limb_difference_is_zero
             .is_zero_expression
             .clone(),
-        rw_rlc: meta.query_advice(c.rw_table.rlc, Rotation::cur()),
+        //rw_rlc: meta.query_advice(c.rw_table.rlc, Rotation::cur()),
     }
 }

--- a/zkevm-circuits/src/state_circuit.rs
+++ b/zkevm-circuits/src/state_circuit.rs
@@ -8,21 +8,22 @@ mod random_linear_combination;
 #[cfg(test)]
 mod test;
 
-use crate::evm_circuit::{
-    param::N_BYTES_WORD,
-    table::RwTableTag,
-    util::RandomLinearCombination,
-    witness::{Rw, RwMap},
+use crate::{
+    evm_circuit::{
+        param::N_BYTES_WORD,
+        table::RwTableTag,
+        util::RandomLinearCombination,
+        witness::{Rw, RwMap, RwRow},
+    },
+    rw_table::RwTable,
 };
 use binary_number::{Chip as BinaryNumberChip, Config as BinaryNumberConfig};
 use constraint_builder::{ConstraintBuilder, Queries};
 use eth_types::{Address, Field, ToLittleEndian};
 use gadgets::is_zero::{IsZeroChip, IsZeroConfig, IsZeroInstruction};
 use halo2_proofs::{
-    circuit::{Layouter, SimpleFloorPlanner},
-    plonk::{
-        Advice, Circuit, Column, ConstraintSystem, Error, Expression, Fixed, Instance, VirtualCells,
-    },
+    circuit::{Layouter, Region, SimpleFloorPlanner},
+    plonk::{Circuit, Column, ConstraintSystem, Error, Expression, Fixed, Instance, VirtualCells},
     poly::Rotation,
 };
 use lexicographic_ordering::{
@@ -41,20 +42,19 @@ const N_LIMBS_ID: usize = 2;
 
 /// Config for StateCircuit
 #[derive(Clone)]
-pub struct StateConfig<F: Field> {
-    selector: Column<Fixed>, // Figure out why you get errors when this is Selector.
+pub struct StateConfig<F, const QUICK_CHECK: bool> {
+    // Figure out why you get errors when this is Selector.
     // https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/407
-    rw_counter: MpiConfig<u32, N_LIMBS_RW_COUNTER>,
-    is_write: Column<Advice>,
-    tag: BinaryNumberConfig<RwTableTag, 4>,
-    id: MpiConfig<u32, N_LIMBS_ID>,
+    selector: Column<Fixed>,
+    rw_table: RwTable,
+    tag_bits: BinaryNumberConfig<RwTableTag, 4>,
+    rw_counter_mpi: MpiConfig<u32, N_LIMBS_RW_COUNTER>,
+    id_mpi: MpiConfig<u32, N_LIMBS_ID>,
+    address_mpi: MpiConfig<Address, N_LIMBS_ACCOUNT_ADDRESS>,
+    storage_key_rlc: RlcConfig<N_BYTES_WORD>,
     is_id_unchanged: IsZeroConfig<F>,
-    address: MpiConfig<Address, N_LIMBS_ACCOUNT_ADDRESS>,
-    field_tag: Column<Advice>,
-    storage_key: RlcConfig<N_BYTES_WORD>,
     is_storage_key_unchanged: IsZeroConfig<F>,
-    value: Column<Advice>,
-    lookups: LookupsConfig,
+    lookups: LookupsConfig<QUICK_CHECK>,
     power_of_randomness: [Column<Instance>; N_BYTES_WORD - 1],
     lexicographic_ordering: LexicographicOrderingConfig<F>,
 }
@@ -62,34 +62,43 @@ pub struct StateConfig<F: Field> {
 type Lookup<F> = (&'static str, Expression<F>, Expression<F>);
 
 /// State Circuit for proving RwTable is valid
+pub type StateCircuit<F, const N_ROWS: usize> = StateCircuitBase<F, false, N_ROWS>;
+/// StateCircuit with lexicographic ordering u16 lookup disabled to allow
+/// smaller `k`. It is almost impossible to trigger u16 lookup verification
+/// error. So StateCircuitLight can be used in opcode gadgets test.
+/// Normal opcodes constaints error can still be captured but cost much less
+/// time.
+pub type StateCircuitLight<F, const N_ROWS: usize> = StateCircuitBase<F, true, N_ROWS>;
+
+/// State Circuit for proving RwTable is valid
 #[derive(Default)]
-pub struct StateCircuit<F: Field, const N_ROWS: usize> {
+pub struct StateCircuitBase<F, const QUICK_CHECK: bool, const N_ROWS: usize> {
     pub(crate) randomness: F,
-    pub(crate) rows: Vec<Rw>,
+    pub(crate) rows: Vec<RwRow<F>>,
     #[cfg(test)]
     overrides: HashMap<(test::AdviceColumn, isize), F>,
 }
 
-impl<F: Field, const N_ROWS: usize> StateCircuit<F, N_ROWS> {
+impl<F: Field, const QUICK_CHECK: bool, const N_ROWS: usize>
+    StateCircuitBase<F, QUICK_CHECK, N_ROWS>
+{
     /// make a new state circuit from an RwMap
     pub fn new(randomness: F, rw_map: RwMap) -> Self {
-        let mut rows: Vec<_> = rw_map.0.into_values().flatten().collect();
-        rows.sort_by_key(|row| {
-            (
-                row.tag() as u64,
-                row.field_tag().unwrap_or_default(),
-                row.id().unwrap_or_default(),
-                row.address().unwrap_or_default(),
-                row.storage_key().unwrap_or_default(),
-                row.rw_counter(),
-            )
-        });
+        let rows = rw_map.table_assignments(randomness);
         Self {
             randomness,
             rows,
             #[cfg(test)]
             overrides: HashMap::new(),
         }
+    }
+    /// estimate k needed to prover
+    pub fn estimate_k(&self) -> u32 {
+        let log2_ceil = |n| u32::BITS - (n as u32).leading_zeros() - (n & (n - 1) == 0) as u32;
+        let k = if QUICK_CHECK { 12 } else { 18 };
+        let k = k.max(log2_ceil(64 + self.rows.len()));
+        log::debug!("state circuit uses k = {}", k);
+        k
     }
 
     /// powers of randomness for instance columns
@@ -98,10 +107,76 @@ impl<F: Field, const N_ROWS: usize> StateCircuit<F, N_ROWS> {
             .map(|exp| vec![self.randomness.pow(&[exp, 0, 0, 0]); N_ROWS])
             .collect()
     }
+    #[allow(clippy::too_many_arguments)]
+    fn assign_row(
+        &self,
+        config: &StateConfig<F, QUICK_CHECK>,
+        region: &mut Region<F>,
+        tag_chip: &binary_number::Chip<F, RwTableTag, 4_usize>,
+        is_storage_key_unchanged: &IsZeroChip<F>,
+        is_id_unchanged: &IsZeroChip<F>,
+        lexicographic_ordering_chip: &LexicographicOrderingChip<F>,
+        offset: usize,
+        row: RwRow<F>,
+        prev_row: Option<RwRow<F>>,
+    ) -> Result<(), Error> {
+        region.assign_fixed(|| "selector", config.selector, offset, || Ok(F::one()))?;
+
+        config
+            .rw_table
+            .assign_row(region, offset, self.randomness, &row)?;
+
+        tag_chip.assign(region, offset, &row.tag)?;
+        config
+            .rw_counter_mpi
+            .assign(region, offset, row.rw_counter as u32)?;
+        config.id_mpi.assign(region, offset, row.id as u32)?;
+        config.address_mpi.assign(region, offset, row.address)?;
+        config
+            .storage_key_rlc
+            .assign(region, offset, self.randomness, row.storage_key)?;
+
+        if offset != 0 {
+            lexicographic_ordering_chip.assign(region, offset, &row, &prev_row.unwrap())?;
+
+            // assign storage key diff
+            let cur_storage_key = RandomLinearCombination::random_linear_combine(
+                row.storage_key.to_le_bytes(),
+                self.randomness,
+            );
+            let prev_storage_key = RandomLinearCombination::random_linear_combine(
+                prev_row.unwrap_or_default().storage_key.to_le_bytes(),
+                self.randomness,
+            );
+            is_storage_key_unchanged.assign(
+                region,
+                offset,
+                Some(cur_storage_key - prev_storage_key),
+            )?;
+
+            // assign id diff
+            let id_change =
+                F::from(row.id as u64) - F::from(prev_row.unwrap_or_default().id as u64);
+            is_id_unchanged.assign(region, offset, Some(id_change))?;
+            let _storage_key_change = RandomLinearCombination::random_linear_combine(
+                row.storage_key.to_le_bytes(),
+                self.randomness,
+            ) - RandomLinearCombination::random_linear_combine(
+                prev_row.unwrap_or_default().storage_key.to_le_bytes(),
+                self.randomness,
+            );
+        }
+
+        Ok(())
+    }
 }
 
-impl<F: Field, const N_ROWS: usize> Circuit<F> for StateCircuit<F, N_ROWS> {
-    type Config = StateConfig<F>;
+impl<F: Field, const QUICK_CHECK: bool, const N_ROWS: usize> Circuit<F>
+    for StateCircuitBase<F, QUICK_CHECK, N_ROWS>
+where
+    F: Field,
+{
+    type Config = StateConfig<F, QUICK_CHECK>;
     type FloorPlanner = SimpleFloorPlanner;
 
     fn without_witnesses(&self) -> Self {
@@ -113,33 +188,39 @@ impl<F: Field, const N_ROWS: usize> Circuit<F> for StateCircuit<F, N_ROWS> {
         let lookups = LookupsChip::configure(meta);
         let power_of_randomness = [0; N_BYTES_WORD - 1].map(|_| meta.instance_column());
 
-        let [is_write, field_tag, value, is_id_unchanged_column, is_storage_key_unchanged_column] =
-            [0; 5].map(|_| meta.advice_column());
+        let rw_table = RwTable::construct(meta);
+        let is_storage_key_unchanged_column = meta.advice_column();
+        let is_id_unchanged_column = meta.advice_column();
+        let id_mpi = MpiChip::configure(meta, rw_table.id, selector, lookups);
+        let address_mpi = MpiChip::configure(meta, rw_table.address, selector, lookups);
+        let storage_key_rlc = RlcChip::configure(
+            meta,
+            selector,
+            rw_table.storage_key,
+            lookups,
+            power_of_randomness,
+        );
+        let rw_counter_mpi = MpiChip::configure(meta, rw_table.rw_counter, selector, lookups);
 
-        let tag = BinaryNumberChip::configure(meta, selector);
-
-        let id = MpiChip::configure(meta, selector, lookups.u16);
-        let address = MpiChip::configure(meta, selector, lookups.u16);
-        let storage_key = RlcChip::configure(meta, selector, lookups.u8, power_of_randomness);
-        let rw_counter = MpiChip::configure(meta, selector, lookups.u16);
+        let tag_bits = BinaryNumberChip::configure(meta, selector);
 
         let lexicographic_ordering = LexicographicOrderingChip::configure(
             meta,
-            tag,
-            field_tag,
-            id.limbs,
-            address.limbs,
-            storage_key.bytes,
-            rw_counter.limbs,
-            lookups.u16,
+            tag_bits,
+            rw_table.field_tag,
+            id_mpi.limbs,
+            address_mpi.limbs,
+            storage_key_rlc.bytes,
+            rw_counter_mpi.limbs,
+            lookups,
         );
 
         let is_id_unchanged = IsZeroChip::configure(
             meta,
             |meta| meta.query_fixed(lexicographic_ordering.selector, Rotation::cur()),
             |meta| {
-                meta.query_advice(id.value, Rotation::cur())
-                    - meta.query_advice(id.value, Rotation::prev())
+                meta.query_advice(rw_table.id, Rotation::cur())
+                    - meta.query_advice(rw_table.id, Rotation::prev())
             },
             is_id_unchanged_column,
         );
@@ -147,24 +228,22 @@ impl<F: Field, const N_ROWS: usize> Circuit<F> for StateCircuit<F, N_ROWS> {
             meta,
             |meta| meta.query_fixed(lexicographic_ordering.selector, Rotation::cur()),
             |meta| {
-                meta.query_advice(storage_key.encoded, Rotation::cur())
-                    - meta.query_advice(storage_key.encoded, Rotation::prev())
+                meta.query_advice(rw_table.storage_key, Rotation::cur())
+                    - meta.query_advice(rw_table.storage_key, Rotation::prev())
             },
             is_storage_key_unchanged_column,
         );
 
         let config = Self::Config {
             selector,
-            rw_counter,
-            is_write,
-            tag,
-            id,
-            is_id_unchanged,
-            address,
-            field_tag,
-            storage_key,
-            value,
+            rw_table,
             lexicographic_ordering,
+            address_mpi,
+            tag_bits,
+            id_mpi,
+            rw_counter_mpi,
+            storage_key_rlc,
+            is_id_unchanged,
             is_storage_key_unchanged,
             lookups,
             power_of_randomness,
@@ -196,78 +275,31 @@ impl<F: Field, const N_ROWS: usize> Circuit<F> for StateCircuit<F, N_ROWS> {
         let lexicographic_ordering_chip =
             LexicographicOrderingChip::construct(config.lexicographic_ordering.clone());
 
-        let tag_chip = BinaryNumberChip::construct(config.tag);
+        let tag_chip = BinaryNumberChip::construct(config.tag_bits);
 
         layouter.assign_region(
             || "rw table",
             |mut region| {
                 let padding_length = N_ROWS - self.rows.len();
-                let padding = (1..=padding_length).map(|rw_counter| Rw::Start { rw_counter });
+                let padding = (1..=padding_length)
+                    .map(|rw_counter| (Rw::Start { rw_counter }).table_assignment(self.randomness));
 
                 let rows = padding.chain(self.rows.iter().cloned());
                 let prev_rows = once(None).chain(rows.clone().map(Some));
 
                 for (offset, (row, prev_row)) in rows.zip(prev_rows).enumerate() {
-                    region.assign_fixed(|| "selector", config.selector, offset, || Ok(F::one()))?;
-                    config
-                        .rw_counter
-                        .assign(&mut region, offset, row.rw_counter() as u32)?;
-                    region.assign_advice(
-                        || "is_write",
-                        config.is_write,
+                    log::trace!("state citcuit assign offset:{} row:{:#?}", offset, row);
+                    self.assign_row(
+                        &config,
+                        &mut region,
+                        &tag_chip,
+                        &is_storage_key_unchanged,
+                        &is_id_unchanged,
+                        &lexicographic_ordering_chip,
                         offset,
-                        || Ok(if row.is_write() { F::one() } else { F::zero() }),
+                        row,
+                        prev_row,
                     )?;
-                    tag_chip.assign(&mut region, offset, &row.tag())?;
-                    if let Some(id) = row.id() {
-                        config.id.assign(&mut region, offset, id as u32)?;
-                    }
-                    if let Some(address) = row.address() {
-                        config.address.assign(&mut region, offset, address)?;
-                    }
-                    if let Some(field_tag) = row.field_tag() {
-                        region.assign_advice(
-                            || "field_tag",
-                            config.field_tag,
-                            offset,
-                            || Ok(F::from(field_tag as u64)),
-                        )?;
-                    }
-                    if let Some(storage_key) = row.storage_key() {
-                        config.storage_key.assign(
-                            &mut region,
-                            offset,
-                            self.randomness,
-                            storage_key,
-                        )?;
-                    }
-                    region.assign_advice(
-                        || "value",
-                        config.value,
-                        offset,
-                        || Ok(row.value_assignment(self.randomness)),
-                    )?;
-
-                    if let Some(prev_row) = prev_row {
-                        lexicographic_ordering_chip.assign(&mut region, offset, &row, &prev_row)?;
-
-                        let id_change = F::from(row.id().unwrap_or_default() as u64)
-                            - F::from(prev_row.id().unwrap_or_default() as u64);
-                        is_id_unchanged.assign(&mut region, offset, Some(id_change))?;
-
-                        let storage_key_change = RandomLinearCombination::random_linear_combine(
-                            row.storage_key().unwrap_or_default().to_le_bytes(),
-                            self.randomness,
-                        ) - RandomLinearCombination::random_linear_combine(
-                            prev_row.storage_key().unwrap_or_default().to_le_bytes(),
-                            self.randomness,
-                        );
-                        is_storage_key_unchanged.assign(
-                            &mut region,
-                            offset,
-                            Some(storage_key_change),
-                        )?;
-                    }
                 }
 
                 #[cfg(test)]
@@ -285,24 +317,31 @@ impl<F: Field, const N_ROWS: usize> Circuit<F> for StateCircuit<F, N_ROWS> {
     }
 }
 
-fn queries<F: Field>(meta: &mut VirtualCells<'_, F>, c: &StateConfig<F>) -> Queries<F> {
+fn queries<F: Field, const QUICK_CHECK: bool>(
+    meta: &mut VirtualCells<'_, F>,
+    c: &StateConfig<F, QUICK_CHECK>,
+) -> Queries<F> {
     Queries {
         selector: meta.query_fixed(c.selector, Rotation::cur()),
+        rw_counter: MpiQueries::new(meta, c.rw_counter_mpi),
+        is_write: meta.query_advice(c.rw_table.is_write, Rotation::cur()),
         lexicographic_ordering_selector: meta
             .query_fixed(c.lexicographic_ordering.selector, Rotation::cur()),
-        rw_counter: MpiQueries::new(meta, c.rw_counter),
-        is_write: meta.query_advice(c.is_write, Rotation::cur()),
-        tag: c.tag.value(Rotation::cur())(meta),
+        aux2: meta.query_advice(c.rw_table.aux2, Rotation::cur()),
+        tag: c.tag_bits.value(Rotation::cur())(meta),
         tag_bits: c
-            .tag
+            .tag_bits
             .bits
             .map(|bit| meta.query_advice(bit, Rotation::cur())),
-        id: MpiQueries::new(meta, c.id),
+        //prev_tag: meta.query_advice(c.rw_table.tag, Rotation::prev()),
+        id: MpiQueries::new(meta, c.id_mpi),
         is_id_unchanged: c.is_id_unchanged.is_zero_expression.clone(),
-        address: MpiQueries::new(meta, c.address),
-        field_tag: meta.query_advice(c.field_tag, Rotation::cur()),
-        storage_key: RlcQueries::new(meta, c.storage_key),
-        value: meta.query_advice(c.value, Rotation::cur()),
+        address: MpiQueries::new(meta, c.address_mpi),
+        field_tag: meta.query_advice(c.rw_table.field_tag, Rotation::cur()),
+        storage_key: RlcQueries::new(meta, c.storage_key_rlc),
+        value: meta.query_advice(c.rw_table.value, Rotation::cur()),
+        value_at_prev_rotation: meta.query_advice(c.rw_table.value, Rotation::prev()),
+        value_prev: meta.query_advice(c.rw_table.value_prev, Rotation::cur()),
         lookups: LookupsQueries::new(meta, c.lookups),
         power_of_randomness: c
             .power_of_randomness

--- a/zkevm-circuits/src/state_circuit/binary_number.rs
+++ b/zkevm-circuits/src/state_circuit/binary_number.rs
@@ -102,7 +102,7 @@ where
 //    T.
 //  - creating expressions (via the Config) that evaluate to 1 when the bits
 //    match a specific value and 0 otherwise.
-pub struct Chip<F: Field, T, const N: usize> {
+pub struct Chip<F, T, const N: usize> {
     config: Config<T, N>,
     _marker: PhantomData<F>,
 }

--- a/zkevm-circuits/src/state_circuit/multiple_precision_integer.rs
+++ b/zkevm-circuits/src/state_circuit/multiple_precision_integer.rs
@@ -1,3 +1,4 @@
+use super::lookups;
 use super::N_LIMBS_ACCOUNT_ADDRESS;
 use super::N_LIMBS_RW_COUNTER;
 use crate::util::Expr;
@@ -128,22 +129,20 @@ where
         }
     }
 
-    pub fn configure(
+    pub fn configure<const QUICK_CHECK: bool>(
         meta: &mut ConstraintSystem<F>,
+        value: Column<Advice>,
         selector: Column<Fixed>,
-        u16_range: Column<Fixed>,
+        lookup: lookups::Config<QUICK_CHECK>,
     ) -> Config<T, N> {
-        let value = meta.advice_column();
         let limbs = [0; N].map(|_| meta.advice_column());
 
         for &limb in &limbs {
-            meta.lookup_any("mpi limb fits into u16", |meta| {
-                vec![(
-                    meta.query_advice(limb, Rotation::cur()),
-                    meta.query_fixed(u16_range, Rotation::cur()),
-                )]
+            lookup.range_check_u16(meta, "mpi limb fits into u16", |meta| {
+                meta.query_advice(limb, Rotation::cur())
             });
         }
+
         meta.create_gate("mpi value matches claimed limbs", |meta| {
             let selector = meta.query_fixed(selector, Rotation::cur());
             let value = meta.query_advice(value, Rotation::cur());

--- a/zkevm-circuits/src/state_circuit/multiple_precision_integer.rs
+++ b/zkevm-circuits/src/state_circuit/multiple_precision_integer.rs
@@ -131,10 +131,10 @@ where
 
     pub fn configure<const QUICK_CHECK: bool>(
         meta: &mut ConstraintSystem<F>,
-        value: Column<Advice>,
         selector: Column<Fixed>,
         lookup: lookups::Config<QUICK_CHECK>,
     ) -> Config<T, N> {
+        let value = meta.advice_column();
         let limbs = [0; N].map(|_| meta.advice_column());
 
         for &limb in &limbs {
@@ -142,7 +142,6 @@ where
                 meta.query_advice(limb, Rotation::cur())
             });
         }
-
         meta.create_gate("mpi value matches claimed limbs", |meta| {
             let selector = meta.query_fixed(selector, Rotation::cur());
             let value = meta.query_advice(value, Rotation::cur());

--- a/zkevm-circuits/src/state_circuit/random_linear_combination.rs
+++ b/zkevm-circuits/src/state_circuit/random_linear_combination.rs
@@ -75,10 +75,10 @@ impl<F: Field, const N: usize> Chip<F, N> {
     pub fn configure<const QUICK_CHECK: bool>(
         meta: &mut ConstraintSystem<F>,
         selector: Column<Fixed>,
-        encoded: Column<Advice>,
         lookup: lookups::Config<QUICK_CHECK>,
         power_of_randomness: [Column<Instance>; 31],
     ) -> Config<N> {
+        let encoded = meta.advice_column();
         let bytes = [0; N].map(|_| meta.advice_column());
 
         for &byte in &bytes {

--- a/zkevm-circuits/src/state_circuit/test.rs
+++ b/zkevm-circuits/src/state_circuit/test.rs
@@ -833,6 +833,18 @@ fn verify_with_overrides(
 
 fn assert_error_matches(result: Result<(), Vec<VerifyFailure>>, name: &str) {
     let errors = result.err().expect("result is not an error");
+    let errors: Vec<_> = errors
+        .iter()
+        .filter(|e| {
+            if let VerifyFailure::ConstraintNotSatisfied { constraint, .. } = e {
+                let constraint = format!("{}", constraint);
+                if constraint.contains("rw table rlc") {
+                    return false;
+                }
+            }
+            true
+        })
+        .collect();
     assert_eq!(errors.len(), 1, "{:?}", errors);
     match &errors[0] {
         VerifyFailure::ConstraintNotSatisfied { constraint, .. } => {

--- a/zkevm-circuits/src/state_circuit/test.rs
+++ b/zkevm-circuits/src/state_circuit/test.rs
@@ -49,22 +49,22 @@ impl AdviceColumn {
         config: &StateConfig<F, QUICK_CHECK>,
     ) -> Column<Advice> {
         match self {
-            Self::IsWrite => config.rw_table.is_write,
-            Self::Address => config.rw_table.address,
-            Self::AddressLimb0 => config.address_mpi.limbs[0],
-            Self::AddressLimb1 => config.address_mpi.limbs[1],
-            Self::StorageKey => config.rw_table.storage_key,
-            Self::StorageKeyByte0 => config.storage_key_rlc.bytes[0],
-            Self::StorageKeyByte1 => config.storage_key_rlc.bytes[1],
+            Self::IsWrite => config.is_write,
+            Self::Address => config.address.value,
+            Self::AddressLimb0 => config.address.limbs[0],
+            Self::AddressLimb1 => config.address.limbs[1],
+            Self::StorageKey => config.storage_key.encoded,
+            Self::StorageKeyByte0 => config.storage_key.bytes[0],
+            Self::StorageKeyByte1 => config.storage_key.bytes[1],
             Self::StorageKeyChangeInverse => config.is_storage_key_unchanged.value_inv,
-            Self::Value => config.rw_table.value,
-            Self::RwCounter => config.rw_table.rw_counter,
-            Self::RwCounterLimb0 => config.rw_counter_mpi.limbs[0],
-            Self::RwCounterLimb1 => config.rw_counter_mpi.limbs[1],
-            Self::TagBit0 => config.tag_bits.bits[0],
-            Self::TagBit1 => config.tag_bits.bits[1],
-            Self::TagBit2 => config.tag_bits.bits[2],
-            Self::TagBit3 => config.tag_bits.bits[3],
+            Self::Value => config.value,
+            Self::RwCounter => config.rw_counter.value,
+            Self::RwCounterLimb0 => config.rw_counter.limbs[0],
+            Self::RwCounterLimb1 => config.rw_counter.limbs[1],
+            Self::TagBit0 => config.tag.bits[0],
+            Self::TagBit1 => config.tag.bits[1],
+            Self::TagBit2 => config.tag.bits[2],
+            Self::TagBit3 => config.tag.bits[3],
         }
     }
 }
@@ -796,10 +796,6 @@ fn invalid_tags() {
 
 fn prover(rows: Vec<Rw>, overrides: HashMap<(AdviceColumn, isize), Fr>) -> MockProver<Fr> {
     let randomness = Fr::rand();
-    let rows = rows
-        .iter()
-        .map(|r| r.table_assignment(randomness))
-        .collect();
 
     let circuit = StateCircuit::<Fr, N_ROWS> {
         randomness,

--- a/zkevm-circuits/src/test_util.rs
+++ b/zkevm-circuits/src/test_util.rs
@@ -55,7 +55,7 @@ impl Default for BytecodeTestConfig {
             enable_evm_circuit_test: true,
             enable_state_circuit_test: true,
             gas_limit: 1_000_000u64,
-            evm_circuit_lookup_tags: get_fixed_table(FixedTableConfig::Incomplete),
+            evm_circuit_lookup_tags: vec![],
         }
     }
 }
@@ -93,7 +93,12 @@ pub fn test_circuits_using_witness_block(
         const N_ROWS: usize = 1 << 16;
         let state_circuit = StateCircuit::<Fr, N_ROWS>::new(block.randomness, block.rws);
         let power_of_randomness = state_circuit.instance();
-        let prover = MockProver::<Fr>::run(18, &state_circuit, power_of_randomness).unwrap();
+        let prover = MockProver::<Fr>::run(
+            state_circuit.estimate_k(),
+            &state_circuit,
+            power_of_randomness,
+        )
+        .unwrap();
         prover.verify_at_rows(0..state_circuit.rows.len(), 0..state_circuit.rows.len())?
     }
 


### PR DESCRIPTION
background: https://github.com/privacy-scaling-explorations/zkevm-specs/issues/202
spec draft PR https://github.com/privacy-scaling-explorations/zkevm-specs/pull/210

Constrain value_prev when needed: (1) value_prev.cur() == value.prev() when keys not changed, (2) constrain default prev value when keys changed
Change rw value tuple to struct in evm_circuit::constraint_builder. It makes reading codes easier in IDE. Using meaning field names is less likely to introduce bugs. (eg: fix things likevalues.swap(4, 5))
Assignment of rw table of evm circuit and state circuit shard much more codes. In fact rw table of evm circuit and state circuit are identical now.
Change FieldExt to Field in some places. We should always use eth_types::Field.
Use a constant bool generic to control state circuit to be "full" or "light"(disable lexicographic_ordering u16 lookup to reduce k. Since this contraint is almost impossible to be broken if assignment codes of state circuit are called). Use 'light state circuit' in opcodes tests. Reduce CI time 35min -> 17min.