### PR TITLE
Ci self hosted

### DIFF
--- a/.github/ciChecksScripts/wakeUpRunner.sh
+++ b/.github/ciChecksScripts/wakeUpRunner.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+profile="cirunner"
+runner_vpc_id="vpc-08ac0db4d8a7cce9e"
+
+# Get runner status
+runner=$(aws ec2 describe-instances --profile $profile --filters Name=tag:Name,Values=[ci-checks-runner] Name=network-interface.vpc-id,Values=[$runner_vpc_id] --query "Reservations[*].Instances[*][InstanceId]" --output text | xargs)
+runner_status=$(aws ec2 describe-instances --profile $profile --instance-ids $runner --query "Reservations[*].Instances[*].State.[Name]" --output text)
+
+while true; do
+    if [ $runner_status = "stopped" ]; then
+        aws ec2 start-instances --profile $profile --instance-ids $runner
+        exit 0
+    elif [ $runner_status = "running" ]; then
+        sleep 120
+        runner_status=$(aws ec2 describe-instances --profile $profile --instance-ids $runner --query "Reservations[*].Instances[*].State.[Name]" --output text)
+        if [ $runner_status = "running" ]; then
+            exit 0
+        fi
+    else
+        sleep 30
+    fi
+done

--- a/.github/workflows/ProverBenchFromHalo2.yml
+++ b/.github/workflows/ProverBenchFromHalo2.yml
@@ -16,7 +16,7 @@ on:
         type: string
 jobs:
   Exec-ProverBench-on-halo2-PR:
-    runs-on: self-hosted
+    runs-on: pse-runner
     env:
       GH_USER: ${{ github.event.inputs.ghuser }}
       HALO2PR: ${{ github.event.inputs.halo2pr }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,80 @@ on:
 ## `actions-rs/toolchain@v1` overwrite set to false so that
 ## `rust-toolchain` is always used and the only source of truth.
 
-jobs:
-  test:
-    if: github.event.pull_request.draft == false
+# If you forked this repo, you can remove concurrency
+concurrency: 
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: false
 
-    name: Test on ${{ matrix.os }}
+jobs:
+
+  wakeuprunner:
+    if: github.event.pull_request.draft == false && github.repository == 'privacy-scaling-explorations/zkevm-circuits'
+
+    name: Wake up self-hosted runner
+    runs-on: pse-runner
+
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          .github/ciChecksScripts/wakeUpRunner.sh
+
+  test:
+    if: github.event.pull_request.draft == false && github.repository == 'privacy-scaling-explorations/zkevm-circuits'
+
+    needs: [wakeuprunner]
+    name: Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # We don't need to test across multiple platforms yet
+        # os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ci-checks-runner]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          override: false
+      - name: Setup golang
+        uses: actions/setup-go@v3
+        with:
+          go-version: ~1.18
+      # Go cache for building geth-utils
+      - name: Go cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Cargo cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Run light tests # light tests are run in parallel
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose --release --all --all-features --exclude integration-tests --exclude circuit-benchmarks
+      - name: Run heavy tests # heavy tests are run serially to avoid OOM
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose --release --all --all-features --exclude integration-tests --exclude circuit-benchmarks serial_ -- --ignored --test-threads 1
+
+  test_forks:
+    if: github.event.pull_request.draft == false && github.repository != 'privacy-scaling-explorations/zkevm-circuits'
+
+    name: Test_forks
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -27,6 +96,10 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           override: false
+      - name: Setup golang
+        uses: actions/setup-go@v3
+        with:
+          go-version: ~1.18
       # Go cache for building geth-utils
       - name: Go cache
         uses: actions/cache@v3

--- a/.github/workflows/gh-actions-prover-benches.yml
+++ b/.github/workflows/gh-actions-prover-benches.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   Prover_benchmarking_Automation:
     if: contains(github.event.label.name, 'benchmarks')
-    runs-on: self-hosted
+    runs-on: pse-runner
     env:
       PR_NUMBER: ${{ github.event.number }}
 


### PR DESCRIPTION
Modified "CI checks" workflow to run specific heavy job(s), on a new self-hosted runner.
Forks, will still be executed on GH runners.
Concurrency was introduced to avoid parallel runs against the self-hosted runner. 

Note:
All self hosted runners have by default 3 tags that cannot be removed.
Since we introduced a new runner in this repo, we changed the tags in two workflows that already use a self-hosted runner to avoid conflicts.