### PR TITLE
optim/opcode-stats: print more detailed metrics per opcode

### DIFF
--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -389,6 +389,8 @@ mod evm_circuit_stats {
     /// This function prints to stdout a table with all the implemented states
     /// and their responsible opcodes with the following stats:
     /// - height: number of rows in the EVM circuit used by the execution state
+    /// - counts of used and unused cells
+    /// - utilization ratios of cells (used / available)
     /// - gas: gas value used for the opcode execution
     /// - height/gas: ratio between circuit cost and gas cost
     ///
@@ -400,6 +402,8 @@ mod evm_circuit_stats {
     pub fn get_evm_states_stats() {
         let mut meta = ConstraintSystem::<Fr>::default();
         let circuit = TestCircuit::configure(&mut meta);
+
+        circuit.evm_circuit.execution.instrument().print();
 
         let mut implemented_states = Vec::new();
         for state in ExecutionState::iter() {

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -1,5 +1,5 @@
-use super::util::{CachedRegion, CellManager, StoredExpression};
 use super::util::instrument::Instrument;
+use super::util::{CachedRegion, CellManager, StoredExpression};
 use crate::{
     evm_circuit::{
         param::{MAX_STEP_HEIGHT, STEP_WIDTH},

--- a/zkevm-circuits/src/evm_circuit/util.rs
+++ b/zkevm-circuits/src/evm_circuit/util.rs
@@ -16,9 +16,9 @@ use std::collections::BTreeMap;
 
 pub(crate) mod common_gadget;
 pub(crate) mod constraint_builder;
+pub(crate) mod instrument;
 pub(crate) mod math_gadget;
 pub(crate) mod memory_gadget;
-pub(crate) mod instrument;
 
 pub use gadgets::util::{and, not, or, select, sum};
 

--- a/zkevm-circuits/src/evm_circuit/util.rs
+++ b/zkevm-circuits/src/evm_circuit/util.rs
@@ -18,6 +18,7 @@ pub(crate) mod common_gadget;
 pub(crate) mod constraint_builder;
 pub(crate) mod math_gadget;
 pub(crate) mod memory_gadget;
+pub(crate) mod instrument;
 
 pub use gadgets::util::{and, not, or, select, sum};
 

--- a/zkevm-circuits/src/evm_circuit/util/instrument.rs
+++ b/zkevm-circuits/src/evm_circuit/util/instrument.rs
@@ -2,8 +2,8 @@ use halo2_proofs::arithmetic::FieldExt;
 use itertools::Itertools;
 
 use crate::evm_circuit::step::ExecutionState;
-use crate::evm_circuit::util::CellType;
 use crate::evm_circuit::util::constraint_builder::ConstraintBuilder;
+use crate::evm_circuit::util::CellType;
 
 /// Instrument captures metrics during the compilation of a circuit.
 #[derive(Clone, Debug, Default)]
@@ -18,8 +18,13 @@ impl Instrument {
         execution_state: ExecutionState,
         cb: &ConstraintBuilder<'a, F>,
     ) {
-        let sizes = cb.curr.cell_manager.get_stats()
-            .into_iter().sorted().collect::<Vec<_>>();
+        let sizes = cb
+            .curr
+            .cell_manager
+            .get_stats()
+            .into_iter()
+            .sorted()
+            .collect::<Vec<_>>();
 
         self.states.push((execution_state, sizes));
     }
@@ -41,10 +46,13 @@ impl Instrument {
             let top_height: usize = sizes.iter().map(|(_, (_, h, _))| *h).max().unwrap();
             let cells: usize = sizes.iter().map(|(_, (_, _, c))| *c).sum();
             let unused_cells = width * top_height - cells;
-            let utilization = ((cells as f64) / (width as f64 * top_height as f64) * 100f64).round();
+            let utilization =
+                ((cells as f64) / (width as f64 * top_height as f64) * 100f64).round();
 
-            println!("            col_type |  width | height |  cells | unused_cells | utilization");
-            println!("    {col_type:<16} | {width:>6} | {top_height:>6} | {cells:>6} | {unused_cells:>12} | {utilization:>6}%");
+            println!(
+                "  column_type        |  width | height |  cells | unused_cells | utilization"
+            );
+            println!("  {col_type:<18} | {width:>6} | {top_height:>6} | {cells:>6} | {unused_cells:>12} | {utilization:>6}%");
 
             sizes.iter().for_each(|(col_type, (width, height, cells))| {
 
@@ -52,7 +60,7 @@ impl Instrument {
                 let col_type = format!("{:?}", col_type);
                 let unused_cells = width * top_height - cells;
                 let utilization = ((*cells as f64) / (*width as f64 * top_height as f64) * 100f64).round();
-                println!("    {col_type:<16} | {width:>6} | {height:>6} | {cells:>6} | {unused_cells:>12} | {utilization:>6}%");
+                println!("  {col_type:<18} | {width:>6} | {height:>6} | {cells:>6} | {unused_cells:>12} | {utilization:>6}%");
             });
 
             println!();

--- a/zkevm-circuits/src/evm_circuit/util/instrument.rs
+++ b/zkevm-circuits/src/evm_circuit/util/instrument.rs
@@ -1,0 +1,60 @@
+use halo2_proofs::arithmetic::FieldExt;
+use itertools::Itertools;
+
+use crate::evm_circuit::step::ExecutionState;
+use crate::evm_circuit::util::CellType;
+use crate::evm_circuit::util::constraint_builder::ConstraintBuilder;
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct Instrument {
+    // States -> Cell Types -> (width, height, num_cells)
+    states: Vec<(ExecutionState, Vec<(CellType, (usize, usize, usize))>)>,
+}
+
+impl Instrument {
+    pub(crate) fn on_gadget_built<'a, F: FieldExt>(
+        &mut self,
+        execution_state: ExecutionState,
+        cb: &ConstraintBuilder<'a, F>,
+    ) {
+        let sizes = cb.curr.cell_manager.get_stats()
+            .into_iter().sorted().collect::<Vec<_>>();
+
+        self.states.push((execution_state, sizes));
+    }
+
+    pub(crate) fn print(&self) {
+        let mut states = self.states.clone();
+        states.sort_by_key(|(_, sizes)| {
+            let cells: usize = sizes.iter().map(|(_, (_, _, c))| *c).sum();
+            cells
+        });
+        states.reverse();
+
+        for (state, sizes) in states {
+            println!("{: <14?} {:?}", state, state.responsible_opcodes());
+
+            // Print overall metrics per execution state.
+            let col_type = "*";
+            let width: usize = sizes.iter().map(|(_, (w, _, _))| *w).sum();
+            let top_height: usize = sizes.iter().map(|(_, (_, h, _))| *h).max().unwrap();
+            let cells: usize = sizes.iter().map(|(_, (_, _, c))| *c).sum();
+            let unused_cells = width * top_height - cells;
+            let utilization = ((cells as f64) / (width as f64 * top_height as f64) * 100f64).round();
+
+            println!("            col_type |  width | height |  cells | unused_cells | utilization");
+            println!("    {col_type:<16} | {width:>6} | {top_height:>6} | {cells:>6} | {unused_cells:>12} | {utilization:>6}%");
+
+            sizes.iter().for_each(|(col_type, (width, height, cells))| {
+
+                // Print metrics per column type.
+                let col_type = format!("{:?}", col_type);
+                let unused_cells = width * top_height - cells;
+                let utilization = ((*cells as f64) / (*width as f64 * top_height as f64) * 100f64).round();
+                println!("    {col_type:<16} | {width:>6} | {height:>6} | {cells:>6} | {unused_cells:>12} | {utilization:>6}%");
+            });
+
+            println!();
+        }
+    }
+}

--- a/zkevm-circuits/src/evm_circuit/util/instrument.rs
+++ b/zkevm-circuits/src/evm_circuit/util/instrument.rs
@@ -5,11 +5,14 @@ use crate::evm_circuit::step::ExecutionState;
 use crate::evm_circuit::util::constraint_builder::ConstraintBuilder;
 use crate::evm_circuit::util::CellType;
 
+type StepSize = Vec<(CellType, ColumnSize)>;
+type ColumnSize = (usize, usize, usize);
+
 /// Instrument captures metrics during the compilation of a circuit.
 #[derive(Clone, Debug, Default)]
 pub(crate) struct Instrument {
     // States -> Cell Types -> (width, height, num_cells)
-    states: Vec<(ExecutionState, Vec<(CellType, (usize, usize, usize))>)>,
+    states: Vec<(ExecutionState, StepSize)>,
 }
 
 impl Instrument {


### PR DESCRIPTION
Run with

    cargo test -p zkevm-circuits --features mock --release get_evm_states_stats -- --nocapture --ignored

[Current Metrics](https://github.com/privacy-scaling-explorations/zkevm-circuits/files/9891417/opcode_metrics2.txt)

