### PR TITLE
add boolean flag lookup

### DIFF
--- a/keccak256/src/permutation/circuit.rs
+++ b/keccak256/src/permutation/circuit.rs
@@ -85,7 +85,13 @@ impl<F: Field> KeccakFConfig<F> {
 
         // Mixing will make sure that the flag is binary constrained and that
         // the out state matches the expected result.
-        let mixing_config = MixingConfig::configure(meta, &from_b9_table, state, generic.clone());
+        let mixing_config = MixingConfig::configure(
+            meta,
+            &from_b9_table,
+            state,
+            generic.clone(),
+            stackable.clone(),
+        );
 
         // Allocate the `out state correctness` gate selector
         let q_out = meta.selector();

--- a/keccak256/src/permutation/tables.rs
+++ b/keccak256/src/permutation/tables.rs
@@ -151,7 +151,7 @@ impl<F: Field> StackableTable<F> {
                 {
                     offset = self.load_range(&mut table, offset, tag, k)?;
                 }
-                self.load_special_chunks(&mut table, offset)?;
+                offset = self.load_special_chunks(&mut table, offset)?;
                 self.load_boolean_flag(&mut table, offset)?;
                 Ok(())
             },


### PR DESCRIPTION
We reuse the stackable table for the boolean flag lookup.
Cost: 1. Adds two rows to the stackable. 2. Need a tag advice cell when doing the lookup.
Benefit: don't need the [x(x-1), x+y=1] gate.

TODO: replace the whole mixing config with this.

