### PR TITLE
Remove keys from CopyEvent

### DIFF
--- a/bus-mapping/src/circuit_input_builder/execution.rs
+++ b/bus-mapping/src/circuit_input_builder/execution.rs
@@ -228,10 +228,4 @@ pub struct CopyEvent {
     pub length: u64,
     /// Represents the list of copy steps in this copy event.
     pub steps: Vec<CopyStep>,
-    /// Helper field for witness generation.
-    pub tx_id: usize,
-    /// Helper field for witness generation.
-    pub call_id: usize,
-    /// Helper field for witness generation.
-    pub pc: ProgramCounter,
 }

--- a/bus-mapping/src/evm/opcodes/calldatacopy.rs
+++ b/bus-mapping/src/evm/opcodes/calldatacopy.rs
@@ -214,9 +214,6 @@ fn gen_copy_event(
         log_id: None,
         length,
         steps: copy_steps,
-        tx_id: state.tx_ctx.id(),
-        call_id: state.call()?.call_id,
-        pc: exec_step.pc,
     })
 }
 

--- a/bus-mapping/src/evm/opcodes/codecopy.rs
+++ b/bus-mapping/src/evm/opcodes/codecopy.rs
@@ -161,9 +161,6 @@ fn gen_copy_event(
         log_id: None,
         length,
         steps: copy_steps,
-        tx_id: state.tx_ctx.id(),
-        call_id: state.call()?.call_id,
-        pc: exec_step.pc,
     })
 }
 

--- a/bus-mapping/src/evm/opcodes/logs.rs
+++ b/bus-mapping/src/evm/opcodes/logs.rs
@@ -216,9 +216,6 @@ fn gen_copy_event(
         log_id: Some(state.tx_ctx.log_id as u64 + 1),
         length: msize as u64,
         steps,
-        tx_id: state.tx_ctx.id(),
-        call_id: state.call()?.call_id,
-        pc: exec_step.pc,
     })
 }
 

