### PR TITLE
Repro - copy_rwc_inc

### DIFF
--- a/bus-mapping/src/evm/opcodes/calldatacopy.rs
+++ b/bus-mapping/src/evm/opcodes/calldatacopy.rs
@@ -118,22 +118,7 @@ fn gen_copy_steps(
     for idx in 0..bytes_left {
         let addr = src_addr + idx;
         let rwc = state.block_ctx.rwc;
-        let (value, is_pad) = if addr < src_addr_end {
-            let byte =
-                state.call_ctx()?.call_data[(addr - state.call()?.call_data_offset) as usize];
-            if !is_root {
-                state.push_op(
-                    exec_step,
-                    RW::READ,
-                    MemoryOp::new(state.call()?.caller_id, addr.into(), byte),
-                );
-                (byte, false)
-            } else {
-                (byte, false)
-            }
-        } else {
-            (0, true)
-        };
+        let (value, is_pad) = (0, true);
         let tag = if is_root {
             CopyDataType::TxCalldata
         } else {
@@ -235,6 +220,7 @@ mod calldatacopy_tests {
     use pretty_assertions::assert_eq;
 
     #[test]
+    #[ignore]
     fn calldatacopy_opcode_internal() {
         let (addr_a, addr_b) = (mock::MOCK_ACCOUNTS[0], mock::MOCK_ACCOUNTS[1]);
 
@@ -465,6 +451,7 @@ mod calldatacopy_tests {
     }
 
     #[test]
+    #[ignore]
     fn calldatacopy_opcode_internal_overflow() {
         let (addr_a, addr_b) = (mock::MOCK_ACCOUNTS[0], mock::MOCK_ACCOUNTS[1]);
 
@@ -530,6 +517,7 @@ mod calldatacopy_tests {
     }
 
     #[test]
+    #[ignore]
     fn calldatacopy_opcode_root() {
         let size = 0x40;
         let offset = 0x00;

--- a/zkevm-circuits/src/copy_circuit.rs
+++ b/zkevm-circuits/src/copy_circuit.rs
@@ -252,6 +252,7 @@ impl<F: Field> CopyCircuit<F> {
                     meta.query_advice(value, Rotation::cur()),
                 ]),
             );
+            // This constraint should fail, but the test cases don't cover it?
             cb.require_equal(
                 "is_pad == 1 - (src_addr < src_addr_end) for read row",
                 1.expr() - addr_lt_addr_end.is_lt(meta, None),

--- a/zkevm-circuits/src/evm_circuit/execution/calldatacopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldatacopy.rs
@@ -209,20 +209,7 @@ impl<F: Field> ExecutionGadget<F> for CallDataCopyGadget<F> {
 
         // rw_counter increase from copy lookup is `length` memory writes + a variable
         // number of memory reads.
-        let copy_rwc_inc = length
-            + if call.is_root {
-                // no memory reads when reading from tx call data.
-                0
-            } else {
-                // memory reads when reading from memory of caller is capped by call_data_length
-                // - data_offset.
-                min(
-                    length.low_u64(),
-                    call_data_length
-                        .checked_sub(data_offset.low_u64())
-                        .unwrap_or_default(),
-                )
-            };
+        let copy_rwc_inc = length;
         self.copy_rwc_inc
             .assign(region, offset, copy_rwc_inc.to_scalar())?;
 


### PR DESCRIPTION
It's valid to only write padding bytes for Calldatacopy.