### PR TITLE
Check read-write consistency for existing rw tables

### DIFF
--- a/zkevm-circuits/src/state_circuit.rs
+++ b/zkevm-circuits/src/state_circuit.rs
@@ -227,12 +227,21 @@ impl<F: Field, const N_ROWS: usize> Circuit<F> for StateCircuit<F, N_ROWS> {
                     )?;
 
                     if let Some(prev_row) = prev_row {
-                        config.lexicographic_ordering.assign(
+                        let is_first_access = config.lexicographic_ordering.assign(
                             &mut region,
                             offset,
                             &row,
                             &prev_row,
                         )?;
+
+                        if !(is_first_access || row.is_write()) {
+                            assert_eq!(
+                                row.value_assignment(self.randomness),
+                                prev_row.value_assignment(self.randomness),
+                                "{:?}",
+                                [prev_row, row]
+                            )
+                        }
                     }
                 }
 

--- a/zkevm-circuits/src/state_circuit/lexicographic_ordering.rs
+++ b/zkevm-circuits/src/state_circuit/lexicographic_ordering.rs
@@ -196,7 +196,7 @@ impl Config {
         offset: usize,
         cur: &Rw,
         prev: &Rw,
-    ) -> Result<(), Error> {
+    ) -> Result<bool, Error> {
         region.assign_fixed(
             || "upper_limb_difference",
             self.selector,
@@ -233,7 +233,10 @@ impl Config {
             || Ok(limb_difference.invert().unwrap()),
         )?;
 
-        Ok(())
+        Ok(!matches!(
+            index,
+            LimbIndex::RwCounter0 | LimbIndex::RwCounter1
+        ))
     }
 }
 


### PR DESCRIPTION
My understanding of read-write consistency is that non-first access reads should not change `row.value`, but the following tests fail when I make these changes:
```
---- evm_circuit::execution::calldatacopy::test::calldatacopy_gadget_multi_step stdout ----
thread 'evm_circuit::execution::calldatacopy::test::calldatacopy_gadget_multi_step' panicked at 'assertion failed: `(left == right)`
  left: `0x000000000000000000000000000000000000000000000000000000000cafe111`,
 right: `0x000000000000000000000000000000000000000000000000000000000cafe333`: [CallContext { rw_counter: 11, is_write: false, call_id: 1, field_tag: CallerAddress, value: 212853555 }, CallContext { rw_counter: 69, is_write: false, call_id: 1, field_tag: CallerAddress, value: 212853009 }]', zkevm-circuits/src/state_circuit.rs:238:29
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- evm_circuit::execution::calldatacopy::test::calldatacopy_gadget_simple stdout ----
thread 'evm_circuit::execution::calldatacopy::test::calldatacopy_gadget_simple' panicked at 'assertion failed: `(left == right)`
  left: `0x000000000000000000000000000000000000000000000000000000000cafe111`,
 right: `0x000000000000000000000000000000000000000000000000000000000cafe333`: [CallContext { rw_counter: 11, is_write: false, call_id: 1, field_tag: CallerAddress, value: 212853555 }, CallContext { rw_counter: 69, is_write: false, call_id: 1, field_tag: CallerAddress, value: 212853009 }]', zkevm-circuits/src/state_circuit.rs:238:29

---- evm_circuit::execution::calldatacopy::test::calldatacopy_gadget_out_of_bound stdout ----
thread 'evm_circuit::execution::calldatacopy::test::calldatacopy_gadget_out_of_bound' panicked at 'assertion failed: `(left == right)`
  left: `0x000000000000000000000000000000000000000000000000000000000cafe111`,
 right: `0x000000000000000000000000000000000000000000000000000000000cafe333`: [CallContext { rw_counter: 11, is_write: false, call_id: 1, field_tag: CallerAddress, value: 212853555 }, CallContext { rw_counter: 69, is_write: false, call_id: 1, field_tag: CallerAddress, value: 212853009 }]', zkevm-circuits/src/state_circuit.rs:238:29

---- evm_circuit::execution::calldataload::test::calldataload_gadget_internal stdout ----
thread 'evm_circuit::execution::calldataload::test::calldataload_gadget_internal' panicked at 'assertion failed: `(left == right)`
  left: `0x000000000000000000000000000000000000000000000000000000000cafe111`,
 right: `0x000000000000000000000000000000000000000000000000000000000cafe333`: [CallContext { rw_counter: 11, is_write: false, call_id: 1, field_tag: CallerAddress, value: 212853555 }, CallContext { rw_counter: 69, is_write: false, call_id: 1, field_tag: CallerAddress, value: 212853009 }]', zkevm-circuits/src/state_circuit.rs:238:29

---- evm_circuit::execution::calldatacopy::test::calldatacopy_gadget_zero_length stdout ----
thread 'evm_circuit::execution::calldatacopy::test::calldatacopy_gadget_zero_length' panicked at 'assertion failed: `(left == right)`
  left: `0x000000000000000000000000000000000000000000000000000000000cafe111`,
 right: `0x000000000000000000000000000000000000000000000000000000000cafe333`: [CallContext { rw_counter: 11, is_write: false, call_id: 1, field_tag: CallerAddress, value: 212853555 }, CallContext { rw_counter: 69, is_write: false, call_id: 1, field_tag: CallerAddress, value: 212853009 }]', zkevm-circuits/src/state_circuit.rs:238:29
```

Is something wrong with my understanding of rw consistency, or is there a bug in the bus mapping for the calldata gadgets?