### PR TITLE
Use correct `CircuitsParams` in `SuperCircuit::build`

### DIFF
--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -333,7 +333,14 @@ impl<const MAX_TXS: usize, const MAX_CALLDATA: usize, const MAX_RWS: usize>
         geth_data: GethData,
         rng: &mut (impl RngCore + Clone),
     ) -> Result<(u32, Self, Vec<Vec<Fr>>, CircuitInputBuilder), bus_mapping::Error> {
-        let block_data = BlockData::new_from_geth_data(geth_data.clone());
+        let block_data = BlockData::new_from_geth_data_with_params(
+            geth_data.clone(),
+            CircuitsParams {
+                max_rws: MAX_RWS,
+                max_txs: MAX_TXS,
+                keccak_padding: None,
+            },
+        );
         let mut builder = block_data.new_circuit_input_builder();
         builder
             .handle_block(&geth_data.eth_block, &geth_data.geth_traces)


### PR DESCRIPTION
The generic of `SuperCircuit` is not used in `SuperCircuit::build`, tho it's not causing issue now (it happens that `MAX_TX` is set to match the default one), but it might cause unexpected witness in the future.