### PR TITLE
git: ignore submodules by default

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "evm-testvectors/tests"]
+	update = none
 	path = testool/tests
 	url = https://github.com/ethereum/tests
 
 [submodule "integration-tests/contracts/vendor/openzeppelin-contracts"]
+	update = none
 	path = integration-tests/contracts/vendor/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -90,7 +90,7 @@ fi
 
 if [ -n "$STEP_GENDATA" ]; then
     echo "+ Gen blockchain data..."
-    git submodule update --init --recursive contracts/vendor
+    git submodule update --init --recursive --checkout contracts/vendor
     rm gendata_output.json > /dev/null 2>&1 || true
     cargo run --bin gen_blockchain_data
 fi


### PR DESCRIPTION
Tools like `Cargo` will fetch dependencies w/ all submodules. Since the latest integration of ethereums-tests, this became a significant operation on CI runs. Luckily, cargo respects `submodule.<name>.update = none`.

Hence, submodules will be skipped by git but this can be explitly overriden via `git submodule update --init --checkout` - the `--checkout` flag is the important one.