### PR TITLE
Don't import FromIterator, TryInto, and TryFrom

### DIFF
--- a/bus-mapping/src/circuit_input_builder/tracer_tests.rs
+++ b/bus-mapping/src/circuit_input_builder/tracer_tests.rs
@@ -16,7 +16,6 @@ use mock::test_ctx::{helpers::*, LoggerConfig, TestContext};
 use mock::MOCK_COINBASE;
 use pretty_assertions::assert_eq;
 use std::collections::HashSet;
-use std::iter::FromIterator;
 
 // Helper struct that contains a CircuitInputBuilder, a particuar tx and a
 // particular execution step so that we can easily get a

--- a/bus-mapping/src/evm/opcodes/mload.rs
+++ b/bus-mapping/src/evm/opcodes/mload.rs
@@ -1,7 +1,6 @@
 use super::Opcode;
 use crate::circuit_input_builder::{CircuitInputStateRef, ExecStep};
 use crate::Error;
-use core::convert::TryInto;
 use eth_types::evm_types::MemoryAddress;
 use eth_types::{GethExecStep, ToBigEndian};
 

--- a/bus-mapping/src/evm/opcodes/mstore.rs
+++ b/bus-mapping/src/evm/opcodes/mstore.rs
@@ -1,7 +1,6 @@
 use super::Opcode;
 use crate::circuit_input_builder::{CircuitInputStateRef, ExecStep};
 use crate::Error;
-use core::convert::TryInto;
 use eth_types::evm_types::MemoryAddress;
 use eth_types::{GethExecStep, ToBigEndian, ToLittleEndian};
 

--- a/eth-types/src/evm_types/memory.rs
+++ b/eth-types/src/evm_types/memory.rs
@@ -1,7 +1,6 @@
 //! Doc this
 use crate::Error;
 use crate::{DebugByte, ToBigEndian, Word};
-use core::convert::TryFrom;
 use core::ops::{Add, AddAssign, Index, IndexMut, Mul, MulAssign, Range, Sub, SubAssign};
 use core::str::FromStr;
 use itertools::Itertools;

