### PR TITLE
fix: Mock `Challenges` with different values

### DIFF
--- a/zkevm-circuits/src/copy_circuit.rs
+++ b/zkevm-circuits/src/copy_circuit.rs
@@ -658,7 +658,8 @@ pub mod dev {
         ) -> Result<(), halo2_proofs::plonk::Error> {
             let block = self.block.as_ref().unwrap();
 
-            let challenges = Challenges::mock(Value::known(self.randomness));
+            let challenges =
+                Challenges::mock(Value::known(self.randomness), Value::known(self.randomness));
 
             config
                 .tx_table

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -288,7 +288,10 @@ pub mod test {
             mut layouter: impl Layouter<F>,
         ) -> Result<(), Error> {
             let block = self.block.as_ref().unwrap();
-            let challenges = Challenges::mock(Value::known(block.randomness));
+            let challenges = Challenges::mock(
+                Value::known(block.randomness),
+                Value::known(block.randomness),
+            );
 
             config
                 .evm_circuit

--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -183,7 +183,10 @@ impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize, const MAX_RWS: u
             Expression::Constant(F::from(MOCK_RANDOMNESS).pow(&[1 + i as u64, 0, 0, 0]))
         });
 
-        let challenges = Challenges::mock(power_of_randomness[0].clone());
+        let challenges = Challenges::mock(
+            power_of_randomness[0].clone(),
+            power_of_randomness[0].clone(),
+        );
 
         let keccak_circuit = KeccakConfig::configure(meta, power_of_randomness[0].clone());
         let keccak_table = keccak_circuit.keccak_table.clone();
@@ -246,7 +249,10 @@ impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize, const MAX_RWS: u
         mut layouter: impl Layouter<F>,
     ) -> Result<(), Error> {
         let block = self.block.as_ref().unwrap();
-        let challenges = Challenges::mock(Value::known(block.randomness));
+        let challenges = Challenges::mock(
+            Value::known(block.randomness),
+            Value::known(block.randomness),
+        );
 
         // --- EVM Circuit ---
         let rws = block.rws.table_assignments();

--- a/zkevm-circuits/src/util.rs
+++ b/zkevm-circuits/src/util.rs
@@ -91,17 +91,10 @@ impl<T: Clone> Challenges<T> {
         self.keccak_input.clone()
     }
 
-    pub(crate) fn mock(challenge: T) -> Self {
+    pub(crate) fn mock(evm_word: T, keccak_input: T) -> Self {
         Self {
-            evm_word: challenge.clone(),
-            keccak_input: challenge,
-        }
-    }
-
-    pub(crate) fn mock_diff(challenge1: T, challenge2: T) -> Self {
-        Self {
-            evm_word: challenge1,
-            keccak_input: challenge2,
+            evm_word,
+            keccak_input,
         }
     }
 }

--- a/zkevm-circuits/src/util.rs
+++ b/zkevm-circuits/src/util.rs
@@ -97,6 +97,13 @@ impl<T: Clone> Challenges<T> {
             keccak_input: challenge,
         }
     }
+
+    pub(crate) fn mock_diff(challenge1: T, challenge2: T) -> Self {
+        Self {
+            evm_word: challenge1,
+            keccak_input: challenge2,
+        }
+    }
 }
 
 impl<F: Field> Challenges<Expression<F>> {


### PR DESCRIPTION
As mentioned in #926, the `Challenges::mock` function was not adding different values for the `Challenges`. Therefore, a new function has been added that allows mocking by passing two different values (one per each challenge).

This allows to keep the API we previously had and also, reduce the need to send always 2 values when only 1 can be passed.

Resolves: #926

I considered to do a `Trait`-based approach by ussing `Add<Output=Self>` but `Expression<F>` does not implement this trait. Same happens for `Challenge` (the one in Halo2).
Therefore, the easiest way to not break the current API and also, not ask for 2 values when we don't need them to be different (everywhere minus Keccak) is to introduce a new function.