### PR TITLE
fix: add `mock` dependency to zkevm-circuit `dev-dependencies`

### DIFF
--- a/zkevm-circuits/Cargo.toml
+++ b/zkevm-circuits/Cargo.toml
@@ -16,7 +16,7 @@ bus-mapping = { path = "../bus-mapping" }
 eth-types = { path = "../eth-types" }
 gadgets = { path = "../gadgets" }
 ethers-core = "0.17.0"
-ethers-signers = "0.17.0"
+ethers-signers = { version = "0.17.0", optional = true }
 mock = { path = "../mock", optional = true }
 strum = "0.24"
 strum_macros = "0.24"
@@ -48,4 +48,4 @@ rand_chacha = "0.3"
 
 [features]
 default = []
-test = ["mock"]
+test = ["ethers-signers", "mock"]

--- a/zkevm-circuits/Cargo.toml
+++ b/zkevm-circuits/Cargo.toml
@@ -39,10 +39,11 @@ subtle = "2.4"
 bus-mapping = { path = "../bus-mapping", features = ["test"] }
 criterion = "0.3"
 ctor = "0.1.22"
+ethers-signers = "0.17.0"
 hex = "0.4.3"
 itertools = "0.10.1"
+mock = { path = "../mock" }
 pretty_assertions = "1.0.0"
-ethers-signers = "0.17.0"
 rand_chacha = "0.3"
 
 [features]


### PR DESCRIPTION
It seems that test build is failed when running `cargo test` (without `--all-features` or `--feature test`) in `zkevm-circuit` folder.
```
error[E0433]: failed to resolve: use of undeclared crate or module `mock`
   --> zkevm-circuits/src/copy_circuit.rs:694:9
    |
694 |     use mock::test_ctx::helpers::account_0_code_account_1_no_code;
    |         ^^^^ use of undeclared crate or module `mock`
```
`mock` dependency was set to optional in PR https://github.com/privacy-scaling-explorations/zkevm-circuits/pull/786.
Fixed to add `mock` to `dev-dependencies` in `Cargo.toml` for tests.