### PR TITLE
[keccak] use tag to stack lookup table cells

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2250,6 +2250,8 @@ dependencies = [
  "plotters",
  "pretty_assertions",
  "rand",
+ "strum",
+ "strum_macros",
 ]
 
 [[package]]

--- a/keccak256/Cargo.toml
+++ b/keccak256/Cargo.toml
@@ -16,6 +16,8 @@ plotters = { version = "0.3.0", optional = true }
 eth-types = { path = "../eth-types" }
 lazy_static = "1.4"
 gadgets = { path = "../gadgets" }
+strum = "0.24"
+strum_macros = "0.24"
 
 [dev-dependencies]
 pretty_assertions = "1.0"

--- a/keccak256/src/permutation/circuit.rs
+++ b/keccak256/src/permutation/circuit.rs
@@ -25,6 +25,7 @@ use std::convert::TryInto;
 #[derive(Clone, Debug)]
 pub struct KeccakFConfig<F: Field> {
     generic: GenericConfig<F>,
+    stackable: StackableTable<F>,
     theta_config: ThetaConfig<F>,
     rho_config: RhoConfig<F>,
     xi_config: XiConfig<F>,
@@ -62,7 +63,8 @@ impl<F: Field> KeccakFConfig<F> {
         // theta
         let theta_config = ThetaConfig::configure(meta.selector(), meta, state);
         // rho
-        let rho_config = RhoConfig::configure(meta, state, fixed, &generic, stackable);
+        let rho_config =
+            RhoConfig::configure(meta, state, fixed, generic.clone(), stackable.clone());
         // xi
         let xi_config = XiConfig::configure(meta.selector(), meta, state);
 
@@ -103,6 +105,7 @@ impl<F: Field> KeccakFConfig<F> {
 
         KeccakFConfig {
             generic,
+            stackable,
             theta_config,
             rho_config,
             xi_config,
@@ -116,6 +119,7 @@ impl<F: Field> KeccakFConfig<F> {
     }
 
     pub fn load(&self, layouter: &mut impl Layouter<F>) -> Result<(), Error> {
+        self.stackable.load(layouter)?;
         self.rho_config.load(layouter)?;
         self.from_b9_table.load(layouter)
     }

--- a/keccak256/src/permutation/circuit.rs
+++ b/keccak256/src/permutation/circuit.rs
@@ -3,15 +3,21 @@ use crate::{
     common::{NEXT_INPUTS_LANES, PERMUTATION, ROUND_CONSTANTS},
     keccak_arith::*,
     permutation::{
-        base_conversion::BaseConversionConfig, generic::GenericConfig, iota::IotaConstants,
-        mixing::MixingConfig, pi::pi_gate_permutation, rho::RhoConfig,
-        tables::FromBase9TableConfig, theta::ThetaConfig, xi::XiConfig,
+        base_conversion::BaseConversionConfig,
+        generic::GenericConfig,
+        iota::IotaConstants,
+        mixing::MixingConfig,
+        pi::pi_gate_permutation,
+        rho::RhoConfig,
+        tables::{FromBase9TableConfig, StackableTable},
+        theta::ThetaConfig,
+        xi::XiConfig,
     },
 };
 use eth_types::Field;
 use halo2_proofs::{
     circuit::{AssignedCell, Layouter, Region},
-    plonk::{Advice, Column, ConstraintSystem, Error, Selector},
+    plonk::{Advice, Column, ConstraintSystem, Error, Selector, TableColumn},
     poly::Rotation,
 };
 use itertools::Itertools;
@@ -45,11 +51,18 @@ impl<F: Field> KeccakFConfig<F> {
 
         let fixed = meta.fixed_column();
         let generic = GenericConfig::configure(meta, state[0..3].try_into().unwrap(), fixed);
+        let table_cols: [TableColumn; 3] = (0..3)
+            .map(|_| meta.lookup_table_column())
+            .collect_vec()
+            .try_into()
+            .unwrap();
+        let stackable =
+            StackableTable::configure(meta, state[0..3].try_into().unwrap(), table_cols);
 
         // theta
         let theta_config = ThetaConfig::configure(meta.selector(), meta, state);
         // rho
-        let rho_config = RhoConfig::configure(meta, state, fixed, &generic);
+        let rho_config = RhoConfig::configure(meta, state, fixed, &generic, stackable);
         // xi
         let xi_config = XiConfig::configure(meta.selector(), meta, state);
 

--- a/keccak256/src/permutation/rho.rs
+++ b/keccak256/src/permutation/rho.rs
@@ -150,7 +150,7 @@ mod tests {
                     GenericConfig::configure(meta, state[0..3].try_into().unwrap(), fixed);
 
                 let rho_config =
-                    RhoConfig::configure(meta, state, fixed, generic.clone(), stackable.clone());
+                    RhoConfig::configure(meta, state, fixed, generic, stackable.clone());
 
                 let q_enable = meta.selector();
                 meta.create_gate("Check states", |meta| {

--- a/keccak256/src/permutation/rho.rs
+++ b/keccak256/src/permutation/rho.rs
@@ -1,8 +1,7 @@
 use crate::permutation::{
     generic::GenericConfig,
-    rho_checks::{LaneRotateConversionConfig, OverflowCheckConfig},
-    rho_helpers::{STEP2_RANGE, STEP3_RANGE},
-    tables::{Base13toBase9TableConfig, RangeCheckConfig, SpecialChunkTableConfig},
+    rho_checks::LaneRotateConversionConfig,
+    tables::{Base13toBase9TableConfig, StackableTable},
 };
 
 use eth_types::Field;
@@ -15,11 +14,9 @@ use std::convert::TryInto;
 #[derive(Debug, Clone)]
 pub struct RhoConfig<F> {
     lane_config: LaneRotateConversionConfig<F>,
-    overflow_check_config: OverflowCheckConfig<F>,
     base13_to_9_table: Base13toBase9TableConfig<F>,
-    special_chunk_table: SpecialChunkTableConfig<F>,
-    step2_range_table: RangeCheckConfig<F, STEP2_RANGE>,
-    step3_range_table: RangeCheckConfig<F, STEP3_RANGE>,
+    stackable: StackableTable<F>,
+    sum: SumConfig<F>,
 }
 
 impl<F: Field> RhoConfig<F> {
@@ -28,36 +25,24 @@ impl<F: Field> RhoConfig<F> {
         state: [Column<Advice>; 25],
         fixed: Column<Fixed>,
         generic: &GenericConfig<F>,
+        stackable: StackableTable<F>,
     ) -> Self {
         state.iter().for_each(|col| meta.enable_equality(*col));
         let base13_to_9_table = Base13toBase9TableConfig::configure(meta);
-        let special_chunk_table = SpecialChunkTableConfig::configure(meta);
-        let step2_range_table = RangeCheckConfig::<F, STEP2_RANGE>::configure(meta);
-        let step3_range_table = RangeCheckConfig::<F, STEP3_RANGE>::configure(meta);
 
         let lane_config = LaneRotateConversionConfig::configure(
             meta,
             &base13_to_9_table,
-            &special_chunk_table,
             state[0..3].try_into().unwrap(),
             fixed,
             generic.clone(),
         );
-
-        let overflow_check_config = OverflowCheckConfig::configure(
-            meta,
-            &step2_range_table,
-            &step3_range_table,
-            state[3],
-            generic.clone(),
-        );
+        let sum = SumConfig::configure(meta, [state[0], state[1]]);
         Self {
             lane_config,
-            overflow_check_config,
             base13_to_9_table,
-            special_chunk_table,
-            step2_range_table,
-            step3_range_table,
+            stackable,
+            sum,
         }
     }
     pub fn assign_rotation_checks(
@@ -93,19 +78,15 @@ impl<F: Field> RhoConfig<F> {
             .iter()
             .flat_map(|(_, _, step3_od)| step3_od.clone())
             .collect::<Vec<_>>();
-        self.overflow_check_config.assign_region(
-            &mut layouter.namespace(|| "Final overflow check"),
-            step2_od_join,
-            step3_od_join,
-        )?;
+        let step2_sum = self.sum.assign_region(layouter, step2_od_join)?;
+        let step3_sum = self.sum.assign_region(layouter, step3_od_join)?;
+        self.stackable.lookup_range_12(layouter, &[step2_sum])?;
+        self.stackable.lookup_range_169(layouter, &[step3_sum])?;
         Ok(next_state)
     }
 
     pub fn load(&self, layouter: &mut impl Layouter<F>) -> Result<(), Error> {
         self.base13_to_9_table.load(layouter)?;
-        self.special_chunk_table.load(layouter)?;
-        self.step2_range_table.load(layouter)?;
-        self.step3_range_table.load(layouter)?;
         Ok(())
     }
 }
@@ -121,7 +102,7 @@ mod tests {
         circuit::{Layouter, SimpleFloorPlanner},
         dev::MockProver,
         pairing::bn256::Fr as Fp,
-        plonk::{Advice, Circuit, Column, ConstraintSystem, Error, Selector},
+        plonk::{Advice, Circuit, Column, ConstraintSystem, Error, Selector, TableColumn},
         poly::Rotation,
     };
     use itertools::Itertools;
@@ -139,6 +120,7 @@ mod tests {
         struct MyConfig<F> {
             q_enable: Selector,
             rho_config: RhoConfig<F>,
+            stackable: StackableTable<F>,
             state: [Column<Advice>; 25],
         }
         impl<F: Field> Circuit<F> for MyCircuit<F> {
@@ -157,10 +139,18 @@ mod tests {
                     .unwrap();
 
                 let fixed = meta.fixed_column();
+                let table_cols: [TableColumn; 3] = (0..3)
+                    .map(|_| meta.lookup_table_column())
+                    .collect_vec()
+                    .try_into()
+                    .unwrap();
+                let stackable =
+                    StackableTable::configure(meta, state[0..3].try_into().unwrap(), table_cols);
                 let generic =
                     GenericConfig::configure(meta, state[0..3].try_into().unwrap(), fixed);
 
-                let rho_config = RhoConfig::configure(meta, state, fixed, &generic);
+                let rho_config =
+                    RhoConfig::configure(meta, state, fixed, &generic, stackable.clone());
 
                 let q_enable = meta.selector();
                 meta.create_gate("Check states", |meta| {
@@ -178,6 +168,7 @@ mod tests {
                 MyConfig {
                     q_enable,
                     rho_config,
+                    stackable,
                     state,
                 }
             }
@@ -188,6 +179,7 @@ mod tests {
                 mut layouter: impl Layouter<F>,
             ) -> Result<(), Error> {
                 config.rho_config.load(&mut layouter)?;
+                config.stackable.load(&mut layouter)?;
                 let state = layouter.assign_region(
                     || "assign input state",
                     |mut region| {

--- a/keccak256/src/permutation/rho_checks.rs
+++ b/keccak256/src/permutation/rho_checks.rs
@@ -80,7 +80,7 @@
 //! [`crate::permutation::tables::Base13toBase9TableConfig`] to lookup
 //! `overflow_detector`. We sum up all the overflow_detectors across 25 lanes,
 //! for each step 1, step 2, and step 3. At the end of the Rho step we perform
-//! the final overflow detector range check in [`OverflowCheckConfig`].
+//! the final overflow detector range check for them.
 //!
 //! The `OVERFLOW_TRANSFORM` maps step 1 to 0, step 2 to 1, step 3 to 13, and
 //! step 4 to 170. It is defined that any possible overflow would result the

--- a/keccak256/src/permutation/rho_checks.rs
+++ b/keccak256/src/permutation/rho_checks.rs
@@ -124,7 +124,7 @@ pub struct LaneRotateConversionConfig<F> {
     q_normal: Selector,
     input_coef: Column<Advice>,
     output_coef: Column<Advice>,
-    pub overflow_detector: Column<Advice>,
+    overflow_detector: Column<Advice>,
     generic: GenericConfig<F>,
     stackable: StackableTable<F>,
 }

--- a/keccak256/src/permutation/tables.rs
+++ b/keccak256/src/permutation/tables.rs
@@ -183,18 +183,18 @@ impl<F: Field> StackableTable<F> {
     pub(crate) fn lookup_special_chunks(
         &self,
         layouter: &mut impl Layouter<F>,
-        values: &[(AssignedCell<F, F>, AssignedCell<F, F>)],
+        last_chunk: &AssignedCell<F, F>,
+        output_coef: &AssignedCell<F, F>,
     ) -> Result<(), Error> {
         layouter.assign_region(
             || "lookup for special chunks",
             |mut region| {
+                let offset = 0;
                 let tag = F::from(TableTags::SpecialChunk as u64);
-                for (offset, (last_chunk, output_coef)) in values.iter().enumerate() {
-                    self.q_enable.enable(&mut region, offset)?;
-                    region.assign_advice_from_constant(|| "tag", self.tag.0, offset, tag)?;
-                    last_chunk.copy_advice(|| "last chunk", &mut region, self.col1.0, offset)?;
-                    output_coef.copy_advice(|| "output coef", &mut region, self.col2.0, offset)?;
-                }
+                self.q_enable.enable(&mut region, offset)?;
+                region.assign_advice_from_constant(|| "tag", self.tag.0, offset, tag)?;
+                last_chunk.copy_advice(|| "last chunk", &mut region, self.col1.0, offset)?;
+                output_coef.copy_advice(|| "output coef", &mut region, self.col2.0, offset)?;
                 Ok(())
             },
         )
@@ -219,6 +219,7 @@ impl<F: Field, const K: u64> RangeCheckConfig<F, K> {
             },
         )
     }
+    #[allow(dead_code)]
     pub(crate) fn configure(meta: &mut ConstraintSystem<F>) -> Self {
         Self {
             range: meta.lookup_table_column(),

--- a/keccak256/src/permutation/tables.rs
+++ b/keccak256/src/permutation/tables.rs
@@ -219,6 +219,8 @@ impl<F: Field, const K: u64> RangeCheckConfig<F, K> {
             },
         )
     }
+    // dead_code reason: WordBuilderConfig is using it. We defer the decision to
+    // remove this after WordBuilderConfig is complete
     #[allow(dead_code)]
     pub(crate) fn configure(meta: &mut ConstraintSystem<F>) -> Self {
         Self {


### PR DESCRIPTION
These tables are using few rows:

- range 12
- range 169
- special chunks (13+1) *13/2 =91 rows

We can use tags to let them share table columns.

It can be unblocked by adding some generic gates.