### PR TITLE
optim/best-degree: set the optimal gate degree

### DIFF
--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -435,6 +435,8 @@ mod evm_circuit_stats {
         let mut meta = ConstraintSystem::<Fr>::default();
         let circuit = TestCircuit::configure(&mut meta);
 
+        println!("Gates max_degree={}", meta.degree());
+
         let mut implemented_states = Vec::new();
         for state in ExecutionState::iter() {
             let height = circuit.evm_circuit.execution.get_step_height_option(state);

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -23,11 +23,11 @@ use halo2_proofs::{
 use super::{rlc, CachedRegion, CellType, StoredExpression};
 
 // Max degree allowed in all expressions passing through the ConstraintBuilder.
-// It aims to cap `extended_k` to 2, which allows constraint degree to 2^2+1,
-// but each ExecutionGadget has implicit selector degree 3, so here it only
-// allows 2^2+1-3 = 2.
-const MAX_DEGREE: usize = 5;
-const IMPLICIT_DEGREE: usize = 3;
+// It aims for `extended_k = k + 3`, which allows constraint degree to 2^3+1=9,
+// but each ExecutionGadget has implicit selector degree 4, so here it only
+// allows 9-4=5.
+const MAX_DEGREE: usize = 9; // 2^3 + 1
+const IMPLICIT_DEGREE: usize = 4; // q_usable + q_step + 2 state selectors
 
 pub(crate) enum Transition<T> {
     Same,


### PR DESCRIPTION
The gate degree of the EVM circuit is currently 7. This is set by the gate "Constrain state machine transitions". However, the constraint builder limits other gates to 6 instead of 7. The parameters and the comment seem outdated.

Meanwhile, 7 is a poor trade-off. The next threshold is **9, which is chosen in this PR**.

The effective degree of gadgets goes from 2 to 5. This will reduce the usage of cells for stored expressions. This, in turn, allows someone to simply configure fewer "Storage" columns, saving verifier time.

**Stats!**

- The gate complexity is down 17% (from 10623 to 8838). This is measured as the count of multiplications, after memoizing. This is the bottleneck in prover time.

Observing the stored expressions of some individual states:

- CALLDATALOAD is no longer the largest instruction. It uses ~2X fewer stored expressions, moving to its next bottleneck at a lower height.
- PUSH -68%. MEMORY -63%. SIGNEXTEND -51%. MUL -20%. ADD -12%. BITWISE -10%.

Data using #863 -- [Before](https://github.com/privacy-scaling-explorations/zkevm-circuits/files/9908474/opcode_metrics3_degree6.txt) -- [After](https://github.com/privacy-scaling-explorations/zkevm-circuits/files/9908475/opcode_metrics3_degree9.txt).
