### PR TITLE
refactor memory gadget

### DIFF
--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -1014,31 +1014,6 @@ impl<'a, F: FieldExt> ConstraintBuilder<'a, F> {
         );
     }
 
-    pub(crate) fn memory_lookup_with_counter(
-        &mut self,
-        rw_counter: Expression<F>,
-        is_write: Expression<F>,
-        memory_address: Expression<F>,
-        byte: Expression<F>,
-    ) {
-        self.rw_lookup_with_counter(
-            "Memory lookup",
-            rw_counter,
-            is_write,
-            RwTableTag::Memory,
-            [
-                self.curr.state.call_id.expr(),
-                memory_address,
-                0.expr(),
-                0.expr(),
-                byte,
-                0.expr(),
-                0.expr(),
-                0.expr(),
-            ],
-        );
-    }
-
     pub(crate) fn tx_log_lookup(
         &mut self,
         tx_id: Expression<F>,


### PR DESCRIPTION
the memory gadget was written long long ago. The "style" is a bit foreign compared to recent opcodes like CALLDATACOPY. Eg: MemoryGadget uses 32 identical (even rwc is same) rw lookup for mstore8, while in later opcodes we choose to use `cb.condition(cond, |cb| cb.lookup(...));`.  So i made a tiny change to make the style more consistent