### PR TITLE
workflows: add reusable workflow for self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI checks
 
 on:
   pull_request:
-    types: [synchronize, opened, reopened, ready_for_review, labeled]
+    types: [synchronize, opened, reopened, ready_for_review]
   push:
     branches:
       - main
@@ -11,50 +11,20 @@ on:
 ## `rust-toolchain` is always used and the only source of truth.
 
 jobs:
-  # Disallows PRs from forks to run on the self-hosted runner,
-  # except if the label `allow-ci` is attached to the PR.
-  permission:
-    if: |
-      github.event.pull_request.draft == false &&
-      (
-        github.repository == 'privacy-scaling-explorations/zkevm-circuits' ||
-        (
-          github.event_name == 'pull_request' &&
-          github.event.action == 'labeled' &&
-          github.event.label.name == 'allow-ci'
-        )
-      )
-    runs-on: ubuntu-latest
-    steps:
-      - run: true
-
-  consecutiveness:
-    needs: [permission]
-    runs-on: ubuntu-latest
-    steps:
-    - uses: mktcode/consecutive-workflow-action@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-
-  wakeuprunner:
-    needs: [consecutiveness]
-    name: Wake up self-hosted runner
-    runs-on: pse-runner
-
-    steps:
-      - uses: actions/checkout@v2
-      - run: |
-          .github/ciChecksScripts/wakeUpRunner.sh
+  runner:
+    if: github.event.pull_request.draft == false
+    uses: ./.github/workflows/select-runner.yml
 
   test:
-    needs: [wakeuprunner]
     name: Test
+    needs: [runner]
     runs-on: ${{ matrix.os }}
+    concurrency: ${{ needs.runner.outputs.concurrency-group }}
     strategy:
       matrix:
         # We don't need to test across multiple platforms yet
         # os: [ubuntu-latest, windows-latest, macOS-latest]
-        os: [ci-checks-runner]
+        os: ${{ fromJSON(needs.runner.outputs.runner-matrix) }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI checks
 
 on:
   pull_request:
-    types: [synchronize, opened, reopened, ready_for_review]
+    types: [synchronize, opened, reopened, ready_for_review, labeled]
   push:
     branches:
       - main
@@ -11,10 +11,25 @@ on:
 ## `rust-toolchain` is always used and the only source of truth.
 
 jobs:
+  # Disallows PRs from forks to run on the self-hosted runner,
+  # except if the label `allow-ci` is attached to the PR.
+  permission:
+    if: |
+      github.event.pull_request.draft == false &&
+      (
+        github.repository == 'privacy-scaling-explorations/zkevm-circuits' ||
+        (
+          github.event_name == 'pull_request' &&
+          github.event.action == 'labeled' &&
+          github.event.label.name == 'allow-ci'
+        )
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
 
   consecutiveness:
-    if: github.event.pull_request.draft == false && github.repository == 'privacy-scaling-explorations/zkevm-circuits'
-
+    needs: [permission]
     runs-on: ubuntu-latest
     steps:
     - uses: mktcode/consecutive-workflow-action@v1
@@ -22,8 +37,6 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
 
   wakeuprunner:
-    if: github.event.pull_request.draft == false && github.repository == 'privacy-scaling-explorations/zkevm-circuits'
-
     needs: [consecutiveness]
     name: Wake up self-hosted runner
     runs-on: pse-runner
@@ -34,8 +47,6 @@ jobs:
           .github/ciChecksScripts/wakeUpRunner.sh
 
   test:
-    if: github.event.pull_request.draft == false && github.repository == 'privacy-scaling-explorations/zkevm-circuits'
-
     needs: [wakeuprunner]
     name: Test
     runs-on: ${{ matrix.os }}
@@ -44,57 +55,6 @@ jobs:
         # We don't need to test across multiple platforms yet
         # os: [ubuntu-latest, windows-latest, macOS-latest]
         os: [ci-checks-runner]
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          override: false
-      - name: Setup golang
-        uses: actions/setup-go@v3
-        with:
-          go-version: ~1.18
-      # Go cache for building geth-utils
-      - name: Go cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - name: Cargo cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Run light tests # light tests are run in parallel
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose --release --all --all-features --exclude integration-tests --exclude circuit-benchmarks
-      - name: Run heavy tests # heavy tests are run serially to avoid OOM
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose --release --all --all-features --exclude integration-tests --exclude circuit-benchmarks serial_ -- --ignored --test-threads 1
-
-  test_forks:
-    if: github.event.pull_request.draft == false && github.repository != 'privacy-scaling-explorations/zkevm-circuits'
-
-    name: Test_forks
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        # We don't need to test across multiple platforms yet
-        # os: [ubuntu-latest, windows-latest, macOS-latest]
-        os: [ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/select-runner.yml
+++ b/.github/workflows/select-runner.yml
@@ -1,0 +1,45 @@
+name: 'Select Runner'
+
+on:
+  workflow_call:
+    inputs:
+      enabled:
+        default: ${{ github.repository == 'privacy-scaling-explorations/zkevm-circuits' }}
+        required: false
+        type: boolean
+
+      matrices:
+        description: 'The matrix at index 0 is intended for not running on the self-hosted runner'
+        default: '[["ubuntu-latest"], ["ci-checks-runner"]]'
+        required: false
+        type: string
+
+      bastion-host:
+        default: pse-runner
+        required: false
+        type: string
+
+    outputs:
+      runner-matrix:
+        value: ${{ jobs.select.outputs.matrix }}
+      concurrency-group:
+        value: ${{ jobs.select.outputs.matrix }}
+
+jobs:
+  select:
+    # dummy step to make github actions happy
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+    outputs:
+      matrix: ${{ toJSON( fromJSON(inputs.matrices)[inputs.enabled] ) }}
+
+  wakeup:
+    name: Wake up self-hosted runner
+    if: ${{ inputs.enabled }}
+    needs: [select]
+    runs-on: ${{ inputs.bastion-host }}
+    concurrency: ${{ needs.select.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v2
+      - run: .github/ciChecksScripts/wakeUpRunner.sh


### PR DESCRIPTION
Moves the selection and additional wakeup mechanism of the self-hosted runner into a reusable workflow.
It also removes the blocking behaviour for the whole ci workflow file of `consecutive-workflow-action` and replaces it with a github native concurrency group. 