### PR TITLE
Increase rw_counter_offset when doing a copy table lookup

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution/calldatacopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldatacopy.rs
@@ -139,7 +139,7 @@ impl<F: Field> ExecutionGadget<F> for CallDataCopyGadget<F> {
         // State transition
         let step_state_transition = StepStateTransition {
             // 1 tx id lookup + 3 stack pop + option(calldatalength lookup)
-            rw_counter: Delta(cb.rw_counter_offset() + copy_rwc_inc.expr()),
+            rw_counter: Delta(cb.rw_counter_offset()),
             program_counter: Delta(1.expr()),
             stack_pointer: Delta(3.expr()),
             gas_left: Delta(

--- a/zkevm-circuits/src/evm_circuit/execution/calldatacopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldatacopy.rs
@@ -125,7 +125,6 @@ impl<F: Field> ExecutionGadget<F> for CallDataCopyGadget<F> {
                 memory_address.offset(),
                 memory_address.length(),
                 0.expr(), // for CALLDATACOPY rlc_acc is 0
-                cb.curr.state.rw_counter.expr() + cb.rw_counter_offset().expr(),
                 copy_rwc_inc.expr(),
             );
         });

--- a/zkevm-circuits/src/evm_circuit/execution/codecopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/codecopy.rs
@@ -94,7 +94,6 @@ impl<F: Field> ExecutionGadget<F> for CodeCopyGadget<F> {
                 dst_memory_addr.offset(),
                 dst_memory_addr.length(),
                 0.expr(), // for CODECOPY, rlc_acc is 0
-                cb.curr.state.rw_counter.expr() + cb.rw_counter_offset().expr(),
                 copy_rwc_inc.expr(),
             );
         });

--- a/zkevm-circuits/src/evm_circuit/execution/codecopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/codecopy.rs
@@ -107,7 +107,7 @@ impl<F: Field> ExecutionGadget<F> for CodeCopyGadget<F> {
 
         // Expected state transition.
         let step_state_transition = StepStateTransition {
-            rw_counter: Transition::Delta(cb.rw_counter_offset() + copy_rwc_inc.expr()),
+            rw_counter: Transition::Delta(cb.rw_counter_offset()),
             program_counter: Transition::Delta(1.expr()),
             stack_pointer: Transition::Delta(3.expr()),
             memory_word_size: Transition::To(memory_expansion.next_memory_word_size()),

--- a/zkevm-circuits/src/evm_circuit/execution/logs.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/logs.rs
@@ -161,7 +161,7 @@ impl<F: Field> ExecutionGadget<F> for LogGadget<F> {
         // State transition
 
         let step_state_transition = StepStateTransition {
-            rw_counter: Delta(cb.rw_counter_offset() + copy_rwc_inc.expr()),
+            rw_counter: Delta(cb.rw_counter_offset()),
             program_counter: Delta(1.expr()),
             stack_pointer: Delta(2.expr() + topic_count),
             memory_word_size: To(memory_expansion.next_memory_word_size()),

--- a/zkevm-circuits/src/evm_circuit/execution/logs.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/logs.rs
@@ -143,7 +143,6 @@ impl<F: Field> ExecutionGadget<F> for LogGadget<F> {
                 dst_addr,
                 memory_address.length(),
                 0.expr(), // for LOGN, rlc_acc is 0
-                cb.curr.state.rw_counter.expr() + cb.rw_counter_offset().expr(),
                 copy_rwc_inc.expr(),
             );
         });

--- a/zkevm-circuits/src/evm_circuit/execution/return.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/return.rs
@@ -170,7 +170,6 @@ impl<F: Field> ExecutionGadget<F> for ReturnGadget<F> {
                     return_data_offset.expr(),
                     copy_length.min(),
                     0.expr(),
-                    cb.curr.state.rw_counter.expr() + cb.rw_counter_offset().expr(),
                     copy_rw_increase.expr(),
                 );
             },

--- a/zkevm-circuits/src/evm_circuit/execution/sha3.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sha3.rs
@@ -59,7 +59,6 @@ impl<F: Field> ExecutionGadget<F> for Sha3Gadget<F> {
                 0.expr(), // dst_addr for CopyDataType::RlcAcc is 0.
                 memory_address.length(),
                 rlc_acc.expr(),
-                cb.curr.state.rw_counter.expr() + cb.rw_counter_offset(),
                 copy_rwc_inc.expr(),
             );
         });

--- a/zkevm-circuits/src/evm_circuit/execution/sha3.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sha3.rs
@@ -81,7 +81,7 @@ impl<F: Field> ExecutionGadget<F> for Sha3Gadget<F> {
         );
 
         let step_state_transition = StepStateTransition {
-            rw_counter: Transition::Delta(cb.rw_counter_offset() + copy_rwc_inc.expr()),
+            rw_counter: Transition::Delta(cb.rw_counter_offset()),
             program_counter: Transition::Delta(1.expr()),
             stack_pointer: Transition::Delta(1.expr()),
             memory_word_size: Transition::To(memory_expansion.next_memory_word_size()),

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -1106,10 +1106,8 @@ impl<'a, F: Field> ConstraintBuilder<'a, F> {
         dst_addr: Expression<F>,
         length: Expression<F>,
         rlc_acc: Expression<F>,
-        rw_counter: Expression<F>,
         rwc_inc: Expression<F>,
     ) {
-        self.rw_counter_offset = self.rw_counter_offset.clone() + rwc_inc.clone();
         self.add_lookup(
             "copy lookup",
             Lookup::CopyTable {
@@ -1123,10 +1121,15 @@ impl<'a, F: Field> ConstraintBuilder<'a, F> {
                 dst_addr,
                 length,
                 rlc_acc,
-                rw_counter,
-                rwc_inc,
+                rw_counter: self.curr.state.rw_counter.expr() + self.rw_counter_offset(),
+                rwc_inc: rwc_inc.clone(),
             },
         );
+        self.rw_counter_offset = self.rw_counter_offset.clone()
+            + match &self.condition {
+                Some(condition) => condition.clone(),
+                None => 1.expr(),
+            } * rwc_inc;
     }
 
     // Keccak Table

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -1109,6 +1109,7 @@ impl<'a, F: Field> ConstraintBuilder<'a, F> {
         rw_counter: Expression<F>,
         rwc_inc: Expression<F>,
     ) {
+        self.rw_counter_offset = self.rw_counter_offset.clone() + rwc_inc.clone();
         self.add_lookup(
             "copy lookup",
             Lookup::CopyTable {


### PR DESCRIPTION
Doing this allows us to do additional rw table lookups after copy table lookups.