### PR TITLE
fix: Return to patch usage for halo2 deps

### DIFF
--- a/bus-mapping/Cargo.toml
+++ b/bus-mapping/Cargo.toml
@@ -13,7 +13,7 @@ mock = { path = "../mock", optional = true }
 
 ethers-core = "0.6"
 ethers-providers = "0.6"
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2022_08_19" }
+halo2_proofs = { version = "0.2.0" }
 itertools = "0.10"
 lazy_static = "1.4"
 log = "0.4.14"

--- a/circuit-benchmarks/Cargo.toml
+++ b/circuit-benchmarks/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2022_08_19" }
+halo2_proofs = { version = "0.2.0" }
 ark-std = { version = "0.3", features = ["print-trace"] }
 zkevm-circuits = { path = "../zkevm-circuits" }
 keccak256 = { path = "../keccak256" }

--- a/eth-types/Cargo.toml
+++ b/eth-types/Cargo.toml
@@ -10,7 +10,7 @@ ethers-core = "0.6"
 ethers-signers = "0.6"
 hex = "0.4"
 lazy_static = "1.4"
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2022_08_19" }
+halo2_proofs = { version = "0.2.0" }
 regex = "1.5.4"
 serde = {version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.66"

--- a/gadgets/Cargo.toml
+++ b/gadgets/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["The appliedzkp team"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2022_08_19" }
+halo2_proofs = { version = "0.2.0" }
 sha3 = "0.7.2"
 eth-types = { path = "../eth-types" }
 digest = "0.7.6"

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -19,7 +19,7 @@ url = "2.2.2"
 pretty_assertions = "1.0.0"
 log = "0.4.14"
 env_logger = "0.9"
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2022_08_19" }
+halo2_proofs = { version = "0.2.0" }
 rand_chacha = "0.3"
 paste = "1.0"
 

--- a/zkevm-circuits/Cargo.toml
+++ b/zkevm-circuits/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2022_08_19" }
+halo2_proofs = { version = "0.2.0" }
 num = "0.4"
 sha3 = "0.10"
 array-init = "2.0.0"


### PR DESCRIPTION
In #724 the patch wasn't working with `0.1.0-beta` so it was left as
TODO.

But thanks to @pinkiebell who pointed out that it was required to bump
the base dep in the multiple Cargo.tomls this was solved.