--- a/zkevm-circuits/src/copy_circuit.rs
+++ b/zkevm-circuits/src/copy_circuit.rs
@@ -373,7 +373,7 @@ impl<F: Field> CopyCircuit<F> {
             || "assign copy table",
             |mut region| {
                 let mut offset = 0;
-                for copy_event in &block.copy_events {
+                for copy_event in block.copy_events.iter() {
                     let rlc_acc = if copy_event.dst_type == CopyDataType::RlcAcc {
                         let values = copy_event
                             .steps

--- a/zkevm-circuits/src/copy_circuit.rs
+++ b/zkevm-circuits/src/copy_circuit.rs
@@ -334,7 +334,7 @@ impl<F: Field> CopyCircuit<F> {
             || "assign copy table",
             |mut region| {
                 let mut offset = 0;
-                for copy_event in block.copy_events.values() {
+                for copy_event in &block.copy_events {
                     for (step_idx, copy_step) in copy_event.steps.iter().enumerate() {
                         self.assign_step(
                             &mut region,

--- a/zkevm-circuits/src/evm_circuit/execution/calldatacopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldatacopy.rs
@@ -19,11 +19,10 @@ use crate::{
     util::Expr,
 };
 use bus_mapping::{circuit_input_builder::CopyDataType, evm::OpcodeId};
-use eth_types::Field;
-use eth_types::ToLittleEndian;
+use eth_types::{Field, ToLittleEndian, Word, ToScalar};
 use halo2_proofs::plonk::Error;
 
-use std::convert::TryInto;
+use std::cmp::min;
 
 #[derive(Clone, Debug)]
 pub(crate) struct CallDataCopyGadget<F> {
@@ -190,8 +189,7 @@ impl<F: Field> ExecutionGadget<F> for CallDataCopyGadget<F> {
             ),
         )?;
         let src_id = if call.is_root { tx.id } else { call.caller_id };
-        self.src_id
-            .assign(region, offset, Some(F::from(src_id as u64)))?;
+        self.src_id.assign(region, offset, Some(F::from(u64::try_from(src_id).unwrap())))?;
 
         // Call data length and call data offset
         let (call_data_length, call_data_offset) = if call.is_root {
@@ -200,20 +198,24 @@ impl<F: Field> ExecutionGadget<F> for CallDataCopyGadget<F> {
             (call.call_data_length, call.call_data_offset)
         };
         self.call_data_length
-            .assign(region, offset, Some(F::from(call_data_length as u64)))?;
+            .assign(region, offset, Some(F::from(call_data_length)))?;
         self.call_data_offset
-            .assign(region, offset, Some(F::from(call_data_offset as u64)))?;
+            .assign(region, offset, Some(F::from(call_data_offset)))?;
 
-        let key = (tx.id, call.id, step.program_counter as usize);
-        let copy_rwc_inc = block
-            .copy_events
-            .get(&key)
-            .unwrap()
-            .steps
-            .first()
-            .map_or(F::zero(), |cs| F::from(cs.rwc_inc_left));
+        let n_memory_reads: u64 = if call.is_root {
+            0 // No memory reads when reading from tx call data.
+        } else {
+            min(
+                length.low_u64(),
+                call_data_length
+                    .checked_sub(call_data_offset)
+                    .unwrap_or_default(),
+            )
+        };
+        let copy_rwc_inc = length // number of memory writes
+            + Word::from(n_memory_reads);
         self.copy_rwc_inc
-            .assign(region, offset, Some(copy_rwc_inc))?;
+            .assign(region, offset, copy_rwc_inc.to_scalar())?;
 
         // Memory expansion
         let (_, memory_expansion_gas_cost) = self.memory_expansion.assign(

--- a/zkevm-circuits/src/evm_circuit/execution/calldatacopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldatacopy.rs
@@ -19,7 +19,7 @@ use crate::{
     util::Expr,
 };
 use bus_mapping::{circuit_input_builder::CopyDataType, evm::OpcodeId};
-use eth_types::{Field, ToLittleEndian, ToScalar, Word};
+use eth_types::{Field, ToLittleEndian, ToScalar};
 use halo2_proofs::plonk::Error;
 
 use std::cmp::min;

--- a/zkevm-circuits/src/evm_circuit/execution/codecopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/codecopy.rs
@@ -182,6 +182,7 @@ impl<F: Field> ExecutionGadget<F> for CodeCopyGadget<F> {
         )?;
         self.memory_copier_gas
             .assign(region, offset, size.as_u64(), memory_expansion_cost)?;
+        // rw_counter increase from copy table lookup is number of bytes copied.
         self.copy_rwc_inc.assign(region, offset, size.to_scalar())?;
 
         Ok(())

--- a/zkevm-circuits/src/evm_circuit/execution/codecopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/codecopy.rs
@@ -135,7 +135,7 @@ impl<F: Field> ExecutionGadget<F> for CodeCopyGadget<F> {
         region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         block: &Block<F>,
-        tx: &Transaction,
+        _: &Transaction,
         call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
@@ -182,17 +182,7 @@ impl<F: Field> ExecutionGadget<F> for CodeCopyGadget<F> {
         )?;
         self.memory_copier_gas
             .assign(region, offset, size.as_u64(), memory_expansion_cost)?;
-
-        let key = (tx.id, call.id, step.program_counter as usize);
-        let copy_rwc_inc = block
-            .copy_events
-            .get(&key)
-            .unwrap()
-            .steps
-            .first()
-            .map_or(F::zero(), |cs| F::from(cs.rwc_inc_left));
-        self.copy_rwc_inc
-            .assign(region, offset, Some(copy_rwc_inc))?;
+        self.copy_rwc_inc.assign(region, offset, Some(F::one()))?;
 
         Ok(())
     }

--- a/zkevm-circuits/src/evm_circuit/execution/codecopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/codecopy.rs
@@ -1,7 +1,7 @@
 use std::convert::TryInto;
 
 use bus_mapping::{circuit_input_builder::CopyDataType, evm::OpcodeId};
-use eth_types::{Field, ToLittleEndian};
+use eth_types::{Field, ToLittleEndian, ToScalar};
 use halo2_proofs::plonk::Error;
 
 use crate::{
@@ -182,7 +182,7 @@ impl<F: Field> ExecutionGadget<F> for CodeCopyGadget<F> {
         )?;
         self.memory_copier_gas
             .assign(region, offset, size.as_u64(), memory_expansion_cost)?;
-        self.copy_rwc_inc.assign(region, offset, Some(F::one()))?;
+        self.copy_rwc_inc.assign(region, offset, size.to_scalar())?;
 
         Ok(())
     }

--- a/zkevm-circuits/src/evm_circuit/execution/logs.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/logs.rs
@@ -240,8 +240,8 @@ impl<F: Field> ExecutionGadget<F> for LogGadget<F> {
             .assign(region, offset, Some(F::from(is_persistent)))?;
         self.tx_id
             .assign(region, offset, Some(F::from(tx.id as u64)))?;
-
-        self.copy_rwc_inc.assign(region, offset, Some(F::one()))?;
+        self.copy_rwc_inc
+            .assign(region, offset, (msize + msize).to_scalar())?;
 
         Ok(())
     }

--- a/zkevm-circuits/src/evm_circuit/execution/logs.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/logs.rs
@@ -241,16 +241,7 @@ impl<F: Field> ExecutionGadget<F> for LogGadget<F> {
         self.tx_id
             .assign(region, offset, Some(F::from(tx.id as u64)))?;
 
-        let key = (tx.id, call.id, step.program_counter as usize);
-        let copy_rwc_inc = block
-            .copy_events
-            .get(&key)
-            .unwrap()
-            .steps
-            .first()
-            .map_or(F::zero(), |cs| F::from(cs.rwc_inc_left));
-        self.copy_rwc_inc
-            .assign(region, offset, Some(copy_rwc_inc))?;
+        self.copy_rwc_inc.assign(region, offset, Some(F::one()))?;
 
         Ok(())
     }

--- a/zkevm-circuits/src/evm_circuit/execution/logs.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/logs.rs
@@ -240,6 +240,8 @@ impl<F: Field> ExecutionGadget<F> for LogGadget<F> {
             .assign(region, offset, Some(F::from(is_persistent)))?;
         self.tx_id
             .assign(region, offset, Some(F::from(tx.id as u64)))?;
+        // rw_counter increase from copy table lookup is `msize` memory reads + `msize`
+        // log writes.
         self.copy_rwc_inc
             .assign(region, offset, (msize + msize).to_scalar())?;
 

--- a/zkevm-circuits/src/evm_circuit/execution/sha3.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sha3.rs
@@ -102,8 +102,8 @@ impl<F: Field> ExecutionGadget<F> for Sha3Gadget<F> {
         region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         block: &Block<F>,
-        _: &Transaction,
-        _: &Call,
+        _tx: &Transaction,
+        _call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
         self.same_context.assign_exec_step(region, offset, step)?;
@@ -119,7 +119,7 @@ impl<F: Field> ExecutionGadget<F> for Sha3Gadget<F> {
 
         self.copy_rwc_inc.assign(region, offset, size.to_scalar())?;
 
-        let values: Vec<_> = (3..3 + (size.low_u64() as usize))
+        let values: Vec<u8> = (3..3 + (size.low_u64() as usize))
             .map(|i| block.rws[step.rw_indices[i]].memory_value())
             .collect();
         let rlc_acc = rlc::value(&values, block.randomness);

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget.rs
@@ -13,7 +13,6 @@ use crate::{
 use array_init::array_init;
 use eth_types::{Field, ToLittleEndian, ToScalar, Word};
 use halo2_proofs::plonk::{Error, Expression};
-use std::convert::TryFrom;
 
 /// Returns `1` when `value == 0`, and returns `0` otherwise.
 #[derive(Clone, Debug)]

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget.rs
@@ -13,6 +13,7 @@ use crate::{
 use array_init::array_init;
 use eth_types::{Field, ToLittleEndian, ToScalar, Word};
 use halo2_proofs::plonk::{Error, Expression};
+use std::convert::TryFrom;
 
 /// Returns `1` when `value == 0`, and returns `0` otherwise.
 #[derive(Clone, Debug)]

--- a/zkevm-circuits/src/evm_circuit/witness.rs
+++ b/zkevm-circuits/src/evm_circuit/witness.rs
@@ -38,9 +38,8 @@ pub struct Block<F> {
     pub bytecodes: HashMap<Word, Bytecode>,
     /// The block context
     pub context: BlockContext,
-    /// Copy events for the EVM circuit's Copy Table, a mapping from (tx_id ||
-    /// call_id || pc) to the corresponding copy event.
-    pub copy_events: HashMap<(usize, usize, usize), CopyEvent>,
+    /// Copy events for the EVM circuit's copy table.
+    pub copy_events: Vec<CopyEvent>,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -1384,15 +1383,6 @@ pub fn block_convert(
                     })
             })
             .collect(),
-        copy_events: block
-            .copy_events
-            .iter()
-            .map(|copy_event| {
-                (
-                    (copy_event.tx_id, copy_event.call_id, copy_event.pc.0),
-                    copy_event.clone(),
-                )
-            })
-            .collect(),
+        copy_events: block.copy_events.clone(),
     }
 }

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -820,7 +820,7 @@ impl CopyTable {
 
                 let tag_chip = BinaryNumberChip::construct(self.tag);
                 let copy_table_columns = self.columns();
-                for copy_event in block.copy_events.values() {
+                for copy_event in block.copy_events.iter() {
                     for (tag, row) in Self::assignments(copy_event, randomness) {
                         for (column, value) in copy_table_columns.iter().zip_eq(row) {
                             region.assign_advice(


### PR DESCRIPTION
They were being used to look up `copy_rwc_inc`, which can be directly computed.