### PR TITLE
Refactor `MulAddWordsGadget`

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution/mul_div_mod.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/mul_div_mod.rs
@@ -3,6 +3,7 @@ use crate::{
         execution::ExecutionGadget,
         step::ExecutionState,
         util::{
+            self,
             common_gadget::SameContextGadget,
             constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
             math_gadget::{IsZeroGadget, LtWordGadget, MulAddWordsGadget},
@@ -24,6 +25,8 @@ use halo2_proofs::plonk::Error;
 #[derive(Clone, Debug)]
 pub(crate) struct MulDivModGadget<F> {
     same_context: SameContextGadget<F>,
+    /// Words a, b, c, d
+    pub words: [util::Word<F>; 4],
     /// Gadget that verifies a * b + c = d
     mul_add_words: MulAddWordsGadget<F>,
     /// Check if divisor is zero for DIV and MOD
@@ -54,8 +57,7 @@ impl<F: Field> ExecutionGadget<F> for MulDivModGadget<F> {
         let c = cb.query_word();
         let d = cb.query_word();
 
-        let mul_add_words =
-            MulAddWordsGadget::construct(cb, [a.clone(), b.clone(), c.clone(), d.clone()]);
+        let mul_add_words = MulAddWordsGadget::construct(cb, [&a, &b, &c, &d]);
         let divisor_is_zero = IsZeroGadget::construct(cb, sum::expr(&b.cells));
         let lt_word = LtWordGadget::construct(cb, &c, &b);
 
@@ -98,6 +100,7 @@ impl<F: Field> ExecutionGadget<F> for MulDivModGadget<F> {
         let same_context = SameContextGadget::construct(cb, opcode, step_state_transition);
 
         Self {
+            words: [a, b, c, d],
             same_context,
             mul_add_words,
             divisor_is_zero,
@@ -132,10 +135,10 @@ impl<F: Field> ExecutionGadget<F> for MulDivModGadget<F> {
             ),
             _ => unreachable!(),
         };
-        self.mul_add_words.words[0].assign(region, offset, Some(a.to_le_bytes()))?;
-        self.mul_add_words.words[1].assign(region, offset, Some(b.to_le_bytes()))?;
-        self.mul_add_words.words[2].assign(region, offset, Some(c.to_le_bytes()))?;
-        self.mul_add_words.words[3].assign(region, offset, Some(d.to_le_bytes()))?;
+        self.words[0].assign(region, offset, Some(a.to_le_bytes()))?;
+        self.words[1].assign(region, offset, Some(b.to_le_bytes()))?;
+        self.words[2].assign(region, offset, Some(c.to_le_bytes()))?;
+        self.words[3].assign(region, offset, Some(d.to_le_bytes()))?;
         self.mul_add_words.assign(region, offset, [a, b, c, d])?;
         self.lt_word.assign(region, offset, c, b)?;
         let b_sum = (0..32).fold(0, |acc, idx| acc + b.byte(idx) as u64);

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget.rs
@@ -783,23 +783,15 @@ pub(crate) fn generate_lagrange_base_polynomial<
 /// MulAddWordsGadget.
 #[derive(Clone, Debug)]
 pub(crate) struct MulAddWordsGadget<F> {
-    pub a: util::Word<F>,
-    pub b: util::Word<F>,
-    pub c: util::Word<F>,
-    pub d: util::Word<F>,
+    pub words: [util::Word<F>; 4],
     carry_lo: [Cell<F>; 9],
     carry_hi: [Cell<F>; 9],
     overflow: Expression<F>,
 }
 
 impl<F: Field> MulAddWordsGadget<F> {
-    pub(crate) fn construct(
-        cb: &mut ConstraintBuilder<F>,
-        a: util::Word<F>,
-        b: util::Word<F>,
-        c: util::Word<F>,
-        d: util::Word<F>,
-    ) -> Self {
+    pub(crate) fn construct(cb: &mut ConstraintBuilder<F>, words: [util::Word<F>; 4]) -> Self {
+        let (a, b, c, d) = (&words[0], &words[1], &words[2], &words[3]);
         let carry_lo = cb.query_bytes();
         let carry_hi = cb.query_bytes();
         let carry_lo_expr = from_bytes::expr(&carry_lo);
@@ -846,10 +838,7 @@ impl<F: Field> MulAddWordsGadget<F> {
         );
 
         Self {
-            a,
-            b,
-            c,
-            d,
+            words,
             carry_lo,
             carry_hi,
             overflow,
@@ -863,10 +852,6 @@ impl<F: Field> MulAddWordsGadget<F> {
         words: [Word; 4],
     ) -> Result<(), Error> {
         let (a, b, c, d) = (words[0], words[1], words[2], words[3]);
-        self.a.assign(region, offset, Some(a.to_le_bytes()))?;
-        self.b.assign(region, offset, Some(b.to_le_bytes()))?;
-        self.c.assign(region, offset, Some(c.to_le_bytes()))?;
-        self.d.assign(region, offset, Some(d.to_le_bytes()))?;
 
         let a_limbs = split_u256_limb64(&a);
         let b_limbs = split_u256_limb64(&b);

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget.rs
@@ -783,15 +783,14 @@ pub(crate) fn generate_lagrange_base_polynomial<
 /// MulAddWordsGadget.
 #[derive(Clone, Debug)]
 pub(crate) struct MulAddWordsGadget<F> {
-    pub words: [util::Word<F>; 4],
     carry_lo: [Cell<F>; 9],
     carry_hi: [Cell<F>; 9],
     overflow: Expression<F>,
 }
 
 impl<F: Field> MulAddWordsGadget<F> {
-    pub(crate) fn construct(cb: &mut ConstraintBuilder<F>, words: [util::Word<F>; 4]) -> Self {
-        let (a, b, c, d) = (&words[0], &words[1], &words[2], &words[3]);
+    pub(crate) fn construct(cb: &mut ConstraintBuilder<F>, words: [&util::Word<F>; 4]) -> Self {
+        let (a, b, c, d) = (words[0], words[1], words[2], words[3]);
         let carry_lo = cb.query_bytes();
         let carry_hi = cb.query_bytes();
         let carry_lo_expr = from_bytes::expr(&carry_lo);
@@ -838,7 +837,6 @@ impl<F: Field> MulAddWordsGadget<F> {
         );
 
         Self {
-            words,
             carry_lo,
             carry_hi,
             overflow,

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget.rs
@@ -793,11 +793,13 @@ pub(crate) struct MulAddWordsGadget<F> {
 }
 
 impl<F: Field> MulAddWordsGadget<F> {
-    pub(crate) fn construct(cb: &mut ConstraintBuilder<F>) -> Self {
-        let a = cb.query_word();
-        let b = cb.query_word();
-        let c = cb.query_word();
-        let d = cb.query_word();
+    pub(crate) fn construct(
+        cb: &mut ConstraintBuilder<F>,
+        a: util::Word<F>,
+        b: util::Word<F>,
+        c: util::Word<F>,
+        d: util::Word<F>,
+    ) -> Self {
         let carry_lo = cb.query_bytes();
         let carry_hi = cb.query_bytes();
         let carry_lo_expr = from_bytes::expr(&carry_lo);


### PR DESCRIPTION
The words `a, b, c, d` are now passed as arguments in `construct` instead of being fetched via `query_word()`.
Closes #547 