### PR TITLE
workflows/integration: limit circuit test threads

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -77,5 +77,5 @@ jobs:
       - run: ./run.sh --steps "gendata"
       - run: ./run.sh --steps "tests" --tests "rpc"
       - run: ./run.sh --steps "tests" --tests "circuit_input_builder"
-      - run: ./run.sh --steps "tests" --tests "circuits"
+      - run: RUST_TEST_THREADS=2 ./run.sh --steps "tests" --tests "circuits"
       - run: ./run.sh --steps "cleanup"


### PR DESCRIPTION
This fixes the integration test workflow that exits with out-of-memory. This started to become a problem after the super circuit was integrated.