### PR TITLE
Modify `PiCircuitConfig` to receive `TxTable` and `BlockTable`.

### DIFF
--- a/zkevm-circuits/src/pi_circuit.rs
+++ b/zkevm-circuits/src/pi_circuit.rs
@@ -13,10 +13,11 @@ use ethers_core::types::Block;
 use halo2_proofs::plonk::Instance;
 
 use crate::table::TxFieldTag;
+use crate::table::TxTable;
 use crate::util::random_linear_combine_word as rlc;
 use halo2_proofs::{
     circuit::{AssignedCell, Layouter, Region, SimpleFloorPlanner, Value},
-    plonk::{Advice, Circuit, Column, ConstraintSystem, Error, Fixed, Selector},
+    plonk::{Advice, Circuit, Column, ConstraintSystem, Error, Selector},
     poly::Rotation,
 };
 
@@ -159,11 +160,7 @@ pub struct PiCircuitConfig<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: u
     block_value: Column<Advice>,
 
     q_tx_table: Selector,
-    tx_id: Column<Advice>,
-    tag: Column<Fixed>,
-    index: Column<Advice>,
-    tx_value: Column<Advice>,
-
+    tx_table: TxTable,
     raw_public_inputs: Column<Advice>,
     rpi_rlc_acc: Column<Advice>,
     rand_rpi: Column<Advice>,
@@ -178,17 +175,10 @@ pub struct PiCircuitConfig<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: u
 impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize>
     PiCircuitConfig<F, MAX_TXS, MAX_CALLDATA>
 {
-    fn new(meta: &mut ConstraintSystem<F>) -> Self {
+    fn new(meta: &mut ConstraintSystem<F>, block_value: Column<Advice>, tx_table: TxTable) -> Self {
         let q_block_table = meta.selector();
-        // BlockTable
-        let block_value = meta.advice_column();
 
         let q_tx_table = meta.selector();
-        // Tx Table
-        let tx_id = meta.advice_column();
-        let tag = meta.fixed_column();
-        let index = meta.advice_column();
-        let tx_value = meta.advice_column();
 
         let raw_public_inputs = meta.advice_column();
         let rpi_rlc_acc = meta.advice_column();
@@ -205,7 +195,7 @@ impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize>
 
         // 0.0 rpi_rlc_acc[0] == RLC(raw_public_inputs, rand_rpi)
         meta.create_gate(
-            "rpi_rlc_acc[i] = rand_rpi * rpi_rlc_acc[i+1] + raw_public_inputs[i] ",
+            "rpi_rlc_acc[i] = rand_rpi * rpi_rlc_acc[i+1] + raw_public_inputs[i]",
             |meta| {
                 // q_not_end * row.rpi_rlc_acc ==
                 // (q_not_end * row_next.rpi_rlc_acc * row.rand_rpi + row.raw_public_inputs )
@@ -239,7 +229,7 @@ impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize>
 
         // 0.2 Block table -> value column match with raw_public_inputs at expected
         // offset
-        meta.create_gate("", |meta| {
+        meta.create_gate("block_table[i] = raw_public_inputs[offset + i]", |meta| {
             let q_block_table = meta.query_selector(q_block_table);
             let block_value = meta.query_advice(block_value, Rotation::cur());
             let rpi_block_value = meta.query_advice(raw_public_inputs, Rotation::cur());
@@ -257,7 +247,7 @@ impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize>
                 // row.q_tx_table * row.tx_table.tx_id
                 // == row.q_tx_table * row_offset_tx_table_tx_id.raw_public_inputs
                 let q_tx_table = meta.query_selector(q_tx_table);
-                let tx_id = meta.query_advice(tx_id, Rotation::cur());
+                let tx_id = meta.query_advice(tx_table.tx_id, Rotation::cur());
                 let rpi_tx_id = meta.query_advice(raw_public_inputs, Rotation(offset as i32));
 
                 vec![q_tx_table * (tx_id - rpi_tx_id)]
@@ -270,7 +260,7 @@ impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize>
                 // row.q_tx_table * row.tx_table.tx_index
                 // == row.q_tx_table * row_offset_tx_table_tx_index.raw_public_inputs
                 let q_tx_table = meta.query_selector(q_tx_table);
-                let tx_index = meta.query_advice(index, Rotation::cur());
+                let tx_index = meta.query_advice(tx_table.index, Rotation::cur());
                 let rpi_tx_index =
                     meta.query_advice(raw_public_inputs, Rotation((offset + tx_table_len) as i32));
 
@@ -284,7 +274,7 @@ impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize>
                 // row.q_tx_table * row.tx_table.tx_value
                 // == row.q_tx_table * row_offset_tx_table_tx_value.raw_public_inputs
                 let q_tx_table = meta.query_selector(q_tx_table);
-                let tx_value = meta.query_advice(tx_value, Rotation::cur());
+                let tx_value = meta.query_advice(tx_table.value, Rotation::cur());
                 let rpi_tx_value = meta.query_advice(
                     raw_public_inputs,
                     Rotation((offset + 2 * tx_table_len) as i32),
@@ -298,10 +288,7 @@ impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize>
             q_block_table,
             block_value,
             q_tx_table,
-            tx_id,
-            tag,
-            index,
-            tx_value,
+            tx_table,
             raw_public_inputs,
             rpi_rlc_acc,
             rand_rpi,
@@ -335,17 +322,26 @@ impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize>
         let tx_id = F::from(tx_id as u64);
         let tag = F::from(tag as u64);
         let index = F::from(index as u64);
-        let tx_value = tx_value;
 
         self.q_tx_table.enable(region, offset)?;
 
         // Assign vals to Tx_table
-        region.assign_advice(|| "tx_id", self.tx_id, offset, || Value::known(tx_id))?;
-        region.assign_fixed(|| "tag", self.tag, offset, || Value::known(tag))?;
-        region.assign_advice(|| "index", self.index, offset, || Value::known(index))?;
+        region.assign_advice(
+            || "tx_id",
+            self.tx_table.tx_id,
+            offset,
+            || Value::known(tx_id),
+        )?;
+        region.assign_advice(|| "tag", self.tx_table.tag, offset, || Value::known(tag))?;
+        region.assign_advice(
+            || "index",
+            self.tx_table.index,
+            offset,
+            || Value::known(index),
+        )?;
         region.assign_advice(
             || "tx_value",
-            self.tx_value,
+            self.tx_table.value,
             offset,
             || Value::known(tx_value),
         )?;
@@ -691,7 +687,9 @@ impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize> Circuit<F>
     }
 
     fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
-        PiCircuitConfig::new(meta)
+        let block_value = meta.advice_column();
+        let tx_table = TxTable::construct(meta);
+        PiCircuitConfig::new(meta, block_value, tx_table)
     }
 
     fn synthesize(


### PR DESCRIPTION
Adapt `PiCircuitConfig::new()` so it can receive `TxTable` and `BlockTable`. This allows for the tables to be shared among several circuits in the SuperCircuit. 

The `Tag` column in the `TxTable` has been switched from fixed to advice, to agree with the definition used in the rest of the code.