### PR TITLE
Add challenge API to state circuit

### DIFF
--- a/circuit-benchmarks/src/state_circuit.rs
+++ b/circuit-benchmarks/src/state_circuit.rs
@@ -28,7 +28,7 @@ mod tests {
             .parse()
             .expect("Cannot parse DEGREE env var as u32");
 
-        let empty_circuit = StateCircuit::<Fr>::new(Fr::default(), RwMap::default(), 1 << 16);
+        let empty_circuit = StateCircuit::<Fr>::new(RwMap::default(), 1 << 16);
 
         // Initialize the polynomial commitment parameters
         let mut rng = XorShiftRng::from_seed([

--- a/integration-tests/tests/circuits.rs
+++ b/integration-tests/tests/circuits.rs
@@ -63,11 +63,8 @@ async fn test_state_circuit_block(block_num: u64) {
 
     let rw_map = RwMap::from(&builder.block.container);
 
-    let randomness = Fr::from(0xcafeu64);
-    let circuit = StateCircuit::<Fr>::new(randomness, rw_map, 1 << 16);
-    let power_of_randomness = circuit.instance();
-
-    let prover = MockProver::<Fr>::run(DEGREE as u32, &circuit, power_of_randomness).unwrap();
+    let circuit = StateCircuit::<Fr>::new(rw_map, 1 << 16);
+    let prover = MockProver::<Fr>::run(DEGREE as u32, &circuit, circuit.instance()).unwrap();
     prover
         .verify_par()
         .expect("state_circuit verification failed");

--- a/zkevm-circuits/src/copy_circuit.rs
+++ b/zkevm-circuits/src/copy_circuit.rs
@@ -668,7 +668,7 @@ pub mod dev {
                 &mut layouter,
                 &self.block.rws.table_assignments(),
                 self.block.circuits_params.max_rws,
-                self.randomness,
+                Value::known(self.randomness),
             )?;
             config.bytecode_table.load(
                 &mut layouter,

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -304,7 +304,7 @@ pub mod test {
                 &mut layouter,
                 &self.block.rws.table_assignments(),
                 self.block.circuits_params.max_rws,
-                self.block.randomness,
+                Value::known(self.block.randomness),
             )?;
             config.bytecode_table.load(
                 &mut layouter,

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -1167,7 +1167,10 @@ impl<F: Field> ExecutionConfig<F> {
             .rws
             .table_assignments()
             .iter()
-            .map(|rw| rw.table_assignment(block.randomness).rlc(block.randomness))
+            .map(|rw| {
+                rw.table_assignment_aux(block.randomness)
+                    .rlc(block.randomness)
+            })
             .collect();
 
         for (name, value) in assigned_rw_values.iter() {
@@ -1178,7 +1181,7 @@ impl<F: Field> ExecutionConfig<F> {
         for (idx, assigned_rw_value) in assigned_rw_values.iter().enumerate() {
             let rw_idx = step.rw_indices[idx];
             let rw = block.rws[rw_idx];
-            let table_assignments = rw.table_assignment(block.randomness);
+            let table_assignments = rw.table_assignment_aux(block.randomness);
             let rlc = table_assignments.rlc(block.randomness);
             if rlc != assigned_rw_value.1 {
                 log::error!(

--- a/zkevm-circuits/src/evm_circuit/execution/extcodehash.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodehash.rs
@@ -156,7 +156,7 @@ impl<F: Field> ExecutionGadget<F> for ExtcodehashGadget<F> {
 
         let [nonce, balance, code_hash] = [5, 6, 7].map(|i| {
             block.rws[step.rw_indices[i]]
-                .table_assignment(block.randomness)
+                .table_assignment_aux(block.randomness)
                 .value
         });
 

--- a/zkevm-circuits/src/state_circuit.rs
+++ b/zkevm-circuits/src/state_circuit.rs
@@ -18,7 +18,10 @@ use eth_types::{Address, Field};
 use gadgets::binary_number::{BinaryNumberChip, BinaryNumberConfig};
 use halo2_proofs::{
     circuit::{Layouter, Region, SimpleFloorPlanner, Value},
-    plonk::{Advice, Circuit, Column, ConstraintSystem, Error, Expression, Fixed, VirtualCells},
+    plonk::{
+        Advice, Circuit, Column, ConstraintSystem, Error, Expression, Fixed, SecondPhase,
+        VirtualCells,
+    },
     poly::Rotation,
 };
 use lexicographic_ordering::Config as LexicographicOrderingConfig;
@@ -76,8 +79,8 @@ impl<F: Field> StateCircuitConfig<F> {
             challenges.evm_word_powers_of_randomness(),
         );
 
-        let initial_value = meta.advice_column();
-        let state_root = meta.advice_column();
+        let initial_value = meta.advice_column_in(SecondPhase);
+        let state_root = meta.advice_column_in(SecondPhase);
 
         let sort_keys = SortKeysConfig {
             tag,

--- a/zkevm-circuits/src/state_circuit.rs
+++ b/zkevm-circuits/src/state_circuit.rs
@@ -10,7 +10,7 @@ mod test;
 use crate::{
     evm_circuit::param::N_BYTES_WORD,
     table::{LookupTable, MptTable, RwTable, RwTableTag},
-    util::{power_of_randomness_from_instance, Expr},
+    util::{Challenges, Expr},
     witness::{MptUpdates, Rw, RwMap},
 };
 use constraint_builder::{ConstraintBuilder, Queries};
@@ -27,7 +27,7 @@ use multiple_precision_integer::{Chip as MpiChip, Config as MpiConfig, Queries a
 use random_linear_combination::{Chip as RlcChip, Config as RlcConfig, Queries as RlcQueries};
 #[cfg(test)]
 use std::collections::HashMap;
-use std::iter::once;
+use std::{iter::once, marker::PhantomData};
 
 use self::constraint_builder::{MptUpdateTableQueries, RwTableQueries};
 
@@ -50,13 +50,14 @@ pub struct StateCircuitConfig<F> {
     lexicographic_ordering: LexicographicOrderingConfig,
     lookups: LookupsConfig,
     power_of_randomness: [Expression<F>; N_BYTES_WORD - 1],
+    challenges: Challenges,
 }
 
 impl<F: Field> StateCircuitConfig<F> {
     /// Configure StateCircuit
     pub fn configure(
         meta: &mut ConstraintSystem<F>,
-        power_of_randomness: [Expression<F>; 31],
+        challenges: Challenges,
         rw_table: &RwTable,
         mpt_table: &MptTable,
     ) -> Self {
@@ -67,12 +68,15 @@ impl<F: Field> StateCircuitConfig<F> {
         let tag = BinaryNumberChip::configure(meta, selector, Some(rw_table.tag));
         let id = MpiChip::configure(meta, selector, rw_table.id, lookups);
         let address = MpiChip::configure(meta, selector, rw_table.address, lookups);
+
+        let challenges_expr = challenges.exprs(meta);
+
         let storage_key = RlcChip::configure(
             meta,
             selector,
             rw_table.storage_key,
             lookups,
-            power_of_randomness.clone(),
+            challenges_expr.evm_word_powers_of_randomness(),
         );
 
         let initial_value = meta.advice_column();
@@ -91,7 +95,7 @@ impl<F: Field> StateCircuitConfig<F> {
             meta,
             sort_keys,
             lookups,
-            power_of_randomness.clone(),
+            challenges_expr.evm_word_powers_of_randomness(),
         );
 
         let config = Self {
@@ -101,9 +105,10 @@ impl<F: Field> StateCircuitConfig<F> {
             state_root,
             lexicographic_ordering,
             lookups,
-            power_of_randomness,
+            power_of_randomness: challenges_expr.evm_word_powers_of_randomness(),
             rw_table: *rw_table,
             mpt_table: *mpt_table,
+            challenges,
         };
 
         let mut constraint_builder = ConstraintBuilder::new();
@@ -129,12 +134,14 @@ impl<F: Field> StateCircuitConfig<F> {
         layouter: &mut impl Layouter<F>,
         rows: &[Rw],
         n_rows: usize, // 0 means dynamically calculated from `rows`.
-        randomness: F,
+        challenges: &Challenges<Value<F>>,
     ) -> Result<(), Error> {
         let updates = MptUpdates::mock_from(rows);
         layouter.assign_region(
             || "state circuit",
-            |mut region| self.assign_with_region(&mut region, rows, &updates, n_rows, randomness),
+            |mut region| {
+                self.assign_with_region(&mut region, rows, &updates, n_rows, challenges.evm_word())
+            },
         )
     }
 
@@ -144,7 +151,7 @@ impl<F: Field> StateCircuitConfig<F> {
         rows: &[Rw],
         updates: &MptUpdates,
         n_rows: usize, // 0 means dynamically calculated from `rows`.
-        randomness: F,
+        randomness: Value<F>,
     ) -> Result<(), Error> {
         let tag_chip = BinaryNumberChip::construct(self.sort_keys.tag);
 
@@ -153,7 +160,7 @@ impl<F: Field> StateCircuitConfig<F> {
         let rows = rows.into_iter();
         let prev_rows = once(None).chain(rows.clone().map(Some));
 
-        let mut state_root = F::zero();
+        let mut state_root = randomness.map(|_| F::zero());
 
         for (offset, (row, prev_row)) in rows.zip(prev_rows).enumerate() {
             if offset >= padding_length {
@@ -172,12 +179,15 @@ impl<F: Field> StateCircuitConfig<F> {
             self.sort_keys
                 .rw_counter
                 .assign(region, offset, row.rw_counter() as u32)?;
+
             if let Some(id) = row.id() {
                 self.sort_keys.id.assign(region, offset, id as u32)?;
             }
+
             if let Some(address) = row.address() {
                 self.sort_keys.address.assign(region, offset, address)?;
             }
+
             if let Some(storage_key) = row.storage_key() {
                 self.sort_keys
                     .storage_key
@@ -191,28 +201,41 @@ impl<F: Field> StateCircuitConfig<F> {
 
                 if is_first_access {
                     // If previous row was a last access, we need to update the state root.
-                    if let Some(update) = updates.get(&prev_row) {
-                        let (new_root, old_root) = update.root_assignments(randomness);
-                        assert_eq!(state_root, old_root);
-                        state_root = new_root;
-                    }
 
-                    if matches!(row.tag(), RwTableTag::CallContext) && !row.is_write() {
-                        assert_eq!(row.value_assignment(randomness), F::zero(), "{:?}", row);
-                    }
+                    state_root = randomness
+                        .zip(state_root)
+                        .map(|(randomness, mut state_root)| {
+                            if let Some(update) = updates.get(&prev_row) {
+                                let (new_root, old_root) = update.root_assignments(randomness);
+                                assert_eq!(state_root, old_root);
+                                state_root = new_root;
+                            }
+                            if matches!(row.tag(), RwTableTag::CallContext) && !row.is_write() {
+                                assert_eq!(
+                                    row.value_assignment(randomness),
+                                    F::zero(),
+                                    "{:?}",
+                                    row
+                                );
+                            }
+                            state_root
+                        });
                 }
             }
 
             // The initial value can be determined from the mpt updates or is 0.
-            let initial_value = updates
-                .get(&row)
-                .map(|u| u.value_assignments(randomness).1)
-                .unwrap_or_default();
+            let initial_value = randomness.map(|randomness| {
+                updates
+                    .get(&row)
+                    .map(|u| u.value_assignments(randomness).1)
+                    .unwrap_or_default()
+            });
+
             region.assign_advice(
                 || "initial_value",
                 self.initial_value,
                 offset,
-                || Value::known(initial_value),
+                || initial_value,
             )?;
 
             // TODO: Switch from Rw::Start -> Rw::Padding to simplify this logic.
@@ -223,7 +246,7 @@ impl<F: Field> StateCircuitConfig<F> {
                     || "state_root",
                     self.state_root,
                     offset - 1,
-                    || Value::known(state_root),
+                    || state_root,
                 )?;
             }
 
@@ -231,15 +254,17 @@ impl<F: Field> StateCircuitConfig<F> {
                 // The last row is always a last access, so we need to handle the case where the
                 // state root changes because of an mpt lookup on the last row.
                 if let Some(update) = updates.get(&row) {
-                    let (new_root, old_root) = update.root_assignments(randomness);
-                    assert_eq!(state_root, old_root);
-                    state_root = new_root;
+                    state_root = randomness.zip(state_root).map(|(randomness, state_root)| {
+                        let (new_root, old_root) = update.root_assignments(randomness);
+                        assert_eq!(state_root, old_root);
+                        new_root
+                    });
                 }
                 region.assign_advice(
                     || "last row state_root",
                     self.state_root,
                     offset,
-                    || Value::known(state_root),
+                    || state_root,
                 )?;
             }
         }
@@ -267,31 +292,29 @@ pub struct StateCircuit<F> {
     pub(crate) rows: Vec<Rw>,
     updates: MptUpdates,
     pub(crate) n_rows: usize,
-    pub(crate) randomness: F,
     #[cfg(test)]
     overrides: HashMap<(test::AdviceColumn, isize), F>,
+    _marker: PhantomData<F>,
 }
 
 impl<F: Field> StateCircuit<F> {
     /// make a new state circuit from an RwMap
-    pub fn new(randomness: F, rw_map: RwMap, n_rows: usize) -> Self {
+    pub fn new(rw_map: RwMap, n_rows: usize) -> Self {
         let rows = rw_map.table_assignments();
         let updates = MptUpdates::mock_from(&rows);
         Self {
-            randomness,
             rows,
             updates,
             n_rows,
             #[cfg(test)]
             overrides: HashMap::new(),
+            _marker: PhantomData::default(),
         }
     }
 
     /// powers of randomness for instance columns
     pub fn instance(&self) -> Vec<Vec<F>> {
-        (1..32)
-            .map(|exp| vec![self.randomness.pow(&[exp, 0, 0, 0]); self.n_rows])
-            .collect()
+        vec![]
     }
 }
 
@@ -309,8 +332,8 @@ where
     fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
         let rw_table = RwTable::construct(meta);
         let mpt_table = MptTable::construct(meta);
-        let power_of_randomness: [Expression<F>; 31] = power_of_randomness_from_instance(meta);
-        Self::Config::configure(meta, power_of_randomness, &rw_table, &mpt_table)
+        let challenges = Challenges::construct(meta);
+        Self::Config::configure(meta, challenges, &rw_table, &mpt_table)
     }
 
     fn synthesize(
@@ -319,6 +342,8 @@ where
         mut layouter: impl Layouter<F>,
     ) -> Result<(), Error> {
         config.load(&mut layouter)?;
+
+        let randomness = config.challenges.values(&mut layouter).evm_word();
 
         // Assigning to same columns in different regions should be avoided.
         // Here we use one single region to assign `overrides` to both rw table and
@@ -330,19 +355,19 @@ where
                     &mut region,
                     &self.rows,
                     self.n_rows,
-                    self.randomness,
+                    randomness,
                 )?;
 
                 config
                     .mpt_table
-                    .load_with_region(&mut region, &self.updates, self.randomness)?;
+                    .load_with_region(&mut region, &self.updates, randomness)?;
 
                 config.assign_with_region(
                     &mut region,
                     &self.rows,
                     &self.updates,
                     self.n_rows,
-                    self.randomness,
+                    randomness,
                 )?;
                 #[cfg(test)]
                 {

--- a/zkevm-circuits/src/state_circuit/random_linear_combination.rs
+++ b/zkevm-circuits/src/state_circuit/random_linear_combination.rs
@@ -33,7 +33,7 @@ impl<const N: usize> Config<N> {
         &self,
         region: &mut Region<'_, F>,
         offset: usize,
-        _randomness: F, // kept for future use
+        _randomness: Value<F>, // kept for future use
         value: U256,
     ) -> Result<(), Error> {
         let bytes = value.to_le_bytes();

--- a/zkevm-circuits/src/state_circuit/test.rs
+++ b/zkevm-circuits/src/state_circuit/test.rs
@@ -91,8 +91,7 @@ fn test_state_circuit_ok(
         ..Default::default()
     });
 
-    let randomness = Fr::from(0xcafeu64);
-    let circuit = StateCircuit::<Fr>::new(randomness, rw_map, N_ROWS);
+    let circuit = StateCircuit::<Fr>::new(rw_map, N_ROWS);
     let power_of_randomness = circuit.instance();
 
     let prover = MockProver::<Fr>::run(19, &circuit, power_of_randomness).unwrap();
@@ -109,12 +108,10 @@ fn degree() {
 
 #[test]
 fn verifying_key_independent_of_rw_length() {
-    let randomness = Fr::from(0xcafeu64);
     let params = ParamsKZG::<Bn256>::setup(17, rand_chacha::ChaCha20Rng::seed_from_u64(2));
 
-    let no_rows = StateCircuit::<Fr>::new(randomness, RwMap::default(), N_ROWS);
+    let no_rows = StateCircuit::<Fr>::new(RwMap::default(), N_ROWS);
     let one_row = StateCircuit::<Fr>::new(
-        randomness,
         RwMap::from(&OperationContainer {
             memory: vec![Operation::new(
                 RWCounter::from(1),
@@ -335,8 +332,12 @@ fn storage_key_rlc() {
         tx_id: 4,
         committed_value: U256::from(300),
     }];
-
-    assert_eq!(verify(rows), Ok(()));
+    if let Err(errs) = verify(rows) {
+        for err in errs {
+            println!("{}", err);
+        }
+        panic!();
+    }
 }
 
 #[test]
@@ -484,13 +485,13 @@ fn storage_key_byte_out_of_range() {
         committed_value: U256::from(500),
     }];
     let overrides = HashMap::from([
-        ((AdviceColumn::StorageKeyByte0, 0), Fr::from(0xcafeu64)), /* 0xcafeu64 is the fixed
-                                                                    * "randomness" we use for
-                                                                    * this test. */
+        ((AdviceColumn::StorageKeyByte0, 0), Fr::from(0xcafeu64)),
         ((AdviceColumn::StorageKeyByte1, 0), Fr::zero()),
     ]);
 
-    let result = verify_with_overrides(rows, overrides);
+    // This will trigger two errors: an RLC encoding error and the "fit into u8", we
+    // only keep the first one
+    let result = verify_with_overrides(rows, overrides).map_err(|mut err| vec![err.remove(1)]);
 
     assert_error_matches(result, "rlc bytes fit into u8");
 }
@@ -981,14 +982,13 @@ fn bad_initial_tx_receipt_value() {
 }
 
 fn prover(rows: Vec<Rw>, overrides: HashMap<(AdviceColumn, isize), Fr>) -> MockProver<Fr> {
-    let randomness = Fr::from(0xcafeu64);
     let updates = MptUpdates::mock_from(&rows);
     let circuit = StateCircuit::<Fr> {
-        randomness,
         rows,
         updates,
         overrides,
         n_rows: N_ROWS,
+        _marker: std::marker::PhantomData::default(),
     };
     let power_of_randomness = circuit.instance();
 
@@ -1005,8 +1005,11 @@ fn verify_with_overrides(
     rows: Vec<Rw>,
     overrides: HashMap<(AdviceColumn, isize), Fr>,
 ) -> Result<(), Vec<VerifyFailure>> {
-    // Sanity check that the original RwTable without overrides is valid.
-    assert_eq!(verify(rows.clone()), Ok(()));
+    assert_eq!(
+        verify(rows.clone()),
+        Ok(()),
+        "Sanity check that the original RwTable without overrides is valid"
+    );
 
     let n_active_rows = rows.len();
     prover(rows, overrides).verify_at_rows(

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -385,25 +385,24 @@ impl RwTable {
             aux2: meta.advice_column_in(SecondPhase),
         }
     }
-    /// Assign a `RwRow` at offset into the `RwTable`
-    pub fn assign<F: Field>(
+    fn assign<F: Field>(
         &self,
         region: &mut Region<'_, F>,
         offset: usize,
-        row: &Value<RwRow<F>>,
+        row: &RwRow<Value<F>>,
     ) -> Result<(), Error> {
         for (column, value) in [
-            (self.rw_counter, row.map(|row| row.rw_counter)),
-            (self.is_write, row.map(|row| row.is_write)),
-            (self.tag, row.map(|row| row.tag)),
-            (self.id, row.map(|row| row.id)),
-            (self.address, row.map(|row| row.address)),
-            (self.field_tag, row.map(|row| row.field_tag)),
-            (self.storage_key, row.map(|row| row.storage_key)),
-            (self.value, row.map(|row| row.value)),
-            (self.value_prev, row.map(|row| row.value_prev)),
-            (self.aux1, row.map(|row| row.aux1)),
-            (self.aux2, row.map(|row| row.aux2)),
+            (self.rw_counter, row.rw_counter),
+            (self.is_write, row.is_write),
+            (self.tag, row.tag),
+            (self.id, row.id),
+            (self.address, row.address),
+            (self.field_tag, row.field_tag),
+            (self.storage_key, row.storage_key),
+            (self.value, row.value),
+            (self.value_prev, row.value_prev),
+            (self.aux1, row.aux1),
+            (self.aux2, row.aux2),
         ] {
             region.assign_advice(|| "assign rw row on rw table", column, offset, || value)?;
         }
@@ -434,8 +433,7 @@ impl RwTable {
     ) -> Result<(), Error> {
         let (rows, _) = RwMap::table_assignments_prepad(rws, n_rows);
         for (offset, row) in rows.iter().enumerate() {
-            let row = randomness.map(|randomness| row.table_assignment(randomness));
-            self.assign(region, offset, &row)?;
+            self.assign(region, offset, &row.table_assignment(randomness))?;
         }
         Ok(())
     }

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -376,11 +376,13 @@ impl RwTable {
             id: meta.advice_column(),
             address: meta.advice_column(),
             field_tag: meta.advice_column(),
-            storage_key: meta.advice_column(),
-            value: meta.advice_column(),
-            value_prev: meta.advice_column(),
-            aux1: meta.advice_column(),
-            aux2: meta.advice_column(),
+            storage_key: meta.advice_column_in(SecondPhase),
+            value: meta.advice_column_in(SecondPhase),
+            value_prev: meta.advice_column_in(SecondPhase),
+            // It seems that aux1 for the moment is not using randomness
+            // TODO check in a future review
+            aux1: meta.advice_column_in(SecondPhase),
+            aux2: meta.advice_column_in(SecondPhase),
         }
     }
     /// Assign a `RwRow` at offset into the `RwTable`

--- a/zkevm-circuits/src/test_util.rs
+++ b/zkevm-circuits/src/test_util.rs
@@ -108,7 +108,7 @@ pub fn test_circuits_witness_block(
     // state circuit and evm circuit must be same
     if config.enable_state_circuit_test {
         const N_ROWS: usize = 1 << 16;
-        let state_circuit = StateCircuit::<Fr>::new(block.randomness, block.rws, N_ROWS);
+        let state_circuit = StateCircuit::<Fr>::new(block.rws, N_ROWS);
         let power_of_randomness = state_circuit.instance();
         let prover = MockProver::<Fr>::run(18, &state_circuit, power_of_randomness).unwrap();
         // Skip verification of Start rows to accelerate testing

--- a/zkevm-circuits/src/util.rs
+++ b/zkevm-circuits/src/util.rs
@@ -99,6 +99,19 @@ impl<T: Clone> Challenges<T> {
     }
 }
 
+impl<F: Field> Challenges<Expression<F>> {
+    ///
+    pub fn evm_word_powers_of_randomness<const S: usize>(&self) -> [Expression<F>; S] {
+        std::iter::successors(self.evm_word.clone().into(), |power| {
+            (self.evm_word.clone() * power.clone()).into()
+        })
+        .take(S)
+        .collect::<Vec<_>>()
+        .try_into()
+        .unwrap()
+    }
+}
+
 pub(crate) fn build_tx_log_address(index: u64, field_tag: TxLogFieldTag, log_id: u64) -> Address {
     (U256::from(index) + (U256::from(field_tag as u64) << 32) + (U256::from(log_id) << 48))
         .to_address()

--- a/zkevm-circuits/src/util.rs
+++ b/zkevm-circuits/src/util.rs
@@ -100,7 +100,7 @@ impl<T: Clone> Challenges<T> {
 }
 
 impl<F: Field> Challenges<Expression<F>> {
-    ///
+    /// Returns powers of randomness for word RLC encoding
     pub fn evm_word_powers_of_randomness<const S: usize>(&self) -> [Expression<F>; S] {
         std::iter::successors(self.evm_word.clone().into(), |power| {
             (self.evm_word.clone() * power.clone()).into()


### PR DESCRIPTION
This PR removes the directly injected randomness for RLP `Word` commitments and replaces it with the provided Challenge API value (for witness) and expression (for constraints).

Note that in some points is required to change from `F` to `Value<F>` (API provides `Value<F>` as the value of the challenge) meaning that, we must must use methods like `map` to propagate the "knowness" of different values.  