--- a/eth-types/src/evm_types/memory.rs
+++ b/eth-types/src/evm_types/memory.rs
@@ -330,7 +330,6 @@ impl Memory {
 
 #[cfg(test)]
 mod memory_tests {
-    use std::convert::TryInto;
 
     use super::*;
 

--- a/eth-types/src/lib.rs
+++ b/eth-types/src/lib.rs
@@ -393,7 +393,6 @@ macro_rules! word_map {
     };
     ($($key_hex:expr => $value_hex:expr),*) => {
         {
-            use std::iter::FromIterator;
             std::collections::HashMap::from_iter([(
                     $(word!($key_hex), word!($value_hex)),*
             )])

--- a/gadgets/src/evm_word.rs
+++ b/gadgets/src/evm_word.rs
@@ -15,7 +15,6 @@ use halo2_proofs::{
     poly::Rotation,
 };
 use sha3::{Digest, Keccak256};
-use std::convert::TryInto;
 
 #[cfg(test)]
 use halo2_proofs::circuit::Layouter;

--- a/keccak256/src/circuit/padding.rs
+++ b/keccak256/src/circuit/padding.rs
@@ -6,7 +6,6 @@ use halo2_proofs::{
     poly::Rotation,
 };
 use itertools::Itertools;
-use std::convert::TryInto;
 use std::iter;
 use std::marker::PhantomData;
 

--- a/keccak256/src/circuit/word_builder.rs
+++ b/keccak256/src/circuit/word_builder.rs
@@ -8,7 +8,6 @@ use halo2_proofs::{
     plonk::{Advice, Column, ConstraintSystem, Error, Expression, Selector},
     poly::Rotation,
 };
-use std::convert::TryInto;
 
 pub type Byte = u8;
 pub type AssignedByte<F> = AssignedCell<F, F>;

--- a/keccak256/src/gate_helpers.rs
+++ b/keccak256/src/gate_helpers.rs
@@ -1,6 +1,5 @@
 use eth_types::Field;
 use num_bigint::BigUint;
-use std::convert::TryInto;
 
 /// Convert a bigUint value to FieldExt
 ///

--- a/keccak256/src/lib.rs
+++ b/keccak256/src/lib.rs
@@ -13,14 +13,14 @@ pub mod plain;
 
 lazy_static::lazy_static! {
     pub static ref EMPTY_HASH: [u8; 32] = {
-        use std::convert::TryInto;
+
 
         let mut keccak = plain::Keccak::default();
         keccak.update(&[]);
         keccak.digest().try_into().unwrap()
     };
     pub static ref EMPTY_HASH_LE: [u8; 32] = {
-        use std::convert::TryInto;
+
         use itertools::Itertools;
 
         EMPTY_HASH.iter().rev().cloned().collect_vec().try_into().unwrap()

--- a/keccak256/src/lib.rs
+++ b/keccak256/src/lib.rs
@@ -13,16 +13,12 @@ pub mod plain;
 
 lazy_static::lazy_static! {
     pub static ref EMPTY_HASH: [u8; 32] = {
-
-
         let mut keccak = plain::Keccak::default();
         keccak.update(&[]);
         keccak.digest().try_into().unwrap()
     };
     pub static ref EMPTY_HASH_LE: [u8; 32] = {
-
         use itertools::Itertools;
-
         EMPTY_HASH.iter().rev().cloned().collect_vec().try_into().unwrap()
     };
 }

--- a/keccak256/src/permutation/absorb.rs
+++ b/keccak256/src/permutation/absorb.rs
@@ -7,7 +7,7 @@ use halo2_proofs::{
     poly::Rotation,
 };
 use itertools::Itertools;
-use std::{convert::TryInto, marker::PhantomData};
+use std::marker::PhantomData;
 
 #[derive(Clone, Debug)]
 pub struct AbsorbConfig<F> {
@@ -174,7 +174,6 @@ impl<F: Field> AbsorbConfig<F> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::common::State;
     use crate::keccak_arith::KeccakFArith;
     use halo2_proofs::circuit::Layouter;
@@ -185,7 +184,6 @@ mod tests {
     use pairing::bn256::Fr as Fp;
     use pairing::group::ff::PrimeField;
     use pretty_assertions::assert_eq;
-    use std::convert::TryInto;
     use std::marker::PhantomData;
 
     #[test]

--- a/keccak256/src/permutation/absorb.rs
+++ b/keccak256/src/permutation/absorb.rs
@@ -174,17 +174,13 @@ impl<F: Field> AbsorbConfig<F> {
 
 #[cfg(test)]
 mod tests {
-    use crate::common::State;
+    use super::*;
     use crate::keccak_arith::KeccakFArith;
-    use halo2_proofs::circuit::Layouter;
     use halo2_proofs::pairing;
-    use halo2_proofs::plonk::{Advice, Column, ConstraintSystem, Error};
     use halo2_proofs::{circuit::SimpleFloorPlanner, dev::MockProver, plonk::Circuit};
-    use itertools::Itertools;
     use pairing::bn256::Fr as Fp;
     use pairing::group::ff::PrimeField;
     use pretty_assertions::assert_eq;
-    use std::marker::PhantomData;
 
     #[test]
     fn test_absorb_gate() {

--- a/keccak256/src/permutation/base_conversion.rs
+++ b/keccak256/src/permutation/base_conversion.rs
@@ -6,7 +6,6 @@ use halo2_proofs::{
 
 use super::tables::BaseInfo;
 use eth_types::Field;
-use std::convert::TryInto;
 
 #[derive(Clone, Debug)]
 pub(crate) struct BaseConversionConfig<F> {

--- a/keccak256/src/permutation/circuit.rs
+++ b/keccak256/src/permutation/circuit.rs
@@ -21,7 +21,7 @@ use halo2_proofs::{
     poly::Rotation,
 };
 use itertools::Itertools;
-use std::convert::TryInto;
+
 #[derive(Clone, Debug)]
 pub struct KeccakFConfig<F: Field> {
     generic: GenericConfig<F>,
@@ -291,7 +291,6 @@ mod tests {
     use halo2_proofs::plonk::{ConstraintSystem, Error};
     use halo2_proofs::{circuit::SimpleFloorPlanner, dev::MockProver, plonk::Circuit};
     use pretty_assertions::assert_eq;
-    use std::convert::TryInto;
 
     // TODO: Remove ignore once this can run in the CI without hanging.
     #[ignore]

--- a/keccak256/src/permutation/circuit.rs
+++ b/keccak256/src/permutation/circuit.rs
@@ -21,7 +21,6 @@ use halo2_proofs::{
     poly::Rotation,
 };
 use itertools::Itertools;
-
 #[derive(Clone, Debug)]
 pub struct KeccakFConfig<F: Field> {
     generic: GenericConfig<F>,

--- a/keccak256/src/permutation/iota.rs
+++ b/keccak256/src/permutation/iota.rs
@@ -3,7 +3,6 @@ use crate::common::{PERMUTATION, ROUND_CONSTANTS};
 use crate::gate_helpers::biguint_to_f;
 use eth_types::Field;
 use itertools::Itertools;
-use std::convert::TryInto;
 
 #[derive(Clone, Debug)]
 pub struct IotaConstants<F> {

--- a/keccak256/src/permutation/mixing.rs
+++ b/keccak256/src/permutation/mixing.rs
@@ -10,7 +10,6 @@ use halo2_proofs::{
     plonk::{Advice, Column, ConstraintSystem, Error, Selector},
     poly::Rotation,
 };
-use std::convert::TryInto;
 
 #[derive(Clone, Debug)]
 pub struct MixingConfig<F> {
@@ -237,7 +236,6 @@ mod tests {
     };
     use itertools::Itertools;
     use pretty_assertions::assert_eq;
-    use std::convert::TryInto;
 
     #[test]
     fn test_mixing_gate() {

--- a/keccak256/src/permutation/pi.rs
+++ b/keccak256/src/permutation/pi.rs
@@ -1,7 +1,6 @@
 use eth_types::Field;
 use halo2_proofs::circuit::AssignedCell;
 use itertools::Itertools;
-use std::convert::TryInto;
 
 /// The Keccak Pi step
 ///

--- a/keccak256/src/permutation/rho.rs
+++ b/keccak256/src/permutation/rho.rs
@@ -9,7 +9,6 @@ use halo2_proofs::{
     circuit::{AssignedCell, Layouter},
     plonk::{Advice, Column, ConstraintSystem, Error, Fixed},
 };
-use std::convert::TryInto;
 
 #[derive(Debug, Clone)]
 pub struct RhoConfig<F> {
@@ -106,7 +105,6 @@ mod tests {
         poly::Rotation,
     };
     use itertools::Itertools;
-    use std::convert::TryInto;
 
     #[test]
     fn test_rho_gate() {

--- a/keccak256/src/permutation/rho_helpers.rs
+++ b/keccak256/src/permutation/rho_helpers.rs
@@ -5,7 +5,6 @@ use crate::{
 use itertools::Itertools;
 use num_bigint::BigUint;
 use num_traits::Zero;
-use std::convert::TryInto;
 
 pub const BASE_NUM_OF_CHUNKS: u32 = 4;
 

--- a/keccak256/src/permutation/tables.rs
+++ b/keccak256/src/permutation/tables.rs
@@ -9,7 +9,7 @@ use halo2_proofs::{
     poly::Rotation,
 };
 use itertools::Itertools;
-use std::convert::TryInto;
+
 use std::marker::PhantomData;
 use strum_macros::{Display, EnumIter};
 

--- a/keccak256/src/permutation/tables.rs
+++ b/keccak256/src/permutation/tables.rs
@@ -9,7 +9,6 @@ use halo2_proofs::{
     poly::Rotation,
 };
 use itertools::Itertools;
-
 use std::marker::PhantomData;
 use strum_macros::{Display, EnumIter};
 

--- a/keccak256/src/permutation/theta.rs
+++ b/keccak256/src/permutation/theta.rs
@@ -6,7 +6,6 @@ use halo2_proofs::{
     poly::Rotation,
 };
 use itertools::Itertools;
-
 use std::marker::PhantomData;
 
 #[derive(Clone, Debug)]
@@ -110,7 +109,6 @@ mod tests {
         plonk::{Advice, Circuit, Column, ConstraintSystem, Error},
     };
     use itertools::Itertools;
-
     use std::marker::PhantomData;
 
     #[test]

--- a/keccak256/src/permutation/theta.rs
+++ b/keccak256/src/permutation/theta.rs
@@ -6,7 +6,7 @@ use halo2_proofs::{
     poly::Rotation,
 };
 use itertools::Itertools;
-use std::convert::TryInto;
+
 use std::marker::PhantomData;
 
 #[derive(Clone, Debug)]
@@ -110,7 +110,7 @@ mod tests {
         plonk::{Advice, Circuit, Column, ConstraintSystem, Error},
     };
     use itertools::Itertools;
-    use std::convert::TryInto;
+
     use std::marker::PhantomData;
 
     #[test]

--- a/keccak256/src/permutation/xi.rs
+++ b/keccak256/src/permutation/xi.rs
@@ -110,7 +110,6 @@ mod tests {
     use halo2_proofs::plonk::{Advice, Column, ConstraintSystem, Error};
     use halo2_proofs::{circuit::SimpleFloorPlanner, dev::MockProver, plonk::Circuit};
     use itertools::Itertools;
-
     use std::marker::PhantomData;
 
     #[test]

--- a/keccak256/src/permutation/xi.rs
+++ b/keccak256/src/permutation/xi.rs
@@ -5,7 +5,7 @@ use halo2_proofs::{
     poly::Rotation,
 };
 use itertools::Itertools;
-use std::{convert::TryInto, marker::PhantomData};
+use std::marker::PhantomData;
 
 #[derive(Clone, Debug)]
 pub struct XiConfig<F> {
@@ -110,7 +110,7 @@ mod tests {
     use halo2_proofs::plonk::{Advice, Column, ConstraintSystem, Error};
     use halo2_proofs::{circuit::SimpleFloorPlanner, dev::MockProver, plonk::Circuit};
     use itertools::Itertools;
-    use std::convert::TryInto;
+
     use std::marker::PhantomData;
 
     #[test]

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -20,7 +20,7 @@ use halo2_proofs::{
     plonk::{Advice, Column, ConstraintSystem, Error, Expression, Selector, VirtualCells},
     poly::Rotation,
 };
-use std::{collections::HashMap, convert::TryInto, iter};
+use std::{collections::HashMap, iter};
 use strum::IntoEnumIterator;
 
 mod add_sub;

--- a/zkevm-circuits/src/evm_circuit/execution/block_ctx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/block_ctx.rs
@@ -17,7 +17,6 @@ use bus_mapping::evm::OpcodeId;
 use eth_types::Field;
 use eth_types::ToLittleEndian;
 use halo2_proofs::plonk::Error;
-use std::convert::{TryFrom, TryInto};
 
 #[derive(Clone, Debug)]
 pub(crate) struct BlockCtxGadget<F, const N_BYTES: usize> {

--- a/zkevm-circuits/src/evm_circuit/execution/calldatacopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldatacopy.rs
@@ -23,8 +23,6 @@ use eth_types::Field;
 use eth_types::ToLittleEndian;
 use halo2_proofs::plonk::Error;
 
-use std::convert::TryInto;
-
 #[derive(Clone, Debug)]
 pub(crate) struct CallDataCopyGadget<F> {
     same_context: SameContextGadget<F>,

--- a/zkevm-circuits/src/evm_circuit/execution/calldataload.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldataload.rs
@@ -1,5 +1,3 @@
-use std::convert::TryInto;
-
 use bus_mapping::evm::OpcodeId;
 use eth_types::{Field, ToLittleEndian};
 use halo2_proofs::plonk::{Error, Expression};

--- a/zkevm-circuits/src/evm_circuit/execution/calldatasize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldatasize.rs
@@ -17,8 +17,6 @@ use bus_mapping::evm::OpcodeId;
 use eth_types::{Field, ToLittleEndian};
 use halo2_proofs::plonk::Error;
 
-use std::convert::TryInto;
-
 #[derive(Clone, Debug)]
 pub(crate) struct CallDataSizeGadget<F> {
     same_context: SameContextGadget<F>,

--- a/zkevm-circuits/src/evm_circuit/execution/caller.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/caller.rs
@@ -17,8 +17,6 @@ use bus_mapping::evm::OpcodeId;
 use eth_types::{Field, ToLittleEndian};
 use halo2_proofs::plonk::Error;
 
-use std::convert::TryInto;
-
 #[derive(Clone, Debug)]
 pub(crate) struct CallerGadget<F> {
     same_context: SameContextGadget<F>,

--- a/zkevm-circuits/src/evm_circuit/execution/codecopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/codecopy.rs
@@ -1,5 +1,3 @@
-use std::convert::TryInto;
-
 use bus_mapping::{circuit_input_builder::CopyDataType, evm::OpcodeId};
 use eth_types::{Field, ToLittleEndian};
 use halo2_proofs::plonk::Error;

--- a/zkevm-circuits/src/evm_circuit/execution/coinbase.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/coinbase.rs
@@ -18,8 +18,6 @@ use eth_types::Field;
 use eth_types::ToLittleEndian;
 use halo2_proofs::plonk::Error;
 
-
-
 #[derive(Clone, Debug)]
 pub(crate) struct CoinbaseGadget<F> {
     same_context: SameContextGadget<F>,

--- a/zkevm-circuits/src/evm_circuit/execution/coinbase.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/coinbase.rs
@@ -18,7 +18,7 @@ use eth_types::Field;
 use eth_types::ToLittleEndian;
 use halo2_proofs::plonk::Error;
 
-use std::convert::TryInto;
+
 
 #[derive(Clone, Debug)]
 pub(crate) struct CoinbaseGadget<F> {

--- a/zkevm-circuits/src/evm_circuit/execution/jump.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/jump.rs
@@ -18,8 +18,6 @@ use crate::{
 use eth_types::{evm_types::OpcodeId, Field, ToLittleEndian};
 use halo2_proofs::plonk::Error;
 
-use std::convert::TryInto;
-
 #[derive(Clone, Debug)]
 pub(crate) struct JumpGadget<F> {
     same_context: SameContextGadget<F>,

--- a/zkevm-circuits/src/evm_circuit/execution/jumpi.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/jumpi.rs
@@ -20,8 +20,6 @@ use crate::{
 use eth_types::{evm_types::OpcodeId, Field, ToLittleEndian};
 use halo2_proofs::plonk::Error;
 
-use std::convert::TryInto;
-
 #[derive(Clone, Debug)]
 pub(crate) struct JumpiGadget<F> {
     same_context: SameContextGadget<F>,

--- a/zkevm-circuits/src/evm_circuit/execution/memory.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/memory.rs
@@ -21,8 +21,6 @@ use crate::{
 use eth_types::{evm_types::OpcodeId, Field, ToLittleEndian};
 use halo2_proofs::plonk::Error;
 
-use std::convert::TryInto;
-
 #[derive(Clone, Debug)]
 pub(crate) struct MemoryGadget<F> {
     same_context: SameContextGadget<F>,

--- a/zkevm-circuits/src/evm_circuit/execution/number.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/number.rs
@@ -17,8 +17,6 @@ use bus_mapping::evm::OpcodeId;
 use eth_types::Field;
 use halo2_proofs::plonk::Error;
 
-use std::convert::TryFrom;
-
 #[derive(Clone, Debug)]
 pub(crate) struct NumberGadget<F> {
     same_context: SameContextGadget<F>,

--- a/zkevm-circuits/src/evm_circuit/execution/origin.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/origin.rs
@@ -16,7 +16,6 @@ use crate::{
 use bus_mapping::evm::OpcodeId;
 use eth_types::{Field, ToLittleEndian};
 use halo2_proofs::plonk::Error;
-use std::convert::TryInto;
 
 #[derive(Clone, Debug)]
 pub(crate) struct OriginGadget<F> {

--- a/zkevm-circuits/src/evm_circuit/execution/timestamp.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/timestamp.rs
@@ -17,8 +17,6 @@ use bus_mapping::evm::OpcodeId;
 use eth_types::Field;
 use halo2_proofs::plonk::Error;
 
-use std::convert::TryFrom;
-
 #[derive(Clone, Debug)]
 pub(crate) struct TimestampGadget<F> {
     same_context: SameContextGadget<F>,

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -18,7 +18,6 @@ use crate::{
 };
 use eth_types::{Field, ToLittleEndian, ToScalar, U256};
 use halo2_proofs::plonk::{Error, Expression};
-use std::convert::TryInto;
 
 /// Construction of execution state that stays in the same call context, which
 /// lookups the opcode and verifies the execution state is responsible for it,

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -16,7 +16,6 @@ use halo2_proofs::plonk::{
     Error,
     Expression::{self, Constant},
 };
-use std::convert::TryInto;
 
 use super::{rlc, CachedRegion, CellType, StoredExpression};
 

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget.rs
@@ -13,7 +13,6 @@ use crate::{
 use array_init::array_init;
 use eth_types::{Field, ToLittleEndian, ToScalar, Word};
 use halo2_proofs::plonk::{Error, Expression};
-use std::convert::TryFrom;
 
 /// Returns `1` when `value == 0`, and returns `0` otherwise.
 #[derive(Clone, Debug)]

--- a/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
@@ -14,7 +14,6 @@ use crate::{
 use array_init::array_init;
 use eth_types::{evm_types::GasCost, Field, ToLittleEndian, U256};
 use halo2_proofs::plonk::{Error, Expression};
-use std::convert::TryInto;
 
 /// Decodes the usable part of an address stored in a Word
 pub(crate) mod address_low {

--- a/zkevm-circuits/src/evm_circuit/witness.rs
+++ b/zkevm-circuits/src/evm_circuit/witness.rs
@@ -24,7 +24,7 @@ use halo2_proofs::arithmetic::{BaseExt, FieldExt};
 use halo2_proofs::pairing::bn256::Fr;
 use itertools::Itertools;
 use sha3::{Digest, Keccak256};
-use std::{collections::HashMap, convert::TryInto, iter};
+use std::{collections::HashMap, iter};
 
 #[derive(Debug, Default, Clone)]
 pub struct Block<F> {

--- a/zkevm-circuits/src/state_circuit/multiple_precision_integer.rs
+++ b/zkevm-circuits/src/state_circuit/multiple_precision_integer.rs
@@ -1,5 +1,4 @@
-use super::N_LIMBS_ACCOUNT_ADDRESS;
-use super::N_LIMBS_RW_COUNTER;
+use super::{N_LIMBS_ACCOUNT_ADDRESS, N_LIMBS_RW_COUNTER};
 use crate::util::Expr;
 use eth_types::{Address, Field, ToScalar};
 use halo2_proofs::{
@@ -8,7 +7,6 @@ use halo2_proofs::{
     poly::Rotation,
 };
 use itertools::Itertools;
-
 use std::marker::PhantomData;
 
 pub trait ToLimbs<const N: usize> {

--- a/zkevm-circuits/src/state_circuit/multiple_precision_integer.rs
+++ b/zkevm-circuits/src/state_circuit/multiple_precision_integer.rs
@@ -8,7 +8,7 @@ use halo2_proofs::{
     poly::Rotation,
 };
 use itertools::Itertools;
-use std::convert::TryInto;
+
 use std::marker::PhantomData;
 
 pub trait ToLimbs<const N: usize> {

--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -29,7 +29,7 @@ use secp256k1::Secp256k1Affine;
 use sha3::{Digest, Keccak256};
 use sign_verify::{pk_bytes_swap_endianness, SignData, SignVerifyChip, SignVerifyConfig};
 pub use sign_verify::{POW_RAND_SIZE, VERIF_HEIGHT};
-use std::convert::TryInto;
+
 use std::marker::PhantomData;
 use subtle::CtOption;
 

--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -29,7 +29,6 @@ use secp256k1::Secp256k1Affine;
 use sha3::{Digest, Keccak256};
 use sign_verify::{pk_bytes_swap_endianness, SignData, SignVerifyChip, SignVerifyConfig};
 pub use sign_verify::{POW_RAND_SIZE, VERIF_HEIGHT};
-
 use std::marker::PhantomData;
 use subtle::CtOption;
 

--- a/zkevm-circuits/src/tx_circuit/sign_verify.rs
+++ b/zkevm-circuits/src/tx_circuit/sign_verify.rs
@@ -33,10 +33,7 @@ use maingate::{
     RangeConfig, RangeInstructions, RegionCtx, UnassignedValue,
 };
 use secp256k1::Secp256k1Affine;
-use std::{
-    io::Cursor,
-    marker::PhantomData,
-};
+use std::{io::Cursor, marker::PhantomData};
 
 /// Power of randomness vector size required for the SignVerifyChip
 pub const POW_RAND_SIZE: usize = 63;

--- a/zkevm-circuits/src/tx_circuit/sign_verify.rs
+++ b/zkevm-circuits/src/tx_circuit/sign_verify.rs
@@ -34,7 +34,6 @@ use maingate::{
 };
 use secp256k1::Secp256k1Affine;
 use std::{
-    convert::{TryFrom, TryInto},
     io::Cursor,
     marker::PhantomData,
 };


### PR DESCRIPTION
We migrated to Rust 2021, which includes these in its prelude: https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html .