### PR TITLE
fix integration test 

### DIFF
--- a/bus-mapping/src/evm/opcodes/codecopy.rs
+++ b/bus-mapping/src/evm/opcodes/codecopy.rs
@@ -106,10 +106,7 @@ fn gen_copy_event(
     let length = geth_step.stack.nth_last(2)?.as_u64();
 
     let code_hash = state.call()?.code_hash;
-    let bytecode: Bytecode = state
-        .code(code_hash)?
-        .try_into()
-        .map_err(eth_types::Error::BytecodeError)?;
+    let bytecode: Bytecode = state.code(code_hash)?.into();
     let src_addr_end = bytecode.to_vec().len() as u64;
 
     let mut exec_step = state.new_step(geth_step)?;

--- a/eth-types/src/error.rs
+++ b/eth-types/src/error.rs
@@ -3,8 +3,6 @@
 use core::fmt::{Display, Formatter, Result as FmtResult};
 use std::error::Error as StdError;
 
-use crate::bytecode::BytecodeError;
-
 /// Error type for any BusMapping related failure.
 #[derive(Debug)]
 pub enum Error {
@@ -33,14 +31,6 @@ pub enum Error {
     /// Error when an EvmWord is too big to be converted into a
     /// `MemoryAddress`.
     WordToMemAddr,
-    /// Error propagated from bytecode module.
-    BytecodeError(BytecodeError),
-}
-
-impl From<BytecodeError> for Error {
-    fn from(e: BytecodeError) -> Self {
-        Self::BytecodeError(e)
-    }
 }
 
 impl Display for Error {


### PR DESCRIPTION
vec\<u8\> should always be valid bytecode. So it will also be more consistent with BytecodeCircuit and geth