### PR TITLE
Add test function to report opcode gas cost in state circuit

### DIFF
--- a/bus-mapping/src/evm/opcodes/call.rs
+++ b/bus-mapping/src/evm/opcodes/call.rs
@@ -13,7 +13,6 @@ use eth_types::{
 };
 use keccak256::EMPTY_HASH;
 use log::warn;
-use std::cmp::max;
 
 /// Placeholder structure used to implement [`Opcode`] trait over it
 /// corresponding to the `OpcodeId::CALL` `OpcodeId`.
@@ -34,21 +33,7 @@ impl Opcode for Call {
         let ret_length = geth_step.stack.nth_last(6)?.as_usize();
 
         // we need to keep the memory until parse_call complete
-        let call_ctx = state.call_ctx_mut()?;
-        let args_minimal = if args_length != 0 {
-            args_offset + args_length
-        } else {
-            0
-        };
-        let ret_minimal = if ret_length != 0 {
-            ret_offset + ret_length
-        } else {
-            0
-        };
-        if args_minimal != 0 || ret_minimal != 0 {
-            let minimal_length = max(args_minimal, ret_minimal);
-            call_ctx.memory.extend_at_least(minimal_length);
-        }
+        state.call_expand_memory(args_offset, args_length, ret_offset, ret_length)?;
 
         let tx_id = state.tx_ctx.id();
         let call = state.parse_call(geth_step)?;

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -26,7 +26,7 @@ use witness::Block;
 pub struct EvmCircuit<F> {
     fixed_table: [Column<Fixed>; 4],
     byte_table: [Column<Fixed>; 1],
-    execution: Box<ExecutionConfig<F>>,
+    pub(crate) execution: Box<ExecutionConfig<F>>,
 }
 
 impl<F: Field> EvmCircuit<F> {
@@ -388,7 +388,7 @@ mod evm_circuit_stats {
 
     /// This function prints to stdout a table with all the implemented states
     /// and their responsible opcodes with the following stats:
-    /// - height: number of rows used by the execution state
+    /// - height: number of rows in the EVM circuit used by the execution state
     /// - gas: gas value used for the opcode execution
     /// - height/gas: ratio between circuit cost and gas cost
     ///

--- a/zkevm-circuits/src/state_circuit.rs
+++ b/zkevm-circuits/src/state_circuit.rs
@@ -370,3 +370,134 @@ fn queries<F: Field>(meta: &mut VirtualCells<'_, F>, c: &StateCircuitConfig<F>) 
             * meta.query_advice(first_different_limb.bits[3], Rotation::cur()),
     }
 }
+
+#[cfg(test)]
+mod state_circuit_stats {
+    use crate::evm_circuit::step::ExecutionState;
+    use crate::evm_circuit::test::TestCircuit;
+    use bus_mapping::{circuit_input_builder::ExecState, mock::BlockData};
+    use eth_types::{bytecode, evm_types::OpcodeId, geth_types::GethData, Address};
+    use halo2_proofs::halo2curves::bn256::Fr;
+    use halo2_proofs::plonk::{Circuit, ConstraintSystem};
+    use mock::{eth, test_ctx::TestContext, MOCK_ACCOUNTS};
+    use strum::IntoEnumIterator;
+
+    /// This function prints to stdout a table with all the implemented states
+    /// and their responsible opcodes with the following stats:
+    /// - height: number of rows in the State circuit used by the execution
+    ///   state
+    /// - gas: gas value used for the opcode execution
+    /// - height/gas: ratio between circuit cost and gas cost
+    ///
+    /// Run with:
+    /// `cargo test -p zkevm-circuits --release get_state_states_stats --
+    /// --nocapture --ignored`
+    #[ignore]
+    #[test]
+    pub fn get_state_states_stats() {
+        // Get the list of implemented execution states by configuring the EVM Circuit
+        // and querying the step height for each possible execution state (only those
+        // implemented will return a Some value).
+        let mut meta = ConstraintSystem::<Fr>::default();
+        let circuit = TestCircuit::configure(&mut meta);
+
+        let mut implemented_states = Vec::new();
+        for state in ExecutionState::iter() {
+            let height = circuit.evm_circuit.execution.get_step_height_option(state);
+            if height.is_some() {
+                implemented_states.push(state);
+            }
+        }
+
+        let mut stats = Vec::new();
+        for state in implemented_states {
+            for opcode in state.responsible_opcodes() {
+                let mut code = bytecode! {
+                    PUSH2(0x100)
+                    MLOAD // Expand memory a bit
+                    PUSH2(0x00)
+                    EXTCODESIZE // Warm up 0x0 address
+                    PUSH2(0x8000)
+                    PUSH2(0x00)
+                    PUSH2(0x10)
+                    PUSH2(0x20)
+                    PUSH2(0x30)
+                };
+                // Make sure that opcodes that take an address as argument use addres 0x0, which
+                // will exist in the test.
+                match opcode {
+                    OpcodeId::BALANCE
+                    | OpcodeId::EXTCODESIZE
+                    | OpcodeId::EXTCODECOPY
+                    | OpcodeId::SELFDESTRUCT
+                    | OpcodeId::EXTCODEHASH => code.append(&bytecode! {
+                        PUSH2(0x40)
+                        PUSH2(0x00)
+                    }),
+                    OpcodeId::CALL
+                    | OpcodeId::CALLCODE
+                    | OpcodeId::DELEGATECALL
+                    | OpcodeId::STATICCALL => code.append(&bytecode! {
+                        PUSH2(0x00)
+                        PUSH2(0x50)
+                    }),
+                    _ => code.append(&bytecode! {
+                        PUSH2(0x40)
+                        PUSH2(0x50)
+                    }),
+                };
+                code.write_op(opcode);
+                code.write_op(OpcodeId::STOP);
+                let block: GethData = TestContext::<3, 1>::new(
+                    None,
+                    |accs| {
+                        accs[0]
+                            .address(MOCK_ACCOUNTS[0])
+                            .balance(eth(10))
+                            .code(code.clone());
+                        accs[1].address(MOCK_ACCOUNTS[1]).balance(eth(10));
+                        accs[2].address(Address::zero()).balance(eth(10)).code(code);
+                    },
+                    |mut txs, accs| {
+                        txs[0]
+                            .from(accs[1].address)
+                            .to(accs[0].address)
+                            .input(vec![1, 2, 3, 4, 5, 6, 7].into());
+                    },
+                    |block, _tx| block.number(0xcafeu64),
+                )
+                .unwrap()
+                .into();
+                let mut builder =
+                    BlockData::new_from_geth_data(block.clone()).new_circuit_input_builder();
+                builder
+                    .handle_block(&block.eth_block, &block.geth_traces)
+                    .unwrap();
+                let step_index = 1 + 11; // 1 is for the BeginTx, 11 for the bytecode opcodes.
+                let step = &builder.block.txs[0].steps()[step_index];
+                let step_next = &builder.block.txs[0].steps()[step_index + 1];
+                assert_eq!(ExecState::Op(opcode), step.exec_state);
+                let h = step_next.rwc.0 - step.rwc.0;
+
+                let gas_cost = block.geth_traces[0].struct_logs[11].gas_cost.0;
+                stats.push((state, opcode, h, gas_cost));
+            }
+        }
+
+        println!(
+            "| {: <14} | {: <14} | {: <2} | {: >6} | {: <5} |",
+            "state", "opcode", "h", "g", "h/g"
+        );
+        println!("| ---            | ---            | ---|    --- | ---   |");
+        for (state, opcode, height, gas_cost) in stats {
+            println!(
+                "| {: <14?} | {: <14?} | {: >2} | {: >6} | {: >1.3} |",
+                state,
+                opcode,
+                height,
+                gas_cost,
+                height as f64 / gas_cost as f64
+            );
+        }
+    }
+}


### PR DESCRIPTION
This test function prints a table with the implemented opcodes and their gas cost, state circuit cost (height / number of rows), and the ratio between the two.  This is similar to https://github.com/privacy-scaling-explorations/zkevm-circuits/pull/616 but for the State Circuit.  The test bytecode does some extra steps so that the opcode avoids extra gas cost due to memory expansions / warming up accounts.

Also add memory expansion for call-like dummy opcodes since the memory check check for CALLCODE, DELEGATECALL and STATICCALL was failing because the memory expansion was not being done.

The resulting table is the following:


| state          | opcode         | h   | g     | h/g    |
| -------------- | -------------- | --- | ----- | ------ |
| STOP           | STOP           | 2   | 0     | inf    |
| ADD_SUB        | ADD            | 3   | 3     | 1.000  |
| ADD_SUB        | SUB            | 3   | 3     | 1.000  |
| MUL_DIV_MOD    | MUL            | 3   | 5     | 0.600  |
| MUL_DIV_MOD    | DIV            | 3   | 5     | 0.600  |
| MUL_DIV_MOD    | MOD            | 3   | 5     | 0.600  |
| SDIV_SMOD      | SDIV           | 3   | 5     | 0.600  |
| SDIV_SMOD      | SMOD           | 3   | 5     | 0.600  |
| ADDMOD         | ADDMOD         | 4   | 8     | 0.500  |
| MULMOD         | MULMOD         | 4   | 8     | 0.500  |
| EXP            | EXP            | 3   | 60    | 0.050  |
| SIGNEXTEND     | SIGNEXTEND     | 3   | 5     | 0.600  |
| CMP            | LT             | 3   | 3     | 1.000  |
| CMP            | GT             | 3   | 3     | 1.000  |
| CMP            | EQ             | 3   | 3     | 1.000  |
| SCMP           | SLT            | 3   | 3     | 1.000  |
| SCMP           | SGT            | 3   | 3     | 1.000  |
| ISZERO         | ISZERO         | 2   | 3     | 0.667  |
| BITWISE        | AND            | 3   | 3     | 1.000  |
| BITWISE        | OR             | 3   | 3     | 1.000  |
| BITWISE        | XOR            | 3   | 3     | 1.000  |
| NOT            | NOT            | 2   | 3     | 0.667  |
| BYTE           | BYTE           | 3   | 3     | 1.000  |
| SHL            | SHL            | 3   | 3     | 1.000  |
| SHR            | SHR            | 3   | 3     | 1.000  |
| SAR            | SAR            | 3   | 3     | 1.000  |
| SHA3           | SHA3           | 67  | 42    | 1.595  |
| ADDRESS        | ADDRESS        | 2   | 2     | 1.000  |
| BALANCE        | BALANCE        | 3   | 100   | 0.030  |
| ORIGIN         | ORIGIN         | 2   | 2     | 1.000  |
| CALLER         | CALLER         | 2   | 2     | 1.000  |
| CALLVALUE      | CALLVALUE      | 2   | 2     | 1.000  |
| CALLDATALOAD   | CALLDATALOAD   | 4   | 3     | 1.333  |
| CALLDATASIZE   | CALLDATASIZE   | 2   | 2     | 1.000  |
| CALLDATACOPY   | CALLDATACOPY   | 53  | 9     | 5.889  |
| CODESIZE       | CODESIZE       | 1   | 2     | 0.500  |
| CODECOPY       | CODECOPY       | 51  | 9     | 5.667  |
| GASPRICE       | GASPRICE       | 2   | 2     | 1.000  |
| EXTCODESIZE    | EXTCODESIZE    | 3   | 100   | 0.030  |
| EXTCODECOPY    | EXTCODECOPY    | 5   | 103   | 0.049  |
| RETURNDATASIZE | RETURNDATASIZE | 1   | 2     | 0.500  |
| RETURNDATACOPY | RETURNDATACOPY | 3   | 9     | 0.333  |
| EXTCODEHASH    | EXTCODEHASH    | 9   | 100   | 0.090  |
| BLOCKHASH      | BLOCKHASH      | 2   | 20    | 0.100  |
| BLOCKCTXU64    | TIMESTAMP      | 1   | 2     | 0.500  |
| BLOCKCTXU64    | NUMBER         | 1   | 2     | 0.500  |
| BLOCKCTXU64    | GASLIMIT       | 1   | 2     | 0.500  |
| BLOCKCTXU160   | COINBASE       | 1   | 2     | 0.500  |
| BLOCKCTXU256   | DIFFICULTY     | 1   | 2     | 0.500  |
| BLOCKCTXU256   | BASEFEE        | 1   | 2     | 0.500  |
| CHAINID        | CHAINID        | 1   | 2     | 0.500  |
| SELFBALANCE    | SELFBALANCE    | 3   | 5     | 0.600  |
| POP            | POP            | 1   | 2     | 0.500  |
| MEMORY         | MLOAD          | 34  | 3     | 11.333 |
| MEMORY         | MSTORE         | 34  | 3     | 11.333 |
| MEMORY         | MSTORE8        | 3   | 3     | 1.000  |
| SLOAD          | SLOAD          | 8   | 2100  | 0.004  |
| SSTORE         | SSTORE         | 10  | 22100 | 0.000  |
| JUMP           | JUMP           | 3   | 8     | 0.375  |
| JUMPI          | JUMPI          | 3   | 10    | 0.300  |
| PC             | PC             | 1   | 2     | 0.500  |
| MSIZE          | MSIZE          | 1   | 2     | 0.500  |
| GAS            | GAS            | 1   | 2     | 0.500  |
| JUMPDEST       | JUMPDEST       | 0   | 1     | 0.000  |
| PUSH           | PUSH1          | 1   | 3     | 0.333  |
| PUSH           | PUSH2          | 1   | 3     | 0.333  |
| PUSH           | PUSH3          | 1   | 3     | 0.333  |
| PUSH           | PUSH4          | 1   | 3     | 0.333  |
| PUSH           | PUSH5          | 1   | 3     | 0.333  |
| PUSH           | PUSH6          | 1   | 3     | 0.333  |
| PUSH           | PUSH7          | 1   | 3     | 0.333  |
| PUSH           | PUSH8          | 1   | 3     | 0.333  |
| PUSH           | PUSH9          | 1   | 3     | 0.333  |
| PUSH           | PUSH10         | 1   | 3     | 0.333  |
| PUSH           | PUSH11         | 1   | 3     | 0.333  |
| PUSH           | PUSH12         | 1   | 3     | 0.333  |
| PUSH           | PUSH13         | 1   | 3     | 0.333  |
| PUSH           | PUSH14         | 1   | 3     | 0.333  |
| PUSH           | PUSH15         | 1   | 3     | 0.333  |
| PUSH           | PUSH16         | 1   | 3     | 0.333  |
| PUSH           | PUSH17         | 1   | 3     | 0.333  |
| PUSH           | PUSH18         | 1   | 3     | 0.333  |
| PUSH           | PUSH19         | 1   | 3     | 0.333  |
| PUSH           | PUSH20         | 1   | 3     | 0.333  |
| PUSH           | PUSH21         | 1   | 3     | 0.333  |
| PUSH           | PUSH22         | 1   | 3     | 0.333  |
| PUSH           | PUSH23         | 1   | 3     | 0.333  |
| PUSH           | PUSH24         | 1   | 3     | 0.333  |
| PUSH           | PUSH25         | 1   | 3     | 0.333  |
| PUSH           | PUSH26         | 1   | 3     | 0.333  |
| PUSH           | PUSH27         | 1   | 3     | 0.333  |
| PUSH           | PUSH28         | 1   | 3     | 0.333  |
| PUSH           | PUSH29         | 1   | 3     | 0.333  |
| PUSH           | PUSH30         | 1   | 3     | 0.333  |
| PUSH           | PUSH31         | 1   | 3     | 0.333  |
| PUSH           | PUSH32         | 1   | 3     | 0.333  |
| DUP            | DUP1           | 2   | 3     | 0.667  |
| DUP            | DUP2           | 2   | 3     | 0.667  |
| DUP            | DUP3           | 2   | 3     | 0.667  |
| DUP            | DUP4           | 2   | 3     | 0.667  |
| DUP            | DUP5           | 2   | 3     | 0.667  |
| DUP            | DUP6           | 2   | 3     | 0.667  |
| DUP            | DUP7           | 2   | 3     | 0.667  |
| DUP            | DUP8           | 2   | 3     | 0.667  |
| DUP            | DUP9           | 2   | 3     | 0.667  |
| DUP            | DUP10          | 3   | 3     | 1.000  |
| DUP            | DUP11          | 3   | 3     | 1.000  |
| DUP            | DUP12          | 3   | 3     | 1.000  |
| DUP            | DUP13          | 3   | 3     | 1.000  |
| DUP            | DUP14          | 3   | 3     | 1.000  |
| DUP            | DUP15          | 3   | 3     | 1.000  |
| DUP            | DUP16          | 3   | 3     | 1.000  |
| SWAP           | SWAP1          | 4   | 3     | 1.333  |
| SWAP           | SWAP2          | 4   | 3     | 1.333  |
| SWAP           | SWAP3          | 4   | 3     | 1.333  |
| SWAP           | SWAP4          | 4   | 3     | 1.333  |
| SWAP           | SWAP5          | 4   | 3     | 1.333  |
| SWAP           | SWAP6          | 4   | 3     | 1.333  |
| SWAP           | SWAP7          | 4   | 3     | 1.333  |
| SWAP           | SWAP8          | 4   | 3     | 1.333  |
| SWAP           | SWAP9          | 3   | 3     | 1.000  |
| SWAP           | SWAP10         | 3   | 3     | 1.000  |
| SWAP           | SWAP11         | 3   | 3     | 1.000  |
| SWAP           | SWAP12         | 3   | 3     | 1.000  |
| SWAP           | SWAP13         | 3   | 3     | 1.000  |
| SWAP           | SWAP14         | 3   | 3     | 1.000  |
| SWAP           | SWAP15         | 3   | 3     | 1.000  |
| SWAP           | SWAP16         | 3   | 3     | 1.000  |
| LOG            | LOG0           | 135 | 887   | 0.152  |
| LOG            | LOG1           | 137 | 1262  | 0.109  |
| LOG            | LOG2           | 139 | 1637  | 0.085  |
| LOG            | LOG3           | 141 | 2012  | 0.070  |
| LOG            | LOG4           | 143 | 2387  | 0.060  |
| CREATE         | CREATE         | 6   | 32000 | 0.000  |
| CALL           | CALL           | 44  | 14273 | 0.003  |
| CALLCODE       | CALLCODE       | 1   | 14273 | 0.000  |
| RETURN         | RETURN         | 0   | 0     | NaN    |
| DELEGATECALL   | DELEGATECALL   | 1   | 180   | 0.006  |
| CREATE2        | CREATE2        | 6   | 32012 | 0.000  |
| STATICCALL     | STATICCALL     | 1   | 180   | 0.006  |
| SELFDESTRUCT   | SELFDESTRUCT   | 3   | 5000  | 0.001  |

Resolve https://github.com/privacy-scaling-explorations/zkevm-chain/issues/15