### PR TITLE
Add test function with EVM circuit stats

### DIFF
--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -534,7 +534,8 @@ mod evm_circuit_stats {
     /// - height/gas: ratio between circuit cost and gas cost
     ///
     /// Run with:
-    /// `cargo test -p zkevm-circuits --release get_evm_states_stats -- --nocapture --ignored`
+    /// `cargo test -p zkevm-circuits --release get_evm_states_stats --
+    /// --nocapture --ignored`
     #[ignore]
     #[test]
     pub fn get_evm_states_stats() {

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -534,7 +534,7 @@ mod evm_circuit_stats {
     /// - height/gas: ratio between circuit cost and gas cost
     ///
     /// Run with:
-    /// `cargo test [...] get_evm_states_stats -- --nocapture --ignored`
+    /// `cargo test -p zkevm-circuits --release get_evm_states_stats -- --nocapture --ignored`
     #[ignore]
     #[test]
     pub fn get_evm_states_stats() {

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -195,7 +195,7 @@ pub mod test {
         bytecode_table: [Column<Advice>; 5],
         block_table: [Column<Advice>; 3],
         copy_table: CopyCircuit<F>,
-        evm_circuit: EvmCircuit<F>,
+        pub evm_circuit: EvmCircuit<F>,
     }
 
     impl<F: Field> TestCircuitConfig<F> {
@@ -513,5 +513,83 @@ pub mod test {
         block: Block<F>,
     ) -> Result<(), Vec<VerifyFailure>> {
         run_test_circuit(block, FixedTableTag::iter().collect())
+    }
+}
+
+#[cfg(test)]
+mod evm_circuit_stats {
+    use super::test::*;
+    use super::*;
+    use crate::evm_circuit::step::ExecutionState;
+    use eth_types::{bytecode, evm_types::OpcodeId, geth_types::GethData};
+    use halo2_proofs::pairing::bn256::Fr;
+    use halo2_proofs::plonk::ConstraintSystem;
+    use mock::test_ctx::{helpers::*, TestContext};
+    use strum::IntoEnumIterator;
+
+    /// This function prints to stdout a table with all the implemented states
+    /// and their responsible opcodes with the following stats:
+    /// - height: number of rows used by the execution state
+    /// - gas: gas value used for the opcode execution
+    /// - height/gas: ratio between circuit cost and gas cost
+    ///
+    /// Run with:
+    /// `cargo test [...] get_evm_states_stats -- --nocapture --ignored`
+    #[ignore]
+    #[test]
+    pub fn get_evm_states_stats() {
+        let mut meta = ConstraintSystem::<Fr>::default();
+        let circuit = TestCircuit::configure(&mut meta);
+
+        let mut implemented_states = Vec::new();
+        for state in ExecutionState::iter() {
+            let height = circuit.evm_circuit.execution.get_step_height_option(state);
+            if let Some(h) = height {
+                implemented_states.push((state, h));
+            }
+        }
+
+        let mut stats = Vec::new();
+        for (state, h) in implemented_states {
+            for opcode in state.responsible_opcodes() {
+                let mut code = bytecode! {
+                    PUSH2(0x8000)
+                    PUSH2(0x00)
+                    PUSH2(0x10)
+                    PUSH2(0x20)
+                    PUSH2(0x30)
+                    PUSH2(0x40)
+                    PUSH2(0x50)
+                };
+                code.write_op(opcode);
+                code.write_op(OpcodeId::STOP);
+                let block: GethData = TestContext::<2, 1>::new(
+                    None,
+                    account_0_code_account_1_no_code(code),
+                    tx_from_1_to_0,
+                    |block, _tx| block.number(0xcafeu64),
+                )
+                .unwrap()
+                .into();
+                let gas_cost = block.geth_traces[0].struct_logs[7].gas_cost.0;
+                stats.push((state, opcode, h, gas_cost));
+            }
+        }
+
+        println!(
+            "| {: <14} | {: <14} | {: <2} | {: >6} | {: <5} |",
+            "state", "opcode", "h", "g", "h/g"
+        );
+        println!("| ---            | ---            | ---|    --- | ---   |");
+        for (state, opcode, height, gas_cost) in stats {
+            println!(
+                "| {: <14} | {: <14} | {: >2} | {: >6} | {: >1.3} |",
+                format!("{:?}", state),
+                format!("{:?}", opcode),
+                height,
+                gas_cost,
+                height as f64 / gas_cost as f64
+            );
+        }
     }
 }

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -452,10 +452,12 @@ impl<F: Field> ExecutionConfig<F> {
         config
     }
 
+    pub fn get_step_height_option(&self, execution_state: ExecutionState) -> Option<usize> {
+        self.height_map.get(&execution_state).copied()
+    }
+
     pub fn get_step_height(&self, execution_state: ExecutionState) -> usize {
-        *self
-            .height_map
-            .get(&execution_state)
+        self.get_step_height_option(execution_state)
             .unwrap_or_else(|| panic!("Execution state unknown: {:?}", execution_state))
     }
 

--- a/zkevm-circuits/src/evm_circuit/util.rs
+++ b/zkevm-circuits/src/evm_circuit/util.rs
@@ -278,6 +278,7 @@ impl<F: FieldExt> CellManager<F> {
             .unwrap()
     }
 
+    /// Returns a map of CellType -> (width, height, num_cells)
     pub(crate) fn get_stats(&self) -> BTreeMap<CellType, (usize, usize, usize)> {
         let mut data = BTreeMap::new();
         for column in self.columns.iter() {


### PR DESCRIPTION
This is a little utility (in the form of a test function) that prints to stdout a table with all the implemented states and their responsible opcodes with the following stats:
- height: number of rows used by the execution state
- gas: gas value used for the opcode execution
- height/gas: ratio between circuit cost and gas cost

The idea of this utility is to quickly check which are the worst case opcodes in terms of rows VS gas cost.

Here's the current table:

| state          | opcode         | h  |      g | h/g   |
| ---            | ---            | ---|    --- | ---   |
| STOP           | STOP           |  2 |      0 | inf |
| ADD_SUB        | ADD            |  5 |      3 | 1.667 |
| ADD_SUB        | SUB            |  5 |      3 | 1.667 |
| MUL_DIV_MOD    | MUL            |  8 |      5 | 1.600 |
| MUL_DIV_MOD    | DIV            |  8 |      5 | 1.600 |
| MUL_DIV_MOD    | MOD            |  8 |      5 | 1.600 |
| SDIV_SMOD      | SDIV           | 19 |      5 | 3.800 |
| SDIV_SMOD      | SMOD           | 19 |      5 | 3.800 |
| ADDMOD         | ADDMOD         | 17 |      8 | 2.125 |
| MULMOD         | MULMOD         | 20 |      8 | 2.500 |
| EXP            | EXP            |  4 |     60 | 0.067 |
| SIGNEXTEND     | SIGNEXTEND     |  4 |      5 | 0.800 |
| CMP            | LT             |  5 |      3 | 1.667 |
| CMP            | GT             |  5 |      3 | 1.667 |
| CMP            | EQ             |  5 |      3 | 1.667 |
| SCMP           | SLT            |  5 |      3 | 1.667 |
| SCMP           | SGT            |  5 |      3 | 1.667 |
| ISZERO         | ISZERO         |  2 |      3 | 0.667 |
| BITWISE        | AND            |  5 |      3 | 1.667 |
| BITWISE        | OR             |  5 |      3 | 1.667 |
| BITWISE        | XOR            |  5 |      3 | 1.667 |
| NOT            | NOT            |  5 |      3 | 1.667 |
| BYTE           | BYTE           |  3 |      3 | 1.000 |
| SHL            | SHL            |  4 |      3 | 1.333 |
| SHR            | SHR            |  7 |      3 | 2.333 |
| SAR            | SAR            |  4 |      3 | 1.333 |
| SHA3           | SHA3           |  4 |     57 | 0.070 |
| ADDRESS        | ADDRESS        |  2 |      2 | 1.000 |
| BALANCE        | BALANCE        |  3 |   2600 | 0.001 |
| ORIGIN         | ORIGIN         |  2 |      2 | 1.000 |
| CALLER         | CALLER         |  2 |      2 | 1.000 |
| CALLVALUE      | CALLVALUE      |  2 |      2 | 1.000 |
| CALLDATALOAD   | CALLDATALOAD   |  9 |      3 | 3.000 |
| CALLDATASIZE   | CALLDATASIZE   |  2 |      2 | 1.000 |
| CALLDATACOPY   | CALLDATACOPY   |  3 |     21 | 0.143 |
| CODESIZE       | CODESIZE       |  2 |      2 | 1.000 |
| CODECOPY       | CODECOPY       |  3 |     21 | 0.143 |
| GASPRICE       | GASPRICE       |  2 |      2 | 1.000 |
| EXTCODESIZE    | EXTCODESIZE    |  3 |   2600 | 0.001 |
| EXTCODECOPY    | EXTCODECOPY    |  6 |   2612 | 0.002 |
| RETURNDATASIZE | RETURNDATASIZE |  2 |      2 | 1.000 |
| RETURNDATACOPY | RETURNDATACOPY |  4 |     21 | 0.190 |
| EXTCODEHASH    | EXTCODEHASH    |  2 |   2600 | 0.001 |
| BLOCKHASH      | BLOCKHASH      |  3 |     20 | 0.150 |
| BLOCKCTXU64    | TIMESTAMP      |  2 |      2 | 1.000 |
| BLOCKCTXU64    | NUMBER         |  2 |      2 | 1.000 |
| BLOCKCTXU64    | GASLIMIT       |  2 |      2 | 1.000 |
| BLOCKCTXU160   | COINBASE       |  2 |      2 | 1.000 |
| BLOCKCTXU256   | DIFFICULTY     |  2 |      2 | 1.000 |
| BLOCKCTXU256   | BASEFEE        |  2 |      2 | 1.000 |
| CHAINID        | CHAINID        |  2 |      2 | 1.000 |
| SELFBALANCE    | SELFBALANCE    |  2 |      5 | 0.400 |
| POP            | POP            |  2 |      2 | 1.000 |
| MEMORY         | MLOAD          |  5 |     15 | 0.333 |
| MEMORY         | MSTORE         |  5 |     15 | 0.333 |
| MEMORY         | MSTORE8        |  5 |     12 | 0.417 |
| SLOAD          | SLOAD          |  2 |   2100 | 0.001 |
| SSTORE         | SSTORE         |  3 |  22100 | 0.000 |
| JUMP           | JUMP           |  2 |      8 | 0.250 |
| JUMPI          | JUMPI          |  2 |     10 | 0.200 |
| PC             | PC             |  2 |      2 | 1.000 |
| MSIZE          | MSIZE          |  2 |      2 | 1.000 |
| GAS            | GAS            |  2 |      2 | 1.000 |
| JUMPDEST       | JUMPDEST       |  2 |      1 | 2.000 |
| PUSH           | PUSH1          |  9 |      3 | 3.000 |
| PUSH           | PUSH2          |  9 |      3 | 3.000 |
| PUSH           | PUSH3          |  9 |      3 | 3.000 |
| PUSH           | PUSH4          |  9 |      3 | 3.000 |
| PUSH           | PUSH5          |  9 |      3 | 3.000 |
| PUSH           | PUSH6          |  9 |      3 | 3.000 |
| PUSH           | PUSH7          |  9 |      3 | 3.000 |
| PUSH           | PUSH8          |  9 |      3 | 3.000 |
| PUSH           | PUSH9          |  9 |      3 | 3.000 |
| PUSH           | PUSH10         |  9 |      3 | 3.000 |
| PUSH           | PUSH11         |  9 |      3 | 3.000 |
| PUSH           | PUSH12         |  9 |      3 | 3.000 |
| PUSH           | PUSH13         |  9 |      3 | 3.000 |
| PUSH           | PUSH14         |  9 |      3 | 3.000 |
| PUSH           | PUSH15         |  9 |      3 | 3.000 |
| PUSH           | PUSH16         |  9 |      3 | 3.000 |
| PUSH           | PUSH17         |  9 |      3 | 3.000 |
| PUSH           | PUSH18         |  9 |      3 | 3.000 |
| PUSH           | PUSH19         |  9 |      3 | 3.000 |
| PUSH           | PUSH20         |  9 |      3 | 3.000 |
| PUSH           | PUSH21         |  9 |      3 | 3.000 |
| PUSH           | PUSH22         |  9 |      3 | 3.000 |
| PUSH           | PUSH23         |  9 |      3 | 3.000 |
| PUSH           | PUSH24         |  9 |      3 | 3.000 |
| PUSH           | PUSH25         |  9 |      3 | 3.000 |
| PUSH           | PUSH26         |  9 |      3 | 3.000 |
| PUSH           | PUSH27         |  9 |      3 | 3.000 |
| PUSH           | PUSH28         |  9 |      3 | 3.000 |
| PUSH           | PUSH29         |  9 |      3 | 3.000 |
| PUSH           | PUSH30         |  9 |      3 | 3.000 |
| PUSH           | PUSH31         |  9 |      3 | 3.000 |
| PUSH           | PUSH32         |  9 |      3 | 3.000 |
| DUP            | DUP1           |  2 |      3 | 0.667 |
| DUP            | DUP2           |  2 |      3 | 0.667 |
| DUP            | DUP3           |  2 |      3 | 0.667 |
| DUP            | DUP4           |  2 |      3 | 0.667 |
| DUP            | DUP5           |  2 |      3 | 0.667 |
| DUP            | DUP6           |  2 |      3 | 0.667 |
| DUP            | DUP7           |  2 |      3 | 0.667 |
| DUP            | DUP8           |  2 |      3 | 0.667 |
| DUP            | DUP9           |  2 |      3 | 0.667 |
| DUP            | DUP10          |  2 |      3 | 0.667 |
| DUP            | DUP11          |  2 |      3 | 0.667 |
| DUP            | DUP12          |  2 |      3 | 0.667 |
| DUP            | DUP13          |  2 |      3 | 0.667 |
| DUP            | DUP14          |  2 |      3 | 0.667 |
| DUP            | DUP15          |  2 |      3 | 0.667 |
| DUP            | DUP16          |  2 |      3 | 0.667 |
| SWAP           | SWAP1          |  2 |      3 | 0.667 |
| SWAP           | SWAP2          |  2 |      3 | 0.667 |
| SWAP           | SWAP3          |  2 |      3 | 0.667 |
| SWAP           | SWAP4          |  2 |      3 | 0.667 |
| SWAP           | SWAP5          |  2 |      3 | 0.667 |
| SWAP           | SWAP6          |  2 |      3 | 0.667 |
| SWAP           | SWAP7          |  2 |      3 | 0.667 |
| SWAP           | SWAP8          |  2 |      3 | 0.667 |
| SWAP           | SWAP9          |  2 |      3 | 0.667 |
| SWAP           | SWAP10         |  2 |      3 | 0.667 |
| SWAP           | SWAP11         |  2 |      3 | 0.667 |
| SWAP           | SWAP12         |  2 |      3 | 0.667 |
| SWAP           | SWAP13         |  2 |      3 | 0.667 |
| SWAP           | SWAP14         |  2 |      3 | 0.667 |
| SWAP           | SWAP15         |  2 |      3 | 0.667 |
| SWAP           | SWAP16         |  2 |      3 | 0.667 |
| LOG            | LOG0           |  3 |    902 | 0.003 |
| LOG            | LOG1           |  3 |   1277 | 0.002 |
| LOG            | LOG2           |  3 |   1652 | 0.002 |
| LOG            | LOG3           |  3 |   2027 | 0.001 |
| LOG            | LOG4           |  3 |   2402 | 0.001 |
| CREATE         | CREATE         |  6 |  32012 | 0.000 |
| CALL           | CALL           | 13 |  41800 | 0.000 |
| CALLCODE       | CALLCODE       | 11 |  16800 | 0.001 |
| RETURN         | RETURN         |  2 |     15 | 0.133 |
| DELEGATECALL   | DELEGATECALL   | 10 |   2689 | 0.004 |
| CREATE2        | CREATE2        |  7 |  32024 | 0.000 |
| STATICCALL     | STATICCALL     | 10 |   2689 | 0.004 |
| SELFDESTRUCT   | SELFDESTRUCT   |  2 |  32600 | 0.000 |

