### PR TITLE
prover: add replica feature

### DIFF
--- a/prover/src/bin/prover_rpcd.rs
+++ b/prover/src/bin/prover_rpcd.rs
@@ -1,223 +1,24 @@
 use env_logger::Env;
-use hyper::body::Buf;
-use hyper::body::HttpBody;
-use hyper::header::HeaderValue;
-use hyper::service::{make_service_fn, service_fn};
-use hyper::{Body, Method, Request, Response, Server, StatusCode};
 use std::env::var;
 
+use prover::server::serve;
 use prover::shared_state::SharedState;
-use prover::structs::*;
-
-/// sets default headers for CORS requests
-fn set_headers(headers: &mut hyper::HeaderMap, extended: bool) {
-    headers.insert("content-type", HeaderValue::from_static("application/json"));
-    headers.insert("access-control-allow-origin", HeaderValue::from_static("*"));
-
-    if extended {
-        headers.insert(
-            "access-control-allow-methods",
-            HeaderValue::from_static("post, get, options"),
-        );
-        headers.insert(
-            "access-control-allow-headers",
-            HeaderValue::from_static("origin, content-type, accept, x-requested-with"),
-        );
-        headers.insert("access-control-max-age", HeaderValue::from_static("300"));
-    }
-}
-
-async fn handle_request(
-    shared_state: SharedState,
-    req: Request<Body>,
-) -> Result<Response<Body>, hyper::Error> {
-    {
-        // limits the request size
-        const MAX_BODY_SIZE: u64 = 1 << 20;
-        let response_content_length = match req.body().size_hint().upper() {
-            Some(v) => v,
-            None => MAX_BODY_SIZE + 1,
-        };
-
-        if response_content_length > MAX_BODY_SIZE {
-            let mut resp = Response::new(Body::from("request too large"));
-            *resp.status_mut() = StatusCode::BAD_REQUEST;
-            return Ok(resp);
-        }
-    }
-
-    match (req.method(), req.uri().path()) {
-        (&Method::GET, "/health") => {
-            // nothing to report yet - healthy by default
-            let mut resp = Response::default();
-            set_headers(resp.headers_mut(), false);
-            Ok(resp)
-        }
-
-        // returns http 200 if busy else 204.
-        // can be used programmatically for e.g. shutting down the instance if no workis being
-        // done.
-        (&Method::GET, "/status") => {
-            let rw = shared_state.rw.lock().await;
-            let is_busy = rw.pending_tasks > 0 || rw.tasks.iter().any(|e| e.result.is_none());
-            drop(rw);
-
-            let mut resp = Response::default();
-            *resp.status_mut() = match is_busy {
-                false => StatusCode::NO_CONTENT,
-                true => StatusCode::OK,
-            };
-            set_headers(resp.headers_mut(), false);
-            Ok(resp)
-        }
-
-        // json-rpc
-        (&Method::POST, "/") => {
-            let body_bytes = hyper::body::aggregate(req.into_body())
-                .await
-                .unwrap()
-                .reader();
-            let json_req: Result<JsonRpcRequest<Vec<serde_json::Value>>, serde_json::Error> =
-                serde_json::from_reader(body_bytes);
-
-            if let Err(err) = json_req {
-                let payload = serde_json::to_vec(&JsonRpcResponseError {
-                    jsonrpc: "2.0".to_string(),
-                    id: 0.into(),
-                    error: JsonRpcError {
-                        // parser error
-                        code: -32700,
-                        message: err.to_string(),
-                    },
-                })
-                .unwrap();
-                let mut resp = Response::new(Body::from(payload));
-                set_headers(resp.headers_mut(), false);
-                return Ok(resp);
-            }
-
-            let json_req = json_req.unwrap();
-            let result: Result<serde_json::Value, String> =
-                handle_method(json_req.method.as_str(), &json_req.params, &shared_state).await;
-            let payload = match result {
-                Err(err) => {
-                    serde_json::to_vec(&JsonRpcResponseError {
-                        jsonrpc: "2.0".to_string(),
-                        id: json_req.id,
-                        error: JsonRpcError {
-                            // internal server error
-                            code: -32000,
-                            message: err,
-                        },
-                    })
-                }
-                Ok(val) => serde_json::to_vec(&JsonRpcResponse {
-                    jsonrpc: "2.0".to_string(),
-                    id: json_req.id,
-                    result: val,
-                }),
-            };
-            let mut resp = Response::new(Body::from(payload.unwrap()));
-            set_headers(resp.headers_mut(), false);
-            Ok(resp)
-        }
-
-        // serve CORS headers
-        (&Method::OPTIONS, "/") => {
-            let mut resp = Response::default();
-            set_headers(resp.headers_mut(), true);
-            Ok(resp)
-        }
-
-        // everything else
-        _ => {
-            let mut not_found = Response::default();
-            *not_found.status_mut() = StatusCode::NOT_FOUND;
-            Ok(not_found)
-        }
-    }
-}
-
-async fn handle_method(
-    method: &str,
-    params: &[serde_json::Value],
-    shared_state: &SharedState,
-) -> Result<serde_json::Value, String> {
-    match method {
-        // enqueues a task for computating proof for any given block
-        "proof" => {
-            let options = params.get(0).ok_or("expected struct ProofRequestOptions")?;
-            let options: ProofRequestOptions =
-                serde_json::from_value(options.to_owned()).map_err(|e| e.to_string())?;
-
-            shared_state
-                .get_or_enqueue(&options)
-                .await
-                .map(|result| serde_json::to_value(result?).map_err(|e| e.to_string()))
-                .unwrap_or_else(|| Ok(serde_json::Value::Null))
-        }
-        // TODO/TBD: add method to only return the witnesses for a block.
-        //  block table, tx table, etc...
-        //
-        // TODO: Add the abilitity to abort the current task.
-
-        // the following methods can be used to programmatically
-        // prune the `tasks` from the list.
-        "flushAll" => {
-            shared_state.rw.lock().await.tasks.clear();
-            Ok(serde_json::Value::Bool(true))
-        }
-        "flushPending" => {
-            shared_state
-                .rw
-                .lock()
-                .await
-                .tasks
-                .retain(|e| e.result.is_some());
-            Ok(serde_json::Value::Bool(true))
-        }
-        "flushCompleted" => {
-            shared_state
-                .rw
-                .lock()
-                .await
-                .tasks
-                .retain(|e| e.result.is_none());
-            Ok(serde_json::Value::Bool(true))
-        }
-        _ => Err("this method is not available".to_string()),
-    }
-}
 
 /// This command starts a http/json-rpc server and serves proof oriented
 /// methods. Required environment variables:
