### PR TITLE
Fix RLC values in Copy/Keccak table lookup (SHA3)

### DIFF
--- a/bus-mapping/Cargo.toml
+++ b/bus-mapping/Cargo.toml
@@ -9,14 +9,15 @@ license = "MIT OR Apache-2.0"
 eth-types = { path = "../eth-types" }
 gadgets = { path = "../gadgets" }
 keccak256 = { path = "../keccak256" }
-mock = { path = "../mock" }
+mock = { path = "../mock", optional = true }
+
 ethers-core = "0.6"
 ethers-providers = "0.6"
 halo2_proofs = { version = "0.1.0-beta.1" }
 itertools = "0.10"
 lazy_static = "1.4"
 log = "0.4.14"
-rand = "0.8"
+rand = { version = "0.8", optional = true }
 serde = {version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.66"
 strum = "0.24"
@@ -29,4 +30,4 @@ tokio = { version = "1.13", features = ["macros"] }
 url = "2.2.2"
 
 [features]
-test = []
+test = ["mock", "rand"]

--- a/bus-mapping/Cargo.toml
+++ b/bus-mapping/Cargo.toml
@@ -9,12 +9,14 @@ license = "MIT OR Apache-2.0"
 eth-types = { path = "../eth-types" }
 gadgets = { path = "../gadgets" }
 keccak256 = { path = "../keccak256" }
+mock = { path = "../mock" }
 ethers-core = "0.6"
 ethers-providers = "0.6"
 halo2_proofs = { version = "0.1.0-beta.1" }
 itertools = "0.10"
 lazy_static = "1.4"
 log = "0.4.14"
+rand = "0.8"
 serde = {version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.66"
 strum = "0.24"
@@ -22,8 +24,9 @@ strum_macros = "0.24"
 
 [dev-dependencies]
 hex = "0.4.3"
-mock = { path = "../mock" }
 pretty_assertions = "1.0.0"
-rand = "0.8"
 tokio = { version = "1.13", features = ["macros"] }
 url = "2.2.2"
+
+[features]
+test = []

--- a/bus-mapping/src/evm.rs
+++ b/bus-mapping/src/evm.rs
@@ -4,3 +4,6 @@ pub(crate) mod opcodes;
 
 pub use eth_types::evm_types::opcode_ids::OpcodeId;
 pub use opcodes::Opcode;
+
+#[cfg(any(feature = "test", test))]
+pub use opcodes::{gen_sha3_code, MemoryKind};

--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -15,6 +15,9 @@ use eth_types::{
 use keccak256::EMPTY_HASH;
 use log::warn;
 
+#[cfg(any(feature = "test", test))]
+pub use sha3::sha3_tests::{gen_sha3_code, MemoryKind};
+
 mod call;
 mod calldatacopy;
 mod calldataload;

--- a/zkevm-circuits/Cargo.toml
+++ b/zkevm-circuits/Cargo.toml
@@ -16,7 +16,7 @@ sha3 = "0.10"
 digest = "0.7.6"
 array-init = "2.0.0"
 paste = "1.0"
-bus-mapping = { path = "../bus-mapping" }
+bus-mapping = { path = "../bus-mapping", features = ["test"] }
 eth-types = { path = "../eth-types" }
 gadgets = { path = "../gadgets" }
 ethers-core = "0.6"

--- a/zkevm-circuits/Cargo.toml
+++ b/zkevm-circuits/Cargo.toml
@@ -16,7 +16,7 @@ sha3 = "0.10"
 digest = "0.7.6"
 array-init = "2.0.0"
 paste = "1.0"
-bus-mapping = { path = "../bus-mapping", features = ["test"] }
+bus-mapping = { path = "../bus-mapping" }
 eth-types = { path = "../eth-types" }
 gadgets = { path = "../gadgets" }
 ethers-core = "0.6"
@@ -42,6 +42,7 @@ num-bigint = { version = "0.4" }
 subtle = "2.4"
 
 [dev-dependencies]
+bus-mapping = { path = "../bus-mapping", features = ["test"] }
 criterion = "0.3"
 ctor = "0.1.22"
 env_logger = "0.9.0"

--- a/zkevm-circuits/src/copy_circuit.rs
+++ b/zkevm-circuits/src/copy_circuit.rs
@@ -381,7 +381,7 @@ impl<F: Field> CopyCircuit<F> {
                             .filter(|s| s.rw.is_write())
                             .map(|s| s.value)
                             .collect::<Vec<u8>>();
-                        rlc::value(&values, block.randomness)
+                        rlc::value(values.iter().rev(), block.randomness)
                     } else {
                         F::zero()
                     };
@@ -670,6 +670,7 @@ mod tests {
     use super::*;
     use bus_mapping::{
         circuit_input_builder::{CircuitInputBuilder, CopyDataType},
+        evm::{gen_sha3_code, MemoryKind},
         mock::BlockData,
         operation::RWCounter,
     };
@@ -802,6 +803,17 @@ mod tests {
         builder
     }
 
+    fn gen_sha3_data() -> CircuitInputBuilder {
+        let (code, _) = gen_sha3_code(0x20, 0x200, MemoryKind::EqualToSize);
+        let test_ctx = TestContext::<2, 1>::simple_ctx_with_bytecode(code).unwrap();
+        let block: GethData = test_ctx.into();
+        let mut builder = BlockData::new_from_geth_data(block.clone()).new_circuit_input_builder();
+        builder
+            .handle_block(&block.eth_block, &block.geth_traces)
+            .unwrap();
+        builder
+    }
+
     #[test]
     fn copy_circuit_valid_calldatacopy() {
         let builder = gen_calldatacopy_data();
@@ -814,6 +826,13 @@ mod tests {
         let builder = gen_codecopy_data();
         let block = block_convert(&builder.block, &builder.code_db);
         assert!(run_circuit(10, block).is_ok());
+    }
+
+    #[test]
+    fn copy_circuit_valid_sha3() {
+        let builder = gen_codecopy_data();
+        let block = block_convert(&builder.block, &builder.code_db);
+        assert!(run_circuit(20, block).is_ok());
     }
 
     fn perturb_tag(block: &mut bus_mapping::circuit_input_builder::Block, tag: CopyDataType) {

--- a/zkevm-circuits/src/evm_circuit/witness.rs
+++ b/zkevm-circuits/src/evm_circuit/witness.rs
@@ -1207,6 +1207,7 @@ impl From<&circuit_input_builder::ExecStep> for ExecutionState {
                     OpcodeId::DIFFICULTY | OpcodeId::BASEFEE => ExecutionState::BLOCKCTXU256,
                     OpcodeId::GAS => ExecutionState::GAS,
                     OpcodeId::SELFBALANCE => ExecutionState::SELFBALANCE,
+                    OpcodeId::SHA3 => ExecutionState::SHA3,
                     OpcodeId::SHR => ExecutionState::SHR,
                     OpcodeId::SLOAD => ExecutionState::SLOAD,
                     OpcodeId::SSTORE => ExecutionState::SSTORE,
@@ -1221,7 +1222,6 @@ impl From<&circuit_input_builder::ExecStep> for ExecutionState {
                     OpcodeId::CODESIZE => ExecutionState::CODESIZE,
                     OpcodeId::RETURN | OpcodeId::REVERT => ExecutionState::RETURN,
                     // dummy ops
-                    OpcodeId::SHA3 => dummy!(ExecutionState::SHA3),
                     OpcodeId::ADDRESS => dummy!(ExecutionState::ADDRESS),
                     OpcodeId::BALANCE => dummy!(ExecutionState::BALANCE),
                     OpcodeId::BLOCKHASH => dummy!(ExecutionState::BLOCKHASH),

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -771,7 +771,7 @@ impl CopyTable {
                 .filter(|s| s.rw.is_write())
                 .map(|s| s.value)
                 .collect::<Vec<u8>>();
-            rlc::value(&values, randomness)
+            rlc::value(values.iter().rev(), randomness)
         } else {
             F::zero()
         };


### PR DESCRIPTION
Fixes the `integration-tests` warning after merging #635 for `SHA3` using a dummy gadget.

Still investigating failure because of Keccak lookup.