### PR TITLE
Fix `CALL` to calculate `is_empty_account` correctly

### DIFF
--- a/bus-mapping/src/evm/opcodes/call.rs
+++ b/bus-mapping/src/evm/opcodes/call.rs
@@ -101,7 +101,7 @@ impl Opcode for Call {
         )?;
 
         let (_, callee_account) = state.sdb.get_account(&call.address);
-        let is_account_empty = callee_account.is_empty();
+        let is_empty_account = callee_account.is_empty();
         let callee_nonce = callee_account.nonce;
         let callee_code_hash = callee_account.code_hash;
         for (field, value) in [
@@ -128,7 +128,7 @@ impl Opcode for Call {
             GasCost::COLD_ACCOUNT_ACCESS.as_u64()
         } + if has_value {
             GasCost::CALL_WITH_VALUE.as_u64()
-                + if is_account_empty {
+                + if is_empty_account {
                     GasCost::NEW_ACCOUNT.as_u64()
                 } else {
                     0


### PR DESCRIPTION
Resovles #636.

It turns out to be a hidden implementation bug which can only be triggered by specific setting (account with code but with zero nonce), which should never happen after [EIP-161](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md)).