-/// - BIND - the interface address + port combination to accept connections on
-///   `[::]:1234`
-/// - PARAMS_PATH - a path to a file generated with the gen_params tool
+/// - BIND
+///   - the interface address + port combination to accept connections on
+///     `[::]:1234`
+/// - `PROVERD_LOOKUP`
+///   - environment variable in the form of HOSTNAME:PORT
 #[tokio::main]
 async fn main() {
     env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
 
-    let addr = var("BIND")
-        .expect("BIND env var")
-        .parse::<std::net::SocketAddr>()
-        .expect("valid socket address");
-    let shared_state = SharedState::new();
-
+    let shared_state = SharedState::default();
     {
         // start the http server
-        let ctx = shared_state.clone();
-        let h1 = tokio::spawn(async move {
-            let service = make_service_fn(move |_| {
-                let ctx = ctx.clone();
-                let service = service_fn(move |req| handle_request(ctx.clone(), req));
-
-                async move { Ok::<_, hyper::Error>(service) }
-            });
-            let server = Server::bind(&addr).serve(service);
-            log::info!("Listening on http://{}", addr);
-            server.await.expect("server should be serving");
-        });
+        let h1 = serve(&shared_state, &var("BIND").expect("BIND env var"));
 
         // starts the duty cycle loop
         let ctx = shared_state.clone();
@@ -227,14 +28,39 @@ async fn main() {
             .build()
             .unwrap();
         let h2 = rt.spawn(async move {
-            let ctx = ctx.clone();
             loop {
-                ctx.duty_cycle().await;
+                let ctx = ctx.clone();
+                // enclose this call to catch panics which may
+                // occur due to network services
+                let _ = tokio::spawn(async move {
+                    log::debug!("task: duty_cycle");
+                    ctx.duty_cycle().await;
+                })
+                .await;
+                tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
+            }
+        });
+
+        // this task loop makes sure to merge task results periodically
+        // even if this instance is busy with proving
+        let ctx = shared_state.clone();
+        let h3 = tokio::spawn(async move {
+            loop {
+                let ctx = ctx.clone();
+                // enclose this call to catch panics which may
+                // occur due to network services
+                let _ = tokio::spawn(async move {
+                    log::debug!("task: merge_tasks_from_peers");
+                    let _ = ctx.merge_tasks_from_peers().await;
+                })
+                .await;
                 tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
             }
         });
 
         // wait for all tasks
-        let _ = tokio::join!(h1, h2);
+        if tokio::try_join!(h1, h2, h3).is_err() {
+            panic!("unexpected task error");
+        }
     }
 }

--- a/prover/src/json_rpc.rs
+++ b/prover/src/json_rpc.rs
@@ -1,0 +1,88 @@
+/// Common utilities for json-rpc
+use hyper::body::Buf;
+use hyper::client::HttpConnector;
+use hyper::Body;
+use hyper::Request;
+use hyper::Uri;
+
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct JsonRpcError {
+    pub code: i32,
+    pub message: String,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct JsonRpcResponseError {
+    pub jsonrpc: String,
+    pub id: serde_json::Value,
+    pub error: JsonRpcError,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct JsonRpcResponse<T> {
+    pub jsonrpc: String,
+    pub id: serde_json::Value,
+    pub result: Option<T>,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct JsonRpcRequest<T: serde::Serialize> {
+    pub jsonrpc: String,
+    pub id: serde_json::Value,
+    pub method: String,
+    pub params: T,
+}
+
+/// Invokes a `json-rpc` request with a timeout of `timeout` ms for the network
+/// and deserialize part.
+pub async fn jsonrpc_request_client<T: Serialize + Send + Sync, R: DeserializeOwned>(
+    timeout: u64,
+    client: &hyper::Client<HttpConnector>,
+    uri: &Uri,
+    method: &str,
+    params: T,
+) -> Result<R, String> {
+    #[derive(Debug, serde::Deserialize)]
+    struct JsonRpcResponseInternal<T> {
+        result: Option<T>,
+        error: Option<JsonRpcError>,
+    }
+
+    let node_req = Request::post(uri);
+    let req_obj = JsonRpcRequest {
+        jsonrpc: "2.0".to_string(),
+        id: 0.into(),
+        method: method.to_string(),
+        params,
+    };
+
+    let node_req = node_req
+        .header(hyper::header::CONTENT_TYPE, "application/json")
+        .body(Body::from(serde_json::to_vec(&req_obj).unwrap()))
+        .unwrap();
+
+    log::debug!("jsonrpc_request_client: {} {}", uri, method);
+
+    let json = tokio::time::timeout(std::time::Duration::from_millis(timeout), async {
+        let resp = client.request(node_req).await.unwrap();
+        let body = hyper::body::aggregate(resp).await.unwrap();
+        let json: JsonRpcResponseInternal<R> = serde_json::from_reader(body.reader()).unwrap();
+
+        json
+    })
+    .await
+    .map_err(|e| e.to_string())?;
+
+    if json.error.is_some() {
+        return Err(json.error.unwrap().message);
+    }
+
+    if json.result.is_none() {
+        return Err("no result in response".to_string());
+    }
+
+    Ok(json.result.unwrap())
+}

--- a/prover/src/json_rpc.rs
+++ b/prover/src/json_rpc.rs
@@ -7,29 +7,30 @@ use hyper::Uri;
 
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+use serde::Deserialize;
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct JsonRpcError {
     pub code: i32,
     pub message: String,
 }
 
-#[derive(Debug, serde::Serialize)]
+#[derive(Debug, Serialize)]
 pub struct JsonRpcResponseError {
     pub jsonrpc: String,
     pub id: serde_json::Value,
     pub error: JsonRpcError,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct JsonRpcResponse<T> {
     pub jsonrpc: String,
     pub id: serde_json::Value,
     pub result: Option<T>,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
-pub struct JsonRpcRequest<T: serde::Serialize> {
+#[derive(Debug, Serialize, Deserialize)]
+pub struct JsonRpcRequest<T: Serialize> {
     pub jsonrpc: String,
     pub id: serde_json::Value,
     pub method: String,
@@ -45,7 +46,7 @@ pub async fn jsonrpc_request_client<T: Serialize + Send + Sync, R: DeserializeOw
     method: &str,
     params: T,
 ) -> Result<R, String> {
-    #[derive(Debug, serde::Deserialize)]
+    #[derive(Debug, Deserialize)]
     struct JsonRpcResponseInternal<T> {
         result: Option<T>,
         error: Option<JsonRpcError>,

--- a/prover/src/json_rpc.rs
+++ b/prover/src/json_rpc.rs
@@ -6,8 +6,8 @@ use hyper::Request;
 use hyper::Uri;
 
 use serde::de::DeserializeOwned;
-use serde::Serialize;
 use serde::Deserialize;
+use serde::Serialize;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct JsonRpcError {

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod compute_proof;
+pub mod json_rpc;
+pub mod server;
 pub mod shared_state;
 pub mod structs;

--- a/prover/src/server.rs
+++ b/prover/src/server.rs
@@ -1,0 +1,237 @@
+use hyper::body::Buf;
+use hyper::body::HttpBody;
+use hyper::header::HeaderValue;
+use hyper::service::{make_service_fn, service_fn};
+use hyper::{Body, Method, Request, Response, Server, StatusCode};
+
+use crate::json_rpc::*;
+use crate::shared_state::SharedState;
+use crate::structs::*;
+
+/// Starts the proverd json-rpc server.
+/// Note: the server may not immediately listening after returning the
+/// `JoinHandle`.
+pub fn serve(ctx: &SharedState, addr: &str) -> tokio::task::JoinHandle<()> {
+    let addr = addr
+        .parse::<std::net::SocketAddr>()
+        .expect("valid socket address");
+    let ctx = ctx.clone();
+    tokio::spawn(async move {
+        let service = make_service_fn(move |_| {
+            let ctx = ctx.clone();
+            let service = service_fn(move |req| handle_request(ctx.clone(), req));
+
+            async move { Ok::<_, hyper::Error>(service) }
+        });
+        let server = Server::bind(&addr).serve(service);
+        log::info!("Listening on http://{}", addr);
+        server.await.expect("server should be serving");
+    })
+}
+
+/// sets default headers for CORS requests
+fn set_headers(headers: &mut hyper::HeaderMap, extended: bool) {
+    headers.insert("content-type", HeaderValue::from_static("application/json"));
+    headers.insert("access-control-allow-origin", HeaderValue::from_static("*"));
+
+    if extended {
+        headers.insert(
+            "access-control-allow-methods",
+            HeaderValue::from_static("post, get, options"),
+        );
+        headers.insert(
+            "access-control-allow-headers",
+            HeaderValue::from_static("origin, content-type, accept, x-requested-with"),
+        );
+        headers.insert("access-control-max-age", HeaderValue::from_static("300"));
+    }
+}
+
+async fn handle_request(
+    shared_state: SharedState,
+    req: Request<Body>,
+) -> Result<Response<Body>, hyper::Error> {
+    {
+        // limits the request size
+        const MAX_BODY_SIZE: u64 = 1 << 20;
+        let response_content_length = match req.body().size_hint().upper() {
+            Some(v) => v,
+            None => MAX_BODY_SIZE + 1,
+        };
+
+        if response_content_length > MAX_BODY_SIZE {
+            let mut resp = Response::new(Body::from("request too large"));
+            *resp.status_mut() = StatusCode::BAD_REQUEST;
+            return Ok(resp);
+        }
+    }
+
+    match (req.method(), req.uri().path()) {
+        (&Method::GET, "/health") => {
+            // nothing to report yet - healthy by default
+            let mut resp = Response::default();
+            set_headers(resp.headers_mut(), false);
+            Ok(resp)
+        }
+
+        // returns http 200 if busy else 204.
+        // can be used programmatically for e.g. shutting down the instance if no workis being
+        // done.
+        (&Method::GET, "/status") => {
+            let rw = shared_state.rw.lock().await;
+            let is_busy = rw.pending.is_some() || rw.tasks.iter().any(|e| e.result.is_none());
+            drop(rw);
+
+            let mut resp = Response::default();
+            *resp.status_mut() = match is_busy {
+                false => StatusCode::NO_CONTENT,
+                true => StatusCode::OK,
+            };
+            set_headers(resp.headers_mut(), false);
+            Ok(resp)
+        }
+
+        // json-rpc
+        (&Method::POST, "/") => {
+            let body_bytes = hyper::body::aggregate(req.into_body())
+                .await
+                .unwrap()
+                .reader();
+            let json_req: Result<JsonRpcRequest<Vec<serde_json::Value>>, serde_json::Error> =
+                serde_json::from_reader(body_bytes);
+
+            if let Err(err) = json_req {
+                let payload = serde_json::to_vec(&JsonRpcResponseError {
+                    jsonrpc: "2.0".to_string(),
+                    id: 0.into(),
+                    error: JsonRpcError {
+                        // parser error
+                        code: -32700,
+                        message: err.to_string(),
+                    },
+                })
+                .unwrap();
+                let mut resp = Response::new(Body::from(payload));
+                set_headers(resp.headers_mut(), false);
+                return Ok(resp);
+            }
+
+            let json_req = json_req.unwrap();
+            let result: Result<serde_json::Value, String> =
+                handle_method(json_req.method.as_str(), &json_req.params, &shared_state).await;
+            let payload = match result {
+                Err(err) => {
+                    serde_json::to_vec(&JsonRpcResponseError {
+                        jsonrpc: "2.0".to_string(),
+                        id: json_req.id,
+                        error: JsonRpcError {
+                            // internal server error
+                            code: -32000,
+                            message: err,
+                        },
+                    })
+                }
+                Ok(val) => serde_json::to_vec(&JsonRpcResponse {
+                    jsonrpc: "2.0".to_string(),
+                    id: json_req.id,
+                    result: Some(val),
+                }),
+            };
+            let mut resp = Response::new(Body::from(payload.unwrap()));
+            set_headers(resp.headers_mut(), false);
+            Ok(resp)
+        }
+
+        // serve CORS headers
+        (&Method::OPTIONS, "/") => {
+            let mut resp = Response::default();
+            set_headers(resp.headers_mut(), true);
+            Ok(resp)
+        }
+
+        // everything else
+        _ => {
+            let mut not_found = Response::default();
+            *not_found.status_mut() = StatusCode::NOT_FOUND;
+            Ok(not_found)
+        }
+    }
+}
+
+async fn handle_method(
+    method: &str,
+    params: &[serde_json::Value],
+    shared_state: &SharedState,
+) -> Result<serde_json::Value, String> {
+    match method {
+        // enqueues a task for computating proof for any given block
+        "proof" => {
+            let options = params.get(0).ok_or("expected struct ProofRequestOptions")?;
+            let options: ProofRequestOptions =
+                serde_json::from_value(options.to_owned()).map_err(|e| e.to_string())?;
+
+            match shared_state.get_or_enqueue(&options).await {
+                // No error
+                None => Ok(serde_json::Value::Null),
+                Some(result) => {
+                    if let Err(err) = result {
+                        return Err(err);
+                    }
+
+                    Ok(serde_json::to_value(result.unwrap()).unwrap())
+                }
+            }
+        }
+        // TODO: Add the abilitity to abort the current task.
+
+        // returns `NodeInformation`
+        // used internally for p2p communication
+        "info" => Ok(serde_json::to_value(shared_state.get_node_information().await).unwrap()),
+
+        // returns `NodeStatus`
+        // used internally for p2p communication
+        "status" => {
+            let mut pending_task = None;
+            let rw = shared_state.rw.lock().await;
+
+            if let Some(val) = &rw.pending {
+                pending_task = Some(val.clone());
+            }
+
+            let ret = NodeStatus {
+                id: shared_state.ro.node_id.clone(),
+                task: pending_task,
+                obtained: rw.obtained,
+            };
+            drop(rw);
+
+            Ok(serde_json::to_value(ret).unwrap())
+        }
+
+        // the following methods can be used to programmatically
+        // prune the `tasks` from the list.
+        "flushAll" => {
+            shared_state.rw.lock().await.tasks.clear();
+            Ok(serde_json::Value::Bool(true))
+        }
+        "flushPending" => {
+            shared_state
+                .rw
+                .lock()
+                .await
+                .tasks
+                .retain(|e| e.result.is_some());
+            Ok(serde_json::Value::Bool(true))
+        }
+        "flushCompleted" => {
+            shared_state
+                .rw
+                .lock()
+                .await
+                .tasks
+                .retain(|e| e.result.is_none());
+            Ok(serde_json::Value::Bool(true))
+        }
+        _ => Err("this method is not available".to_string()),
+    }
+}

--- a/prover/src/server.rs
+++ b/prover/src/server.rs
@@ -170,17 +170,11 @@ async fn handle_method(
             let options: ProofRequestOptions =
                 serde_json::from_value(options.to_owned()).map_err(|e| e.to_string())?;
 
-            match shared_state.get_or_enqueue(&options).await {
-                // No error
-                None => Ok(serde_json::Value::Null),
-                Some(result) => {
-                    if let Err(err) = result {
-                        return Err(err);
-                    }
-
-                    Ok(serde_json::to_value(result.unwrap()).unwrap())
-                }
-            }
+            shared_state
+                .get_or_enqueue(&options)
+                .await
+                .map(|result| serde_json::to_value(result?).map_err(|e| e.to_string()))
+                .unwrap_or_else(|| Ok(serde_json::Value::Null))
         }
         // TODO: Add the abilitity to abort the current task.
 

--- a/prover/src/shared_state.rs
+++ b/prover/src/shared_state.rs
@@ -2,38 +2,56 @@ use halo2_proofs::pairing::bn256::G1Affine;
 use halo2_proofs::poly::commitment::Params;
 
 use std::collections::HashMap;
+use std::env::var;
+use std::fmt::Write;
 use std::fs::File;
+use std::net::ToSocketAddrs;
 use std::sync::Arc;
 
+use hyper::Uri;
+use rand::{thread_rng, Rng};
 use tokio::sync::Mutex;
 
 use crate::compute_proof::compute_proof;
-use crate::structs::{ProofRequestOptions, Proofs};
+use crate::json_rpc::jsonrpc_request_client;
+use crate::structs::*;
 
-#[derive(Debug, Clone)]
-pub struct ProofRequest {
-    pub options: ProofRequestOptions,
-    pub result: Option<Result<Proofs, String>>,
+#[derive(Clone)]
+pub struct RoState {
+    // a unique identifier
+    pub node_id: String,
+    // a `HOSTNAME:PORT` conformant string that will be used for DNS service discovery of other
+    // nodes
+    pub node_lookup: String,
 }
 
 pub struct RwState {
     pub tasks: Vec<ProofRequest>,
-    pub pending_tasks: u32,
     pub params_cache: HashMap<String, Arc<Params<G1Affine>>>,
+    /// The current active task this instance wants to obtain or is working on.
+    pub pending: Option<ProofRequestOptions>,
+    /// `true` if this instance started working on `pending`
+    pub obtained: bool,
 }
 
 #[derive(Clone)]
 pub struct SharedState {
+    pub ro: RoState,
     pub rw: Arc<Mutex<RwState>>,
 }
 
 impl SharedState {
-    pub fn new() -> SharedState {
+    pub fn new(node_id: String, node_lookup: String) -> SharedState {
         Self {
+            ro: RoState {
+                node_id,
+                node_lookup,
+            },
             rw: Arc::new(Mutex::new(RwState {
                 tasks: Vec::new(),
-                pending_tasks: 0,
                 params_cache: HashMap::new(),
+                pending: None,
+                obtained: false,
             })),
         }
     }
@@ -59,6 +77,7 @@ impl SharedState {
                     log::debug!("retrying: {:#?}", task);
                     // will be a candidate in `duty_cycle` again
                     task.result = None;
+                    task.edition += 1;
                 } else {
                     log::debug!("completed: {:#?}", task);
                     return task.result.clone();
@@ -72,6 +91,7 @@ impl SharedState {
             let task = ProofRequest {
                 options: options.clone(),
                 result: None,
+                edition: 0,
             };
             log::debug!("enqueue: {:#?}", task);
             rw.tasks.push(task);
@@ -85,45 +105,81 @@ impl SharedState {
     /// - starting a new task
     /// Blocks until completion but releases the lock of `self.rw` in between.
     pub async fn duty_cycle(&self) {
-        let mut rw = self.rw.lock().await;
-
-        if rw.pending_tasks > 0 {
-            // already computing
-            // TODO: can spawn multiple tasks if ever required
+        // fix the 'world' view
+        if let Err(err) = self.merge_tasks_from_peers().await {
+            log::error!("merge_tasks_from_peers failed with: {}", err);
             return;
         }
 
-        // find a pending task
-        let pending_task = rw.tasks.iter().find(|&e| e.result.is_none());
-        if pending_task.is_none() {
-            // nothing to do
+        let rw = self.rw.lock().await;
+        if rw.pending.is_some() || rw.obtained {
+            // already computing
             return;
+        }
+        // find a pending task
+        let tasks: Vec<ProofRequestOptions> = rw
+            .tasks
+            .iter()
+            .filter(|&e| e.result.is_none())
+            .map(|e| e.options.clone())
+            .collect();
+        drop(rw);
+
+        for task in tasks {
+            // signals that this node wants to process this task
+            log::debug!("trying to obtain {:#?}", task);
+            self.rw.lock().await.pending = Some(task);
+
+            // notify other peers
+            // wrap the object because it's important to clear `pending` on error
+            {
+                let self_copy = self.clone();
+                let obtain_task =
+                    tokio::spawn(
+                        async move { self_copy.obtain_task().await.expect("obtain_task") },
+                    )
+                    .await;
+
+                if obtain_task.is_err() || !obtain_task.unwrap() {
+                    self.rw.lock().await.pending = None;
+                    log::debug!("failed to obtain task");
+                    continue;
+                }
+
+                // won the race
+                self.rw.lock().await.obtained = true;
+                break;
+            }
         }
 
         // needs to be cloned because of long running tasks and
         // the possibility that the task gets removed in the meantime
-        let mut pending_task = pending_task.unwrap().clone();
-        {
-            rw.pending_tasks += 1;
-            log::info!("compute_proof: {:#?}", pending_task);
-            drop(rw);
+        let task_options = self.rw.lock().await.pending.clone();
+        if task_options.is_none() {
+            // nothing to do
+            return;
         }
+
+        // succesfully obtained the task
+        let task_options = task_options.unwrap();
+        log::info!("compute_proof: {:#?}", task_options);
 
         // Note: this catches any panics for the task itself but will not help in the
         // situation when the process get itself OOM killed, stack overflows etc.
         // This could be avoided by spawning a subprocess for the proof computation
         // instead.
 
-        let pending_task_copy = pending_task.clone();
+        // spawn a task to catch panics
+        let task_options_copy = task_options.clone();
         let self_copy = self.clone();
         let task_result: Result<Result<Proofs, String>, tokio::task::JoinError> =
             tokio::spawn(async move {
                 // lazily load the file and cache it
-                let param = self_copy.load_param(&pending_task_copy.options.param).await;
+                let param = self_copy.load_param(&task_options_copy.param).await;
                 let res = compute_proof(
                     param.as_ref(),
-                    &pending_task_copy.options.block,
-                    &pending_task_copy.options.rpc,
+                    &task_options_copy.block,
+                    &task_options_copy.rpc,
                 )
                 .await;
 
@@ -160,21 +216,67 @@ impl SharedState {
             log::info!("task_result: {:#?}", task_result);
 
             let mut rw = self.rw.lock().await;
-            rw.pending_tasks -= 1;
-
-            let task = rw
-                .tasks
-                .iter_mut()
-                .find(|e| e.options == pending_task.options);
+            // clear fields
+            rw.pending = None;
+            rw.obtained = false;
+            // insert task result
+            let task = rw.tasks.iter_mut().find(|e| e.options == task_options);
             if let Some(task) = task {
                 // found our task, update result
                 task.result = Some(task_result);
+                task.edition += 1;
             } else {
-                // task was already removed in the meantime, insert it again
-                pending_task.result = Some(task_result);
-                rw.tasks.push(pending_task);
+                // task was already removed in the meantime,
+                // assume it's obsolete and forget about it
+                log::info!(
+                    "task was already removed, ignoring result {:#?}",
+                    task_options
+                );
             }
         }
+    }
+
+    /// Returns `node_id` and `tasks` for this instance.
+    /// Normally used for the rpc api.
+    pub async fn get_node_information(&self) -> NodeInformation {
+        NodeInformation {
+            id: self.ro.node_id.clone(),
+            tasks: self.rw.lock().await.tasks.clone(),
+        }
+    }
+
+    /// Pulls `NodeInformation` from all other peers and
+    /// merges missing or updated tasks from these peers to
+    /// preserve information in case individual nodes are going to be
+    /// terminated.
+    ///
+    /// Always returns `true` otherwise returns with error.
+    pub async fn merge_tasks_from_peers(&self) -> Result<bool, String> {
+        const LOG_TAG: &str = "merge_tasks_from_peers:";
+
+        let hyper_client = hyper::Client::new();
+        let addrs_iter = self
+            .ro
+            .node_lookup
+            .to_socket_addrs()
+            .map_err(|e| e.to_string())?;
+
+        for addr in addrs_iter {
+            let uri = Uri::try_from(format!("http://{}", addr)).map_err(|e| e.to_string())?;
+            let peer: NodeInformation =
+                jsonrpc_request_client(5000, &hyper_client, &uri, "info", serde_json::json!([]))
+                    .await?;
+
+            if peer.id == self.ro.node_id {
+                log::debug!("{} skipping self({})", LOG_TAG, peer.id);
+                continue;
+            }
+
+            log::debug!("{} merging with peer({})", LOG_TAG, peer.id);
+            self.merge_tasks(&peer).await;
+        }
+
+        Ok(true)
     }
 
     async fn load_param(&self, params_path: &str) -> Arc<Params<G1Affine>> {
@@ -200,10 +302,105 @@ impl SharedState {
 
         rw.params_cache.get(params_path).unwrap().clone()
     }
+
+    async fn merge_tasks(&self, node_info: &NodeInformation) {
+        const LOG_TAG: &str = "merge_tasks:";
+        let mut rw = self.rw.lock().await;
+
+        for peer_task in &node_info.tasks {
+            let maybe_task = rw.tasks.iter_mut().find(|e| e.options == peer_task.options);
+
+            if let Some(existent_task) = maybe_task {
+                if existent_task.edition >= peer_task.edition {
+                    // fast case
+                    log::debug!("{} up to date {:#?}", LOG_TAG, existent_task);
+                    continue;
+                }
+
+                // update result, edition
+                existent_task.edition = peer_task.edition;
+                existent_task.result = peer_task.result.clone();
+                log::debug!("{} updated {:#?}", LOG_TAG, existent_task);
+            } else {
+                // copy task
+                rw.tasks.push(peer_task.clone());
+                log::debug!("{} new task {:#?}", LOG_TAG, peer_task);
+            }
+        }
+    }
+
+    /// Tries to obtain `self.rw.pending` by querying all other peers
+    /// about their current task item that resolves to either
+    /// winning or losing the task depending on the algorithm.
+    ///
+    /// Expects `self.rw.pending` to be not `None`
+    async fn obtain_task(&self) -> Result<bool, String> {
+        const LOG_TAG: &str = "obtain_task:";
+
+        let task_options = self
+            .rw
+            .lock()
+            .await
+            .pending
+            .as_ref()
+            .expect("pending task")
+            .clone();
+
+        // resolve all other nodes for this service
+        let hyper_client = hyper::Client::new();
+        let addrs_iter = self
+            .ro
+            .node_lookup
+            .to_socket_addrs()
+            .map_err(|e| e.to_string())?;
+        for addr in addrs_iter {
+            let uri = Uri::try_from(format!("http://{}", addr)).map_err(|e| e.to_string())?;
+            let peer: NodeStatus =
+                jsonrpc_request_client(5000, &hyper_client, &uri, "status", serde_json::json!([]))
+                    .await?;
+
+            if peer.id == self.ro.node_id {
+                log::debug!("{} skipping self({})", LOG_TAG, peer.id);
+                continue;
+            }
+
+            if let Some(peer_task) = peer.task {
+                if peer_task == task_options {
+                    // a slight chance to 'win' the task
+                    if !peer.obtained && peer.id > self.ro.node_id {
+                        log::debug!("{} won task against {}", LOG_TAG, peer.id);
+                        // continue the race against the remaining peers
+                        continue;
+                    }
+
+                    log::debug!("{} lost task against {}", LOG_TAG, peer.id);
+                    // early return
+                    return Ok(false);
+                }
+            }
+        }
+
+        // default
+        Ok(true)
+    }
 }
 
 impl Default for SharedState {
+    /// The default setup a random `node_id` and expects a
+    /// - `PROVERD_LOOKUP`
+    ///   - environment variable in the form of HOSTNAME:PORT
     fn default() -> Self {
-        Self::new()
+        // derive a (sufficiently large) random worker id
+        const N: usize = 16;
+        let mut arr = [0u8; N];
+        thread_rng().fill(&mut arr[..]);
+        let mut node_id = String::with_capacity(N * 2);
+        for byte in arr {
+            write!(node_id, "{:02x}", byte).unwrap();
+        }
+
+        let addr: String = var("PROVERD_LOOKUP").expect("PROVERD_LOOKUP env var");
+
+        Self::new(node_id, addr)
     }
 }

--- a/prover/src/structs.rs
+++ b/prover/src/structs.rs
@@ -1,38 +1,21 @@
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct Proofs {
     pub state_proof: eth_types::Bytes,
     pub evm_proof: eth_types::Bytes,
     pub duration: u64,
 }
 
-#[derive(Debug, serde::Serialize)]
-pub struct JsonRpcError {
-    pub code: i32,
-    pub message: String,
+impl std::fmt::Debug for Proofs {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Proofs")
+            .field("state_proof", &format!("{}", &self.state_proof))
+            .field("evm_proof", &format!("{}", &self.evm_proof))
+            .field("duration", &self.duration)
+            .finish()
+    }
 }
 
-#[derive(Debug, serde::Serialize)]
-pub struct JsonRpcResponseError {
-    pub jsonrpc: String,
-    pub id: serde_json::Value,
-    pub error: JsonRpcError,
-}
-
-#[derive(Debug, serde::Serialize)]
-pub struct JsonRpcResponse<T: serde::Serialize> {
-    pub jsonrpc: String,
-    pub id: serde_json::Value,
-    pub result: T,
-}
-
-#[derive(Debug, serde::Deserialize)]
-pub struct JsonRpcRequest<T: serde::Serialize> {
-    pub id: serde_json::Value,
-    pub method: String,
-    pub params: T,
-}
-
-#[derive(Debug, Default, Clone, serde::Deserialize)]
+#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ProofRequestOptions {
     /// the block number
     pub block: u64,
@@ -48,4 +31,27 @@ impl PartialEq for ProofRequestOptions {
     fn eq(&self, other: &Self) -> bool {
         self.block == other.block && self.rpc == other.rpc && self.param == other.param
     }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ProofRequest {
+    pub options: ProofRequestOptions,
+    pub result: Option<Result<Proofs, String>>,
+    /// A counter to keep track of changes of the `result` field
+    pub edition: u64,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct NodeInformation {
+    pub id: String,
+    pub tasks: Vec<ProofRequest>,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct NodeStatus {
+    pub id: String,
+    /// The current active task this instance wants to obtain or is working on.
+    pub task: Option<ProofRequestOptions>,
+    /// `true` if this instance started working on `task`
+    pub obtained: bool,
 }

--- a/prover/tests/proverd.rs
+++ b/prover/tests/proverd.rs
@@ -1,0 +1,69 @@
+use tokio::time::{sleep, Duration};
+
+use prover::server::serve;
+use prover::shared_state::SharedState;
+use prover::structs::ProofRequestOptions;
+
+fn init_logger() {
+    let _ = env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("debug"))
+        .is_test(true)
+        .try_init();
+}
+
+#[tokio::test]
+async fn proverd_simple_signaling() {
+    init_logger();
+
+    let node_a = SharedState::new("a".to_string(), "127.0.0.1:11111".to_string());
+    let node_b = SharedState::new("b".to_string(), "127.0.0.1:11112".to_string());
+    // start http servers
+    {
+        let _ = serve(&node_a, &node_b.ro.node_lookup);
+        let _ = serve(&node_b, &node_a.ro.node_lookup);
+    }
+
+    // wait a bit for the rpc server to start
+    sleep(Duration::from_millis(300)).await;
+
+    let proof_a = ProofRequestOptions {
+        block: 1,
+        param: "/none".to_string(),
+        retry: false,
+        rpc: "http://localhost:1111".to_string(),
+    };
+    let proof_b = ProofRequestOptions {
+        block: 2,
+        param: "/none".to_string(),
+        retry: false,
+        rpc: "http://localhost:1111".to_string(),
+    };
+
+    // enqueue tasks
+    assert!(node_a.get_or_enqueue(&proof_a).await.is_none());
+    assert!(node_b.get_or_enqueue(&proof_b).await.is_none());
+
+    // start work on node_a
+    node_a.duty_cycle().await;
+    assert!(node_a.get_or_enqueue(&proof_a).await.is_some());
+
+    // node_b didn't sync yet
+    assert!(!node_b.get_or_enqueue(&proof_a).await.is_some());
+    // sync, do work
+    let _ = node_b.merge_tasks_from_peers().await;
+    // check again
+    assert!(node_b.get_or_enqueue(&proof_a).await.is_some());
+
+    // no result yet
+    assert!(!node_b.get_or_enqueue(&proof_b).await.is_some());
+    // sync, do work
+    node_b.duty_cycle().await;
+    // check again
+    assert!(node_b.get_or_enqueue(&proof_b).await.is_some());
+
+    // node_a didn't sync yet
+    assert!(!node_a.get_or_enqueue(&proof_b).await.is_some());
+    // sync node_a
+    let _ = node_a.merge_tasks_from_peers().await;
+    // check again
+    assert!(node_a.get_or_enqueue(&proof_b).await.is_some());
+}

--- a/prover/tests/proverd.rs
+++ b/prover/tests/proverd.rs
@@ -47,21 +47,21 @@ async fn proverd_simple_signaling() {
     assert!(node_a.get_or_enqueue(&proof_a).await.is_some());
 
     // node_b didn't sync yet
-    assert!(!node_b.get_or_enqueue(&proof_a).await.is_some());
+    assert!(node_b.get_or_enqueue(&proof_a).await.is_none());
     // sync, do work
     let _ = node_b.merge_tasks_from_peers().await;
     // check again
     assert!(node_b.get_or_enqueue(&proof_a).await.is_some());
 
     // no result yet
-    assert!(!node_b.get_or_enqueue(&proof_b).await.is_some());
+    assert!(node_b.get_or_enqueue(&proof_b).await.is_none());
     // sync, do work
     node_b.duty_cycle().await;
     // check again
     assert!(node_b.get_or_enqueue(&proof_b).await.is_some());
 
     // node_a didn't sync yet
-    assert!(!node_a.get_or_enqueue(&proof_b).await.is_some());
+    assert!(node_a.get_or_enqueue(&proof_b).await.is_none());
     // sync node_a
     let _ = node_a.merge_tasks_from_peers().await;
     // check again


### PR DESCRIPTION
This allows the `prover_rpcd` to scale horizontally by increasing the number of replicas with orchestrator tools
that support service discovery via DNS.

- each node/peer will try to obtain pending tasks
- simple algorithm to aid races to the same task
- redundant, because all tasks are replicated by each peer in case individual nodes are terminated