### PR TITLE
zkevm-circuits: add pub visibility for SuperCircuit fields and add re…

### DIFF
--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -78,16 +78,22 @@ pub struct SuperCircuitConfig<F: Field, const MAX_TXS: usize, const MAX_CALLDATA
 }
 
 /// The Super Circuit contains all the zkEVM circuits
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct SuperCircuit<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize> {
     // EVM Circuit
-    block: Block<F>,
-    fixed_table_tags: Vec<FixedTableTag>,
+    /// Block witness. Usually derived via
+    /// `evm_circuit::witness::block_convert`.
+    pub block: Block<F>,
+    /// Passed down to the evm_circuit. Usually that will be
+    /// `FixedTableTag::iter().collect()`.
+    pub fixed_table_tags: Vec<FixedTableTag>,
     // Tx Circuit
-    tx_circuit: TxCircuit<F, MAX_TXS, MAX_CALLDATA>,
+    /// The transaction circuit that will be used in the `synthesize` step.
+    pub tx_circuit: TxCircuit<F, MAX_TXS, MAX_CALLDATA>,
     // Bytecode Circuit
     // bytecodes: Vec<UnrolledBytecode<F>>,
-    bytecode_size: usize,
+    /// The maximium size for the underlying bytecode circuit.
+    pub bytecode_size: usize,
 }
 
 impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize>

--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -25,13 +25,15 @@ use num::Integer;
 use num_bigint::BigUint;
 // use rand_core::RngCore;
 use rlp::RlpStream;
-use secp256k1::Secp256k1Affine;
 use sha3::{Digest, Keccak256};
 use sign_verify::{pk_bytes_swap_endianness, SignData, SignVerifyChip, SignVerifyConfig};
-pub use sign_verify::{POW_RAND_SIZE, VERIF_HEIGHT};
 use std::convert::TryInto;
 use std::marker::PhantomData;
 use subtle::CtOption;
+
+pub use group::{Curve, Group};
+pub use secp256k1::Secp256k1Affine;
+pub use sign_verify::{POW_RAND_SIZE, VERIF_HEIGHT};
 
 lazy_static! {
     // Curve Scalar.  Referece: Section 2.4.1 (parameter `n`) in "SEC 2: Recommended Elliptic Curve
@@ -208,7 +210,7 @@ impl<F: Field> TxCircuitConfig<F> {
 }
 
 /// Tx Circuit for verifying transaction signatures
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 pub struct TxCircuit<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize> {
     /// SignVerify chip
     pub sign_verify: SignVerifyChip<F, MAX_TXS>,


### PR DESCRIPTION
…-exports of common structs for SuperCircuit consumers.

Makes it a bit easier for external crates to consume the SuperCircuit.