### PR TITLE
Box ExecutionConfig in EvmCircuit

### DIFF
--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -22,7 +22,7 @@ use witness::Block;
 pub struct EvmCircuit<F> {
     fixed_table: [Column<Fixed>; 4],
     byte_table: [Column<Fixed>; 1],
-    execution: ExecutionConfig<F>,
+    execution: Box<ExecutionConfig<F>>,
 }
 
 impl<F: Field> EvmCircuit<F> {
@@ -38,7 +38,7 @@ impl<F: Field> EvmCircuit<F> {
         let fixed_table = [(); 4].map(|_| meta.fixed_column());
         let byte_table = [(); 1].map(|_| meta.fixed_column());
 
-        let execution = ExecutionConfig::configure(
+        let execution = Box::new(ExecutionConfig::configure(
             meta,
             power_of_randomness,
             &fixed_table,
@@ -47,7 +47,7 @@ impl<F: Field> EvmCircuit<F> {
             rw_table,
             bytecode_table,
             block_table,
-        );
+        ));
 
         Self {
             fixed_table,


### PR DESCRIPTION
The type ExecutionConfig has been growing a lot with each opcode
gadget that we add.  Currently it's around 337 KiB.  By having functions
that return an EvmCircuit or a struct that contains an EvmCircuit,
we're actually allocating 337 KiB in the stack to hold the
ExecutionConfig.

So if we have a TestCircuit::configure that retruns a struct containing
EvmCircuit and calls EvmCircuit::configure that returns a struct
containing ExecutionConfig and calls ExecutionConfig::configure that
returns itself, by this point we have 3 times the size of
ExecutionConfig allocated in the stack, which means 1 MiB.

By moving this struct to the heap with Box as soon as possible, we will
only have one call in the entire call stack that requires allocating the
struct in the stack.

It may be interesting to look for other big structs that we hold in the
stack in several calls within a call stack.

NOTE: This should fix the issue found in https://github.com/privacy-scaling-explorations/zkevm-circuits/pull/564