### PR TITLE
Fix order of block hash assignment

### DIFF
--- a/zkevm-circuits/src/witness/block.rs
+++ b/zkevm-circuits/src/witness/block.rs
@@ -104,21 +104,23 @@ impl BlockContext {
                     ),
                 ],
             ],
-            self.history_hashes
-                .iter()
-                .rev()
-                .enumerate()
-                .map(|(idx, hash)| {
-                    [
-                        F::from(BlockContextFieldTag::BlockHash as u64),
-                        (self.number - idx - 1).to_scalar().unwrap(),
-                        RandomLinearCombination::random_linear_combine(
-                            hash.to_le_bytes(),
-                            randomness,
-                        ),
-                    ]
-                })
-                .collect(),
+            {
+                let len_history = self.history_hashes.len();
+                self.history_hashes
+                    .iter()
+                    .enumerate()
+                    .map(|(idx, hash)| {
+                        [
+                            F::from(BlockContextFieldTag::BlockHash as u64),
+                            (self.number - len_history + idx).to_scalar().unwrap(),
+                            RandomLinearCombination::random_linear_combine(
+                                hash.to_le_bytes(),
+                                randomness,
+                            ),
+                        ]
+                    })
+                    .collect()
+            },
         ]
         .concat()
     }


### PR DESCRIPTION
Fix #716 
[Handling `history_hashes` in circuit input builder](https://github.com/privacy-scaling-explorations/zkevm-circuits/blob/main/bus-mapping/src/circuit_input_builder/block.rs#L48) is valid, but [assigning block table](https://github.com/privacy-scaling-explorations/zkevm-circuits/blob/main/zkevm-circuits/src/witness/block.rs#L114) has invalid order. Lastest block hash is stored in last element of `history_hashes`. But in assignment, first element of `history_hashes` is used for lastest block.
So imo, just fixing order in assignment can solve this issue. Are there any other issues in that?