### PR TITLE
Constrain CallContext initial value to be 0

### DIFF
--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -314,8 +314,9 @@ pub fn gen_begin_tx_ops(state: &mut CircuitInputStateRef) -> Result<ExecStep, Er
             CallContextField::IsPersistent,
             (call.is_persistent as usize).into(),
         ),
+        (CallContextField::IsSuccess, call.is_success.to_word()),
     ] {
-        state.call_context_read(&mut exec_step, call.call_id, field, value);
+        state.call_context_write(&mut exec_step, call.call_id, field, value);
     }
 
     // Increase caller's nonce
@@ -423,7 +424,7 @@ pub fn gen_begin_tx_ops(state: &mut CircuitInputStateRef) -> Result<ExecStep, Er
                 (CallContextField::IsCreate, 0.into()),
                 (CallContextField::CodeHash, code_hash.to_word()),
             ] {
-                state.call_context_read(&mut exec_step, call.call_id, field, value);
+                state.call_context_write(&mut exec_step, call.call_id, field, value);
             }
 
             Ok(exec_step)

--- a/bus-mapping/src/evm/opcodes/call.rs
+++ b/bus-mapping/src/evm/opcodes/call.rs
@@ -98,7 +98,7 @@ impl Opcode for Call {
                 (call.is_persistent as u64).into(),
             ),
         ] {
-            state.call_context_read(&mut exec_step, call.call_id, field, value);
+            state.call_context_write(&mut exec_step, call.call_id, field, value);
         }
 
         state.transfer(
@@ -233,7 +233,7 @@ impl Opcode for Call {
                     (CallContextField::IsCreate, 0.into()),
                     (CallContextField::CodeHash, call.code_hash.to_word()),
                 ] {
-                    state.call_context_read(&mut exec_step, call.call_id, field, value);
+                    state.call_context_write(&mut exec_step, call.call_id, field, value);
                 }
 
                 Ok(vec![exec_step])

--- a/eth-types/src/lib.rs
+++ b/eth-types/src/lib.rs
@@ -185,6 +185,16 @@ impl ToWord for Address {
     }
 }
 
