### PR TITLE
workflows/integration: only run integration tests on push to `main` o…

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,15 +1,40 @@
 name: Integration Tests
 
 on:
+  on: issue_comment
   pull_request:
-    types: [synchronize, opened, reopened, ready_for_review, labeled]
+    types: [synchronize, opened, reopened, ready_for_review]
   push:
     branches:
       - main
 
 jobs:
+  help:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Help
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const { data: comments } = await github.rest.issues.listComments({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+          })
+          const botComment = comments.find(comment => comment.user.id === 41898282)
+          if (!botComment) {
+            const body = '👋 Comment on this pull request with `/test` to run the integration tests.'
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body,
+            })
+          }
+
   consecutiveness:
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-integration-tests')
+    if: github.event_name == 'push' || (github.event_name == 'issue_comment' && github.event.comment.body == '/test')
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,7 +1,7 @@
 name: Integration Tests
 
 on:
-  on: issue_comment
+  issue_comment:
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
   push:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,12 +8,10 @@ on:
     branches:
       - main
 
-permissions:
-  pull-requests: 'write'
-
 jobs:
   help:
     if: github.event_name == 'pull_request'
+    permissions: read-all|write-all
     runs-on: ubuntu-latest
     steps:
     - name: Help

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  pull-requests: 'write'
+
 jobs:
   help:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,14 +20,13 @@ jobs:
       uses: actions/github-script@v6
       with:
         script: |
-          /*const { data: comments } = await github.rest.issues.listComments({
+          const { data: comments } = await github.rest.issues.listComments({
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
           })
           const botComment = comments.find(comment => comment.user.id === 41898282)
-          */
-          if (true) {
+          if (botComment) {
             const body = '👋 Comment on this pull request with `/test` to run the integration tests.'
             await github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,8 +12,8 @@ jobs:
   help:
     if: github.event_name == 'pull_request'
     permissions:
-      issues: write
-      pull-requests: write
+      issues: read|write
+      pull-requests: read|write
     runs-on: ubuntu-latest
     steps:
     - name: Help

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,8 +12,8 @@ jobs:
   help:
     if: github.event_name == 'pull_request'
     permissions:
-      issues: 'read|write'
-      pull-requests: 'read|write'
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - name: Help

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,7 +11,9 @@ on:
 jobs:
   help:
     if: github.event_name == 'pull_request'
-    permissions: 'read-all|write-all'
+    permissions:
+      issues: 'read|write'
+      pull-requests: 'read|write'
     runs-on: ubuntu-latest
     steps:
     - name: Help

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -2,7 +2,7 @@ name: Integration Tests
 
 on:
   issue_comment:
-  pull_request:
+  pull_request_target:
     types: [synchronize, opened, reopened, ready_for_review]
   push:
     branches:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   help:
     if: github.event_name == 'pull_request'
-    permissions: read-all|write-all
+    permissions: 'read-all|write-all'
     runs-on: ubuntu-latest
     steps:
     - name: Help

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,6 +16,7 @@ jobs:
     - name: Help
       uses: actions/github-script@v6
       with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
           const { data: comments } = await github.rest.issues.listComments({
             issue_number: context.issue.number,

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -2,14 +2,14 @@ name: Integration Tests
 
 on:
   pull_request:
-    types: [synchronize, opened, reopened, ready_for_review]
+    types: [synchronize, opened, reopened, ready_for_review, labeled]
   push:
     branches:
       - main
 
 jobs:
   consecutiveness:
-    if: github.event.pull_request.draft == false
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-integration-tests')
 
     runs-on: ubuntu-latest
     steps:
@@ -18,8 +18,6 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
 
   wakeuprunner:
-    if: github.event.pull_request.draft == false
-
     needs: [consecutiveness]
     name: Wake up self-hosted runner
     runs-on: pse-runner
@@ -30,8 +28,6 @@ jobs:
           .github/integrationTestsScripts/wakeUpRunner.sh
 
   integration-tests:
-    if: github.event.pull_request.draft == false
-
     needs: [wakeuprunner]
     name: Integration Tests
     runs-on: integration-tests-runner

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,22 +12,22 @@ jobs:
   help:
     if: github.event_name == 'pull_request'
     permissions:
-      issues: read|write
-      pull-requests: read|write
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - name: Help
       uses: actions/github-script@v6
       with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
-          const { data: comments } = await github.rest.issues.listComments({
+          /*const { data: comments } = await github.rest.issues.listComments({
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
           })
           const botComment = comments.find(comment => comment.user.id === 41898282)
-          if (!botComment) {
+          */
+          if (true) {
             const body = '👋 Comment on this pull request with `/test` to run the integration tests.'
             await github.rest.issues.createComment({
               issue_number: context.issue.number,


### PR DESCRIPTION
…r PR with `run-integration-tests` label.

Some PRs don't require a integration test run for various reasons. This makes running the integration tests optional on request via labeling. Integration tests will still run on merge to `main`.