### PR TITLE
Fix phase of `hash_input_rlc` in Bytecode circuit

### DIFF
--- a/zkevm-circuits/src/bytecode_circuit/bytecode_unroller.rs
+++ b/zkevm-circuits/src/bytecode_circuit/bytecode_unroller.rs
@@ -10,7 +10,10 @@ use eth_types::{Field, ToLittleEndian, Word};
 use gadgets::is_zero::{IsZeroChip, IsZeroConfig, IsZeroInstruction};
 use halo2_proofs::{
     circuit::{Layouter, Region, Value},
-    plonk::{Advice, Column, ConstraintSystem, Error, Expression, Fixed, Selector, VirtualCells},
+    plonk::{
+        Advice, Column, ConstraintSystem, Error, Expression, Fixed, SecondPhase, Selector,
+        VirtualCells,
+    },
     poly::Rotation,
 };
 use keccak256::plain::Keccak;
@@ -68,7 +71,7 @@ impl<F: Field> Config<F> {
         let q_last = meta.selector();
         let value = bytecode_table.value;
         let push_rindex = meta.advice_column();
-        let hash_input_rlc = meta.advice_column();
+        let hash_input_rlc = meta.advice_column_in(SecondPhase);
         let code_length = meta.advice_column();
         let byte_push_size = meta.advice_column();
         let is_final = meta.advice_column();

--- a/zkevm-circuits/src/bytecode_circuit/dev.rs
+++ b/zkevm-circuits/src/bytecode_circuit/dev.rs
@@ -72,7 +72,6 @@ impl<F: Field> BytecodeCircuitTester<F> {
             size: 2usize.pow(k),
         };
 
-        const NUM_BLINDING_ROWS: usize = 7 - 1;
         let prover = MockProver::<F>::run(k, &circuit, Vec::new()).unwrap();
         let result = prover.verify();
         if let Err(failures) = &result {
@@ -101,7 +100,6 @@ pub fn test_bytecode_circuit_unrolled<F: Field>(
         size: 2usize.pow(k),
     };
 
-    const NUM_BLINDING_ROWS: usize = 7 - 1;
     let prover = MockProver::<F>::run(k, &circuit, Vec::new()).unwrap();
     let result = prover.verify();
     if let Err(failures) = &result {


### PR DESCRIPTION
This PR aims to fix the phase of `hash_input_rlc` in Bytecode circuit cause it's containing value that depends on challenge usable after phase 1.

Bytecode circuit in `main` after #770 was just tested locally with real prover and failed expectedly, after this PR it's working again.

Thanks for @ed255 to spot that mistake.