### PR TITLE
reconstruct access list in bus-mapping

### DIFF
--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -15,6 +15,7 @@ use eth_types::{
 use keccak256::EMPTY_HASH;
 use log::warn;
 
+mod balance;
 mod call;
 mod calldatacopy;
 mod calldataload;
@@ -28,6 +29,7 @@ mod create;
 mod dup;
 mod extcodecopy;
 mod extcodehash;
+mod extcodesize;
 mod gasprice;
 mod logs;
 mod mload;
@@ -47,6 +49,7 @@ mod swap;
 #[cfg(test)]
 mod memory_expansion_test;
 
+use balance::Balance;
 use call::Call;
 use calldatacopy::Calldatacopy;
 use calldataload::Calldataload;
@@ -59,6 +62,7 @@ use create::DummyCreate;
 use dup::Dup;
 use extcodecopy::Extcodecopy;
 use extcodehash::Extcodehash;
+use extcodesize::Extcodesize;
 use gasprice::GasPrice;
 use logs::Log;
 use mload::Mload;
@@ -140,7 +144,7 @@ fn fn_gen_associated_ops(opcode_id: &OpcodeId) -> FnGenAssociatedOps {
         OpcodeId::SAR => StackOnlyOpcode::<2, 1>::gen_associated_ops,
         OpcodeId::SHA3 => Sha3::gen_associated_ops,
         OpcodeId::ADDRESS => StackOnlyOpcode::<0, 1>::gen_associated_ops,
-        OpcodeId::BALANCE => StackOnlyOpcode::<1, 1>::gen_associated_ops,
+        OpcodeId::BALANCE => Balance::gen_associated_ops,
         OpcodeId::ORIGIN => Origin::gen_associated_ops,
         OpcodeId::CALLER => Caller::gen_associated_ops,
         OpcodeId::CALLVALUE => Callvalue::gen_associated_ops,
@@ -150,7 +154,7 @@ fn fn_gen_associated_ops(opcode_id: &OpcodeId) -> FnGenAssociatedOps {
         OpcodeId::GASPRICE => GasPrice::gen_associated_ops,
         OpcodeId::CODECOPY => Codecopy::gen_associated_ops,
         OpcodeId::CODESIZE => Codesize::gen_associated_ops,
-        OpcodeId::EXTCODESIZE => StackOnlyOpcode::<1, 1>::gen_associated_ops,
+        OpcodeId::EXTCODESIZE => Extcodesize::gen_associated_ops,
         OpcodeId::EXTCODECOPY => Extcodecopy::gen_associated_ops,
         OpcodeId::RETURNDATASIZE => StackOnlyOpcode::<0, 1>::gen_associated_ops,
         OpcodeId::RETURNDATACOPY => Returndatacopy::gen_associated_ops,
@@ -225,9 +229,13 @@ fn fn_gen_associated_ops(opcode_id: &OpcodeId) -> FnGenAssociatedOps {
             warn!("Using dummy gen_call_ops for opcode {:?}", opcode_id);
             DummyCall::gen_associated_ops
         }
-        OpcodeId::CREATE | OpcodeId::CREATE2 => {
+        OpcodeId::CREATE => {
             warn!("Using dummy gen_create_ops for opcode {:?}", opcode_id);
-            DummyCreate::gen_associated_ops
+            DummyCreate::<false>::gen_associated_ops
+        }
+        OpcodeId::CREATE2 => {
+            warn!("Using dummy gen_create_ops for opcode {:?}", opcode_id);
+            DummyCreate::<true>::gen_associated_ops
         }
         _ => {
             warn!("Using dummy gen_associated_ops for opcode {:?}", opcode_id);

--- a/bus-mapping/src/evm/opcodes/balance.rs
+++ b/bus-mapping/src/evm/opcodes/balance.rs
@@ -1,0 +1,44 @@
+use crate::circuit_input_builder::{CircuitInputStateRef, ExecStep};
+use crate::evm::Opcode;
+use crate::operation::{TxAccessListAccountOp, RW};
+use crate::Error;
+use eth_types::{GethExecStep, ToAddress, ToWord};
+
+#[derive(Debug, Copy, Clone)]
+pub(crate) struct Balance;
+
+impl Opcode for Balance {
+    fn gen_associated_ops(
+        state: &mut CircuitInputStateRef,
+        geth_steps: &[GethExecStep],
+    ) -> Result<Vec<ExecStep>, Error> {
+        let geth_step = &geth_steps[0];
+        let mut exec_step = state.new_step(geth_step)?;
+
+        let address = geth_steps[0].stack.last()?.to_address();
+        state.stack_read(
+            &mut exec_step,
+            geth_step.stack.last_filled(),
+            address.to_word(),
+        )?;
+        let is_warm = state.sdb.check_account_in_access_list(&address);
+        state.push_op_reversible(
+            &mut exec_step,
+            RW::WRITE,
+            TxAccessListAccountOp {
+                tx_id: state.tx_ctx.id(),
+                address,
+                is_warm: true,
+                is_warm_prev: is_warm,
+            },
+        )?;
+
+        state.stack_write(
+            &mut exec_step,
+            geth_steps[1].stack.nth_last_filled(0),
+            geth_steps[1].stack.nth_last(0)?,
+        )?;
+
+        Ok(vec![exec_step])
+    }
+}

--- a/bus-mapping/src/evm/opcodes/balance.rs
+++ b/bus-mapping/src/evm/opcodes/balance.rs
@@ -12,6 +12,7 @@ impl Opcode for Balance {
         state: &mut CircuitInputStateRef,
         geth_steps: &[GethExecStep],
     ) -> Result<Vec<ExecStep>, Error> {
+        // TODO: finish this, only access list part is done
         let geth_step = &geth_steps[0];
         let mut exec_step = state.new_step(geth_step)?;
 

--- a/bus-mapping/src/evm/opcodes/create.rs
+++ b/bus-mapping/src/evm/opcodes/create.rs
@@ -6,94 +6,110 @@ use eth_types::GethExecStep;
 use keccak256::EMPTY_HASH;
 
 #[derive(Debug, Copy, Clone)]
-pub struct DummyCreate;
+pub struct DummyCreate<const IS_CREATE2: bool>;
 
-impl Opcode for DummyCreate {
+impl<const IS_CREATE2: bool> Opcode for DummyCreate<IS_CREATE2> {
     fn gen_associated_ops(
         state: &mut CircuitInputStateRef,
         geth_steps: &[GethExecStep],
     ) -> Result<Vec<ExecStep>, Error> {
         // TODO: replace dummy create here
-        dummy_gen_create_ops(state, geth_steps)
-    }
-}
+        let geth_step = &geth_steps[0];
 
-fn dummy_gen_create_ops(
-    state: &mut CircuitInputStateRef,
-    geth_steps: &[GethExecStep],
-) -> Result<Vec<ExecStep>, Error> {
-    let geth_step = &geth_steps[0];
+        let offset = geth_step.stack.nth_last(1)?.as_usize();
+        let length = geth_step.stack.nth_last(2)?.as_usize();
 
-    let offset = geth_step.stack.nth_last(1)?.as_usize();
-    let length = geth_step.stack.nth_last(2)?.as_usize();
+        if length != 0 {
+            state
+                .call_ctx_mut()?
+                .memory
+                .extend_at_least(offset + length);
+        }
 
-    if length != 0 {
-        state
-            .call_ctx_mut()?
-            .memory
-            .extend_at_least(offset + length);
-    }
+        let mut exec_step = state.new_step(geth_step)?;
 
-    let mut exec_step = state.new_step(geth_step)?;
+        let tx_id = state.tx_ctx.id();
+        let call = state.parse_call(geth_step)?;
 
-    let tx_id = state.tx_ctx.id();
-    let call = state.parse_call(geth_step)?;
+        // Quote from [EIP-2929](https://eips.ethereum.org/EIPS/eip-2929)
+        // > When a CREATE or CREATE2 opcode is called,
+        // > immediately (ie. before checks are done to determine
+        // > whether or not the address is unclaimed)
+        // > add the address being created to accessed_addresses,
+        // > but gas costs of CREATE and CREATE2 are unchanged
+        let address = if IS_CREATE2 {
+            state.create2_address(&geth_steps[0])?
+        } else {
+            state.create_address()?
+        };
+        let is_warm = state.sdb.check_account_in_access_list(&address);
+        state.push_op_reversible(
+            &mut exec_step,
+            RW::WRITE,
+            TxAccessListAccountOp {
+                tx_id: state.tx_ctx.id(),
+                address,
+                is_warm: true,
+                is_warm_prev: is_warm,
+            },
+        )?;
 
-    // Increase caller's nonce
-    let nonce_prev = state.sdb.get_nonce(&call.caller_address);
-    state.push_op_reversible(
-        &mut exec_step,
-        RW::WRITE,
-        AccountOp {
-            address: call.caller_address,
-            field: AccountField::Nonce,
-            value: (nonce_prev + 1).into(),
-            value_prev: nonce_prev.into(),
-        },
-    )?;
+        // Increase caller's nonce
+        let nonce_prev = state.sdb.get_nonce(&call.caller_address);
+        state.push_op_reversible(
+            &mut exec_step,
+            RW::WRITE,
+            AccountOp {
+                address: call.caller_address,
+                field: AccountField::Nonce,
+                value: (nonce_prev + 1).into(),
+                value_prev: nonce_prev.into(),
+            },
+        )?;
 
-    // Add callee into access list
-    let is_warm = state.sdb.check_account_in_access_list(&call.address);
-    state.push_op_reversible(
-        &mut exec_step,
-        RW::WRITE,
-        TxAccessListAccountOp {
-            tx_id,
-            address: call.address,
-            is_warm: true,
-            is_warm_prev: is_warm,
-        },
-    )?;
+        // Add callee into access list
+        let is_warm = state.sdb.check_account_in_access_list(&call.address);
+        state.push_op_reversible(
+            &mut exec_step,
+            RW::WRITE,
+            TxAccessListAccountOp {
+                tx_id,
+                address: call.address,
+                is_warm: true,
+                is_warm_prev: is_warm,
+            },
+        )?;
 
-    state.push_call(call.clone());
+        state.push_call(call.clone());
 
-    // Increase callee's nonce
-    let nonce_prev = state.sdb.get_nonce(&call.address);
-    debug_assert!(nonce_prev == 0);
-    state.push_op_reversible(
-        &mut exec_step,
-        RW::WRITE,
-        AccountOp {
-            address: call.address,
-            field: AccountField::Nonce,
-            value: 1.into(),
-            value_prev: 0.into(),
-        },
-    )?;
+        // Increase callee's nonce
+        let nonce_prev = state.sdb.get_nonce(&call.address);
+        debug_assert!(nonce_prev == 0);
+        state.push_op_reversible(
+            &mut exec_step,
+            RW::WRITE,
+            AccountOp {
+                address: call.address,
+                field: AccountField::Nonce,
+                value: 1.into(),
+                value_prev: 0.into(),
+            },
+        )?;
 
-    state.transfer(
-        &mut exec_step,
-        call.caller_address,
-        call.address,
-        call.value,
-    )?;
+        state.transfer(
+            &mut exec_step,
+            call.caller_address,
+            call.address,
+            call.value,
+        )?;
 
-    if call.code_hash.to_fixed_bytes() == *EMPTY_HASH {
-        // 1. Create with empty initcode.
-        state.handle_return(geth_step)?;
-        Ok(vec![exec_step])
-    } else {
-        // 2. Create with non-empty initcode.
-        Ok(vec![exec_step])
+        if call.code_hash.to_fixed_bytes() == *EMPTY_HASH {
+            // 1. Create with empty initcode.
+            state.handle_return(geth_step)?;
+            Ok(vec![exec_step])
+        } else {
+            // 2. Create with non-empty initcode.
+            Ok(vec![exec_step])
+        }
     }
 }

--- a/bus-mapping/src/evm/opcodes/extcodesize.rs
+++ b/bus-mapping/src/evm/opcodes/extcodesize.rs
@@ -1,0 +1,44 @@
+use crate::circuit_input_builder::{CircuitInputStateRef, ExecStep};
+use crate::evm::Opcode;
+use crate::operation::{TxAccessListAccountOp, RW};
+use crate::Error;
+use eth_types::{GethExecStep, ToAddress, ToWord};
+
+#[derive(Debug, Copy, Clone)]
+pub(crate) struct Extcodesize;
+
+impl Opcode for Extcodesize {
+    fn gen_associated_ops(
+        state: &mut CircuitInputStateRef,
+        geth_steps: &[GethExecStep],
+    ) -> Result<Vec<ExecStep>, Error> {
+        let geth_step = &geth_steps[0];
+        let mut exec_step = state.new_step(geth_step)?;
+
+        let external_address = geth_steps[0].stack.last()?.to_address();
+        state.stack_read(
+            &mut exec_step,
+            geth_step.stack.last_filled(),
+            external_address.to_word(),
+        )?;
+        let is_warm = state.sdb.check_account_in_access_list(&external_address);
+        state.push_op_reversible(
+            &mut exec_step,
+            RW::WRITE,
+            TxAccessListAccountOp {
+                tx_id: state.tx_ctx.id(),
+                address: external_address,
+                is_warm: true,
+                is_warm_prev: is_warm,
+            },
+        )?;
+
+        state.stack_write(
+            &mut exec_step,
+            geth_steps[1].stack.nth_last_filled(0),
+            geth_steps[1].stack.nth_last(0)?,
+        )?;
+
+        Ok(vec![exec_step])
+    }
+}

--- a/bus-mapping/src/evm/opcodes/extcodesize.rs
+++ b/bus-mapping/src/evm/opcodes/extcodesize.rs
@@ -12,6 +12,7 @@ impl Opcode for Extcodesize {
         state: &mut CircuitInputStateRef,
         geth_steps: &[GethExecStep],
     ) -> Result<Vec<ExecStep>, Error> {
+        // TODO: finish this, only access list part is done
         let geth_step = &geth_steps[0];
         let mut exec_step = state.new_step(geth_step)?;
 


### PR DESCRIPTION
## For reviewers

Apply "Hide writespace" can get a better diff view.

## Reason

Currently statedb calculated incorrectly due to incomplete implementation of [EIP-2929](https://eips.ethereum.org/EIPS/eip-2929). OpCode like `EXTCODESIZE` can easily break the system.

We need correct access list to calculate gas (like `CALL`, `CREATE`, `SSTORE`, etc.)

### Notice

Some of the Opcode need further implementation of busmapping, `TODO` is added to comments.