+impl ToWord for bool {
+    fn to_word(&self) -> Word {
+        if *self {
+            Word::one()
+        } else {
+            Word::zero()
+        }
+    }
+}
+
 impl<F: Field> ToScalar<F> for Address {
     fn to_scalar(&self) -> Option<F> {
         let mut bytes = [0u8; 32];

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -173,26 +173,30 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
         }
 
         cb.require_step_state_transition(StepStateTransition {
-            // 19 read/write including:
-            //   - Read CallContext TxId
-            //   - Read CallContext RwCounterEndOfReversion
-            //   - Read CallContext IsPersistent
+            // 23 reads and writes:
+            //   - Write CallContext TxId
+            //   - Write CallContext RwCounterEndOfReversion
+            //   - Write CallContext IsPersistent
+            //   - Write CallContext IsSuccess
             //   - Write Account Nonce
             //   - Write TxAccessListAccount
             //   - Write TxAccessListAccount
             //   - Write Account Balance
             //   - Write Account Balance
             //   - Read Account CodeHash
-            //   - Read CallContext Depth
-            //   - Read CallContext CallerAddress
-            //   - Read CallContext CalleeAddress
-            //   - Read CallContext CallDataOffset
-            //   - Read CallContext CallDataLength
-            //   - Read CallContext Value
-            //   - Read CallContext IsStatic
-            //   - Read CallContext LastCalleeId
-            //   - Read CallContext LastCalleeReturnDataOffset
-            //   - Read CallContext LastCalleeReturnDataLength
+            //   - Write CallContext Depth
+            //   - Write CallContext CallerAddress
+            //   - Write CallContext CalleeAddress
+            //   - Write CallContext CallDataOffset
+            //   - Write CallContext CallDataLength
+            //   - Write CallContext Value
+            //   - Write CallContext IsStatic
+            //   - Write CallContext LastCalleeId
+            //   - Write CallContext LastCalleeReturnDataOffset
+            //   - Write CallContext LastCalleeReturnDataLength
+            //   - Write CallContext IsRoot
+            //   - Write CallContext IsCreate
+            //   - Write CallContext CodeHash
             rw_counter: Delta(23.expr()),
             call_id: To(call_id.expr()),
             is_root: To(true.expr()),

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -49,8 +49,20 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
         // Use rw_counter of the step which triggers next call as its call_id.
         let call_id = cb.curr.state.rw_counter.clone();
 
-        let tx_id = cb.call_context(Some(call_id.expr()), CallContextFieldTag::TxId);
-        let mut reversion_info = cb.reversion_info(None);
+        let tx_id = cb.query_cell();
+        cb.call_context_lookup(
+            1.expr(),
+            Some(call_id.expr()),
+            CallContextFieldTag::TxId,
+            tx_id.expr(),
+        );
+        let mut reversion_info = cb.reversion_info_write(None);
+        cb.call_context_lookup(
+            1.expr(),
+            Some(call_id.expr()),
+            CallContextFieldTag::IsSuccess,
+            reversion_info.is_persistent(),
+        );
 
         let [tx_nonce, tx_gas, tx_caller_address, tx_callee_address, tx_is_create, tx_call_data_length, tx_call_data_gas_cost] =
             [
@@ -138,7 +150,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             code_hash.expr(),
         );
 
-        // Setup next call's context.
+        // Setup first call's context.
         for (field_tag, value) in [
             (CallContextFieldTag::Depth, 1.expr()),
             (CallContextFieldTag::CallerAddress, tx_caller_address.expr()),
@@ -157,7 +169,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             (CallContextFieldTag::IsCreate, 0.expr()),
             (CallContextFieldTag::CodeHash, code_hash.expr()),
         ] {
-            cb.call_context_lookup(false.expr(), Some(call_id.expr()), field_tag, value);
+            cb.call_context_lookup(true.expr(), Some(call_id.expr()), field_tag, value);
         }
 
         cb.require_step_state_transition(StepStateTransition {
@@ -181,7 +193,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             //   - Read CallContext LastCalleeId
             //   - Read CallContext LastCalleeReturnDataOffset
             //   - Read CallContext LastCalleeReturnDataLength
-            rw_counter: Delta(22.expr()),
+            rw_counter: Delta(23.expr()),
             call_id: To(call_id.expr()),
             is_root: To(true.expr()),
             is_create: To(false.expr()),
@@ -222,7 +234,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
     ) -> Result<(), Error> {
         let gas_fee = tx.gas_price * tx.gas;
         let [caller_balance_pair, callee_balance_pair, (callee_code_hash, _)] =
-            [step.rw_indices[6], step.rw_indices[7], step.rw_indices[8]]
+            [step.rw_indices[7], step.rw_indices[8], step.rw_indices[9]]
                 .map(|idx| block.rws[idx].account_value_pair());
 
         self.tx_id

--- a/zkevm-circuits/src/evm_circuit/execution/call.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/call.rs
@@ -89,7 +89,7 @@ impl<F: Field> ExecutionGadget<F> for CallGadget<F> {
         let callee_call_id = cb.curr.state.rw_counter.clone();
 
         let tx_id = cb.call_context(None, CallContextFieldTag::TxId);
-        let mut reversion_info = cb.reversion_info(None);
+        let mut reversion_info = cb.reversion_info_read(None);
         let [current_address, is_static, depth] = [
             CallContextFieldTag::CalleeAddress,
             CallContextFieldTag::IsStatic,
@@ -134,7 +134,7 @@ impl<F: Field> ExecutionGadget<F> for CallGadget<F> {
         );
 
         // Propagate rw_counter_end_of_reversion and is_persistent
-        let mut callee_reversion_info = cb.reversion_info(Some(callee_call_id.expr()));
+        let mut callee_reversion_info = cb.reversion_info_write(Some(callee_call_id.expr()));
         cb.require_equal(
             "callee_is_persistent == is_persistent ⋅ is_success",
             callee_reversion_info.is_persistent(),
@@ -281,7 +281,7 @@ impl<F: Field> ExecutionGadget<F> for CallGadget<F> {
                 (CallContextFieldTag::IsCreate, 0.expr()),
                 (CallContextFieldTag::CodeHash, callee_code_hash.expr()),
             ] {
-                cb.call_context_lookup(false.expr(), Some(callee_call_id.expr()), field_tag, value);
+                cb.call_context_lookup(true.expr(), Some(callee_call_id.expr()), field_tag, value);
             }
 
             // Give gas stipend if value is not zero

--- a/zkevm-circuits/src/evm_circuit/execution/extcodehash.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodehash.rs
@@ -44,7 +44,7 @@ impl<F: Field> ExecutionGadget<F> for ExtcodehashGadget<F> {
         cb.stack_pop(external_address.expr());
 
         let tx_id = cb.call_context(None, CallContextFieldTag::TxId);
-        let mut reversion_info = cb.reversion_info(None);
+        let mut reversion_info = cb.reversion_info_read(None);
 
         let is_warm = cb.query_bool();
         cb.account_access_list_write(

--- a/zkevm-circuits/src/evm_circuit/execution/sload.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sload.rs
@@ -41,7 +41,7 @@ impl<F: Field> ExecutionGadget<F> for SloadGadget<F> {
         let opcode = cb.query_cell();
 
         let tx_id = cb.call_context(None, CallContextFieldTag::TxId);
-        let mut reversion_info = cb.reversion_info(None);
+        let mut reversion_info = cb.reversion_info_read(None);
         let callee_address = cb.call_context(None, CallContextFieldTag::CalleeAddress);
 
         let key = cb.query_cell();

--- a/zkevm-circuits/src/evm_circuit/execution/sstore.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sstore.rs
@@ -53,7 +53,7 @@ impl<F: Field> ExecutionGadget<F> for SstoreGadget<F> {
         let is_static = cb.call_context(None, CallContextFieldTag::IsStatic);
         cb.require_zero("is_static is false", is_static.expr());
 
-        let mut reversion_info = cb.reversion_info(None);
+        let mut reversion_info = cb.reversion_info_read(None);
         let callee_address = cb.call_context(None, CallContextFieldTag::CalleeAddress);
 
         let key = cb.query_cell();

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -940,12 +940,21 @@ impl<'a, F: Field> ConstraintBuilder<'a, F> {
         );
     }
 
-    pub(crate) fn reversion_info(&mut self, call_id: Option<Expression<F>>) -> ReversionInfo<F> {
+    fn reversion_info(
+        &mut self,
+        call_id: Option<Expression<F>>,
+        is_write: bool,
+    ) -> ReversionInfo<F> {
         let [rw_counter_end_of_reversion, is_persistent] = [
             CallContextFieldTag::RwCounterEndOfReversion,
             CallContextFieldTag::IsPersistent,
         ]
-        .map(|field_tag| self.call_context(call_id.clone(), field_tag));
+        .map(|field_tag| {
+            let cell = self.query_cell();
+            self.call_context_lookup(is_write.expr(), call_id.clone(), field_tag, cell.expr());
+            cell
+        });
+
         ReversionInfo {
             rw_counter_end_of_reversion,
             is_persistent,
@@ -955,6 +964,20 @@ impl<'a, F: Field> ConstraintBuilder<'a, F> {
                 self.curr.state.reversible_write_counter.expr()
             },
         }
+    }
+
+    pub(crate) fn reversion_info_read(
+        &mut self,
+        call_id: Option<Expression<F>>,
+    ) -> ReversionInfo<F> {
+        self.reversion_info(call_id, false)
+    }
+
+    pub(crate) fn reversion_info_write(
+        &mut self,
+        call_id: Option<Expression<F>>,
+    ) -> ReversionInfo<F> {
+        self.reversion_info(call_id, true)
     }
 
     // Stack

--- a/zkevm-circuits/src/state_circuit/constraint_builder.rs
+++ b/zkevm-circuits/src/state_circuit/constraint_builder.rs
@@ -364,13 +364,12 @@ impl<F: Field> ConstraintBuilder<F> {
             "field_tag in CallContextFieldTag range",
             vec![(q.field_tag(), q.lookups.call_context_field_tag.clone())],
         );
-
+        self.require_zero("initial CallContext value is 0", q.initial_value());
         self.require_equal(
             "state_root is unchanged for CallContext",
             q.state_root(),
             q.state_root_prev(),
         );
-        // TODO: explain why call context doesn't need an initial value.
     }
 
     fn build_tx_log_constraints(&mut self, q: &Queries<F>) {


### PR DESCRIPTION
Satisfy the constraints by changing the initial CallContext lookups to be writes.