### PR TITLE
Remove forked bitvec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,10 +213,11 @@ dependencies = [
 
 [[package]]
 name = "bitvec"
-version = "0.20.5"
-source = "git+https://github.com/ed255/bitvec.git?rev=5cfc5fa8496c66872d21905e677120fc3e79693c#5cfc5fa8496c66872d21905e677120fc3e79693c"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
 dependencies = [
- "funty 1.2.0",
+ "funty 1.1.0",
  "radium 0.6.2",
  "tap",
  "wyz 0.2.0",
@@ -1585,9 +1586,9 @@ dependencies = [
 
 [[package]]
 name = "funty"
-version = "1.2.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "funty"
@@ -2624,7 +2625,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373b1a4c1338d9cd3d1fa53b3a11bdab5ab6bd80a20f7f7becd76953ae2be909"
 dependencies = [
  "arrayvec",
- "bitvec 0.20.5",
+ "bitvec 0.20.4",
  "byte-slice-cast",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,6 @@ members = [
 ]
 
 [patch.crates-io]
-# This fork makes bitvec 0.20.x work with funty 1.1 and funty 1.2.  Without
-# this fork, bitvec 0.20.x is incompatible with funty 1.2, which we depend on,
-# and leads to a compilation error.  This can be removed once the upstream PR
-# is resolved: https://github.com/bitvecto-rs/bitvec/pull/141
-bitvec = { git = "https://github.com/ed255/bitvec.git", rev = "5cfc5fa8496c66872d21905e677120fc3e79693c" }
 halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2022_08_19" }
 
 # Definition of benchmarks profile to use.


### PR DESCRIPTION
The compliation error comming from the funty dependency of bitvec isn't happening anymore, so we remove the patched dependency to the forked bitvec.

Resolve https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/163