### PR TITLE
Bug: fix to not invoke `transfer` for call related opcodes (except `CALL`)

### DIFF
--- a/bus-mapping/src/circuit_input_builder/call.rs
+++ b/bus-mapping/src/circuit_input_builder/call.rs
@@ -101,6 +101,11 @@ impl Call {
     pub fn is_create(&self) -> bool {
         self.kind.is_create()
     }
+
+    /// This call is call with op DELEGATECALL
+    pub fn is_delegatecall(&self) -> bool {
+        matches!(self.kind, CallKind::DelegateCall)
+    }
 }
 
 /// Context of a [`Call`].

--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -595,7 +595,7 @@ impl<'a> CircuitInputStateRef<'a> {
                 step.stack.nth_last(2)?,
             ),
             CallKind::CallCode => (caller.address, caller.address, step.stack.nth_last(2)?),
-            CallKind::DelegateCall => (caller.caller_address, caller.address, Word::zero()),
+            CallKind::DelegateCall => (caller.caller_address, caller.address, caller.value),
             CallKind::StaticCall => (
                 caller.address,
                 step.stack.nth_last(1)?.to_address(),

--- a/bus-mapping/src/evm/opcodes/callop.rs
+++ b/bus-mapping/src/evm/opcodes/callop.rs
@@ -120,6 +120,7 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
         let callee_nonce = callee_account.nonce;
 
         if call.kind == CallKind::Call {
+            // Transfer value only for CALL opcode.
             state.transfer(
                 &mut exec_step,
                 call.caller_address,
@@ -127,6 +128,7 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
                 call.value,
             )?;
         } else {
+            // Get callee balance for CALLCODE, DELEGATECALL and STATICCALL opcodes.
             let callee_balance = callee_account.balance;
             state.account_read(
                 &mut exec_step,
@@ -260,6 +262,7 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
                     ),
                     (
                         CallContextField::Value,
+                        // Should set to value of current call for DELEGATECALL.
                         if call.kind == CallKind::DelegateCall {
                             current_call.value
                         } else {

--- a/bus-mapping/src/evm/opcodes/callop.rs
+++ b/bus-mapping/src/evm/opcodes/callop.rs
@@ -258,7 +258,14 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
                         CallContextField::ReturnDataLength,
                         call.return_data_length.into(),
                     ),
-                    (CallContextField::Value, call.value),
+                    (
+                        CallContextField::Value,
+                        if call.kind == CallKind::DelegateCall {
+                            current_call.value
+                        } else {
+                            call.value
+                        },
+                    ),
                     (CallContextField::IsSuccess, (call.is_success as u64).into()),
                     (CallContextField::IsStatic, (call.is_static as u64).into()),
                     (CallContextField::LastCalleeId, 0.into()),

--- a/bus-mapping/src/evm/opcodes/callop.rs
+++ b/bus-mapping/src/evm/opcodes/callop.rs
@@ -4,7 +4,7 @@ use crate::operation::{AccountField, CallContextField, TxAccessListAccountOp, RW
 use crate::Error;
 use eth_types::evm_types::gas_utils::{eip150_gas, memory_expansion_gas_cost};
 use eth_types::evm_types::GasCost;
-use eth_types::{GethExecStep, ToWord};
+use eth_types::{GethExecStep, ToWord, Word};
 use keccak256::EMPTY_HASH;
 use log::warn;
 
@@ -115,46 +115,52 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
             state.call_context_write(&mut exec_step, call.call_id, field, value);
         }
 
-        let (_, callee_account) = state.sdb.get_account(&call.address);
-        let is_empty_account = callee_account.is_empty();
-        let callee_nonce = callee_account.nonce;
-
-        if call.kind == CallKind::Call {
-            // Transfer value only for CALL opcode.
-            state.transfer(
-                &mut exec_step,
-                call.caller_address,
-                call.address,
-                call.value,
-            )?;
-        } else {
-            // Get callee balance for CALLCODE, DELEGATECALL and STATICCALL opcodes.
-            let callee_balance = callee_account.balance;
-            state.account_read(
-                &mut exec_step,
-                call.address,
-                AccountField::Balance,
-                callee_balance,
-                callee_balance,
-            )?;
+        match call.kind {
+            CallKind::Call => {
+                // Transfer value only for CALL opcode.
+                state.transfer(
+                    &mut exec_step,
+                    call.caller_address,
+                    call.address,
+                    call.value,
+                )?;
+            }
+            CallKind::CallCode => {
+                // For CALLCODE opcode, get caller balance to constrain it should be greater or
+                // equal to stack `value`.
+                let (_, caller_account) = state.sdb.get_account(&call.caller_address);
+                let caller_balance = caller_account.balance;
+                state.account_read(
+                    &mut exec_step,
+                    call.caller_address,
+                    AccountField::Balance,
+                    caller_balance,
+                    caller_balance,
+                )?;
+            }
+            _ => (),
         }
 
-        state.account_read(
-            &mut exec_step,
-            call.address,
-            AccountField::Nonce,
-            callee_nonce,
-            callee_nonce,
-        )?;
         let callee_code_hash = call.code_hash;
-        let callee_code_hash_word = callee_code_hash.to_word();
-        state.account_read(
-            &mut exec_step,
-            callee_address,
-            AccountField::CodeHash,
-            callee_code_hash_word,
-            callee_code_hash_word,
-        )?;
+        let (callee_exists, _) = state.sdb.get_account(&callee_address);
+        if callee_exists {
+            let callee_code_hash_word = callee_code_hash.to_word();
+            state.account_read(
+                &mut exec_step,
+                callee_address,
+                AccountField::CodeHash,
+                callee_code_hash_word,
+                callee_code_hash_word,
+            )?;
+        } else {
+            state.account_read(
+                &mut exec_step,
+                callee_address,
+                AccountField::NonExisting,
+                Word::zero(),
+                Word::zero(),
+            )?;
+        }
 
         // Calculate next_memory_word_size and callee_gas_left manually in case
         // there isn't next geth_step (e.g. callee doesn't have code).
@@ -178,7 +184,7 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
             GasCost::COLD_ACCOUNT_ACCESS.as_u64()
         } + if has_value {
             GasCost::CALL_WITH_VALUE.as_u64()
-                + if is_empty_account {
+                + if call.kind == CallKind::Call && !callee_exists {
                     GasCost::NEW_ACCOUNT.as_u64()
                 } else {
                     0

--- a/bus-mapping/src/evm/opcodes/callop.rs
+++ b/bus-mapping/src/evm/opcodes/callop.rs
@@ -175,7 +175,7 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
         .max()
         .unwrap();
 
-        let has_value = !call.value.is_zero();
+        let has_value = !call.value.is_zero() && !call.is_delegatecall();
         let memory_expansion_gas_cost =
             memory_expansion_gas_cost(curr_memory_word_size, next_memory_word_size);
         let gas_cost = if is_warm {
@@ -266,15 +266,7 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
                         CallContextField::ReturnDataLength,
                         call.return_data_length.into(),
                     ),
-                    (
-                        CallContextField::Value,
-                        // Should set to value of current call for DELEGATECALL.
-                        if call.kind == CallKind::DelegateCall {
-                            current_call.value
-                        } else {
-                            call.value
-                        },
-                    ),
+                    (CallContextField::Value, call.value),
                     (CallContextField::IsSuccess, (call.is_success as u64).into()),
                     (CallContextField::IsStatic, (call.is_static as u64).into()),
                     (CallContextField::LastCalleeId, 0.into()),

--- a/bus-mapping/src/evm/opcodes/callop.rs
+++ b/bus-mapping/src/evm/opcodes/callop.rs
@@ -115,6 +115,9 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
             state.call_context_write(&mut exec_step, call.call_id, field, value);
         }
 
+        let callee_code_hash = call.code_hash;
+        let callee_exists = !state.sdb.get_account(&callee_address).1.is_empty();
+
         match call.kind {
             CallKind::Call => {
                 // Transfer value only for CALL opcode.
@@ -141,8 +144,6 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
             _ => (),
         }
 
-        let callee_code_hash = call.code_hash;
-        let callee_exists = !state.sdb.get_account(&callee_address).1.is_empty();
         if callee_exists {
             let callee_code_hash_word = callee_code_hash.to_word();
             state.account_read(

--- a/bus-mapping/src/evm/opcodes/callop.rs
+++ b/bus-mapping/src/evm/opcodes/callop.rs
@@ -142,7 +142,7 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
         }
 
         let callee_code_hash = call.code_hash;
-        let (callee_exists, _) = state.sdb.get_account(&callee_address);
+        let callee_exists = !state.sdb.get_account(&callee_address).1.is_empty();
         if callee_exists {
             let callee_code_hash_word = callee_code_hash.to_word();
             state.account_read(

--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -34,12 +34,12 @@ pub(crate) struct CallOpGadget<F> {
     reversion_info: ReversionInfo<F>,
     current_callee_address: Cell<F>,
     current_caller_address: Cell<F>,
-    current_value: Cell<F>,
     is_static: Cell<F>,
     depth: Cell<F>,
     gas: Word<F>,
     code_address: Word<F>,
     value: Word<F>,
+    current_value: Word<F>,
     is_success: Cell<F>,
     gas_is_u64: IsZeroGadget<F>,
     is_warm: Cell<F>,
@@ -103,12 +103,11 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
         ]
         .map(|field_tag| cb.call_context(None, field_tag));
 
-        let [current_caller_address, current_value] = cb.condition(is_delegatecall.expr(), |cb| {
-            [
-                CallContextFieldTag::CallerAddress,
-                CallContextFieldTag::Value,
-            ]
-            .map(|field_tag| cb.call_context(None, field_tag))
+        let (current_caller_address, current_value) = cb.condition(is_delegatecall.expr(), |cb| {
+            (
+                cb.call_context(None, CallContextFieldTag::CallerAddress),
+                cb.call_context_as_word(None, CallContextFieldTag::Value),
+            )
         });
 
         cb.range_lookup(depth.expr(), 1024);
@@ -368,12 +367,12 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
             reversion_info,
             current_callee_address,
             current_caller_address,
-            current_value,
             is_static,
             depth,
             gas: gas_word,
             code_address: code_address_word,
             value,
+            current_value,
             is_success,
             gas_is_u64,
             is_warm,
@@ -505,15 +504,8 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
                     .expect("unexpected Address -> Scalar conversion failure"),
             ),
         )?;
-        self.current_value.assign(
-            region,
-            offset,
-            Value::known(
-                current_value
-                    .to_scalar()
-                    .expect("unexpected U256 -> Scalar conversion failure"),
-            ),
-        )?;
+        self.current_value
+            .assign(region, offset, Some(current_value.to_le_bytes()))?;
         self.is_static
             .assign(region, offset, Value::known(F::from(is_static.low_u64())))?;
         self.depth

--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -10,7 +10,7 @@ use crate::evm_circuit::util::math_gadget::{
     BatchedIsZeroGadget, ConstantDivisionGadget, IsEqualGadget, IsZeroGadget, MinMaxGadget,
 };
 use crate::evm_circuit::util::memory_gadget::{MemoryAddressGadget, MemoryExpansionGadget};
-use crate::evm_circuit::util::{from_bytes, select, sum, CachedRegion, Cell, Word};
+use crate::evm_circuit::util::{from_bytes, or, select, sum, CachedRegion, Cell, Word};
 use crate::evm_circuit::witness::{Block, Call, ExecStep, Transaction};
 use crate::table::{AccountFieldTag, CallContextFieldTag};
 use crate::util::Expr;
@@ -355,7 +355,10 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
                     select::expr(is_delegatecall.expr(), current_value.expr(), value.expr()),
                 ),
                 (CallContextFieldTag::IsSuccess, is_success.expr()),
-                (CallContextFieldTag::IsStatic, is_staticcall.expr()),
+                (
+                    CallContextFieldTag::IsStatic,
+                    or::expr([is_static.expr(), is_staticcall.expr()]),
+                ),
                 (CallContextFieldTag::LastCalleeId, 0.expr()),
                 (CallContextFieldTag::LastCalleeReturnDataOffset, 0.expr()),
                 (CallContextFieldTag::LastCalleeReturnDataLength, 0.expr()),

--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -536,19 +536,15 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
                 field_tag: AccountFieldTag::CodeHash,
                 value,
                 ..
-            } => (
-                RandomLinearCombination::random_linear_combine(
-                    value.to_le_bytes(),
-                    block.randomness,
-                ),
-                true,
-            ),
+            } => (value.to_le_bytes(), true),
             Rw::Account {
                 field_tag: AccountFieldTag::NonExisting,
                 ..
-            } => (F::zero(), false),
+            } => (*EMPTY_HASH_LE, false),
             _ => unreachable!(),
         };
+        let callee_code_hash =
+            RandomLinearCombination::random_linear_combine(callee_code_hash, block.randomness);
         self.opcode
             .assign(region, offset, Value::known(F::from(opcode.as_u64())))?;
         self.is_call.assign(
@@ -824,7 +820,7 @@ mod test {
         Account {
             address: Address::repeat_byte(0xff),
             code: code.into(),
-            nonce: if false { 0 } else { 1 }.into(),
+            nonce: if is_empty { 0 } else { 1 }.into(),
             balance: if is_empty { 0 } else { 0xdeadbeefu64 }.into(),
             ..Default::default()
         }

--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -7,11 +7,13 @@ use crate::evm_circuit::util::constraint_builder::{
     ConstraintBuilder, ReversionInfo, StepStateTransition,
 };
 use crate::evm_circuit::util::math_gadget::{
-    BatchedIsZeroGadget, ConstantDivisionGadget, IsEqualGadget, IsZeroGadget, MinMaxGadget,
+    CmpWordsGadget, ConstantDivisionGadget, IsEqualGadget, IsZeroGadget, MinMaxGadget,
 };
 use crate::evm_circuit::util::memory_gadget::{MemoryAddressGadget, MemoryExpansionGadget};
-use crate::evm_circuit::util::{from_bytes, or, select, sum, CachedRegion, Cell, Word};
-use crate::evm_circuit::witness::{Block, Call, ExecStep, Transaction};
+use crate::evm_circuit::util::{
+    from_bytes, or, select, sum, CachedRegion, Cell, RandomLinearCombination, Word,
+};
+use crate::evm_circuit::witness::{Block, Call, ExecStep, Rw, Transaction};
 use crate::table::{AccountFieldTag, CallContextFieldTag};
 use crate::util::Expr;
 use bus_mapping::evm::OpcodeId;
@@ -50,10 +52,10 @@ pub(crate) struct CallOpGadget<F> {
     rd_address: MemoryAddressGadget<F>,
     memory_expansion: MemoryExpansionGadget<F, 2, N_BYTES_MEMORY_WORD_SIZE>,
     transfer: TransferGadget<F>,
-    callee_balance: Cell<F>,
-    callee_nonce: Cell<F>,
+    caller_balance: Word<F>,
+    callee_exists: Cell<F>,
     callee_code_hash: Cell<F>,
-    is_empty_nonce_and_balance: BatchedIsZeroGadget<F, 2>,
+    enough_transfer_balance: CmpWordsGadget<F>,
     is_empty_code_hash: IsEqualGadget<F>,
     one_64th_gas: ConstantDivisionGadget<F, N_BYTES_GAS>,
     capped_callee_gas_left: MinMaxGadget<F, N_BYTES_GAS>,
@@ -195,51 +197,56 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
         });
 
         // Verify transfer only for CALL opcode.
+        let caller_balance = cb.query_word();
         let transfer = cb.condition(is_call.expr(), |cb| {
-            TransferGadget::construct(
+            let transfer = TransferGadget::construct(
                 cb,
                 caller_address.expr(),
                 callee_address.expr(),
                 value.clone(),
                 &mut callee_reversion_info,
-            )
-        });
-
-        // Get callee balance for CALLCODE, DELEGATECALL and STATICCALL opcodes.
-        let callee_balance = cb.condition(1.expr() - is_call.expr(), |cb| {
-            let callee_balance = cb.query_cell();
-            cb.account_read(
-                callee_address.expr(),
-                AccountFieldTag::Balance,
-                callee_balance.expr(),
             );
-            callee_balance
+            cb.require_equal(
+                "caller_balance == transfer.sender.balance_prev for CALL opcode",
+                caller_balance.expr(),
+                transfer.sender().balance_prev().expr(),
+            );
+            transfer
         });
 
-        // Verify gas cost
-        let callee_nonce = cb.query_cell();
-        cb.account_read(
-            callee_address.expr(),
-            AccountFieldTag::Nonce,
-            callee_nonce.expr(),
-        );
+        // For CALLCODE opcode, get caller balance to constrain it should be greater or
+        // equal to stack `value`.
+        cb.condition(is_callcode.expr(), |cb| {
+            cb.account_read(
+                caller_address.expr(),
+                AccountFieldTag::Balance,
+                caller_balance.expr(),
+            );
+        });
+
+        // For both CALL and CALLCODE opcodes, verify caller balance is greater than or
+        // equal to stack `value`.
+        let enough_transfer_balance = CmpWordsGadget::construct(cb, &value, &caller_balance);
+        cb.condition(is_call.expr() + is_callcode.expr(), |cb| {
+            cb.require_zero(
+                "transfer_value <= caller_balance for both CALL and CALLCODE opcodes",
+                1.expr() - enough_transfer_balance.eq.expr() - enough_transfer_balance.lt.expr(),
+            );
+        });
+
+        let callee_exists = cb.query_bool();
         let callee_code_hash = cb.query_cell();
-        cb.account_read(
-            code_address,
-            AccountFieldTag::CodeHash,
-            callee_code_hash.expr(),
-        );
-        let is_empty_nonce_and_balance = BatchedIsZeroGadget::construct(
-            cb,
-            [
-                callee_nonce.expr(),
-                select::expr(
-                    is_call.expr(),
-                    transfer.receiver().balance_prev().expr(),
-                    callee_balance.expr(),
-                ),
-            ],
-        );
+        cb.condition(callee_exists.expr(), |cb| {
+            cb.account_read(
+                code_address.expr(),
+                AccountFieldTag::CodeHash,
+                callee_code_hash.expr(),
+            );
+        });
+        cb.condition(1.expr() - callee_exists.expr(), |cb| {
+            cb.account_read(code_address, AccountFieldTag::NonExisting, 0.expr());
+        });
+
         let is_empty_code_hash = IsEqualGadget::construct(
             cb,
             callee_code_hash.expr(),
@@ -248,14 +255,16 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
                 cb.power_of_randomness(),
             ),
         );
-        let is_empty_account = is_empty_nonce_and_balance.expr() * is_empty_code_hash.expr();
-        // Sum up gas cost
+
+        // Sum up and verify gas cost.
         let gas_cost = select::expr(
             is_warm_prev.expr(),
             GasCost::WARM_ACCESS.expr(),
             GasCost::COLD_ACCOUNT_ACCESS.expr(),
         ) + has_value.clone()
-            * (GasCost::CALL_WITH_VALUE.expr() + is_empty_account * GasCost::NEW_ACCOUNT.expr())
+            * (GasCost::CALL_WITH_VALUE.expr()
+                // Only CALL opcode could invoke transfer to make empty account into non-empty.
+                + is_call.expr() * (1.expr() - callee_exists.expr()) * GasCost::NEW_ACCOUNT.expr())
             + memory_expansion.gas_cost();
 
         // Apply EIP 150
@@ -287,17 +296,16 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
             // `transfer` call (+3).
             //
             // For CALLCODE opcode, it has an extra stack pop `value` and one account read
-            // for callee balance (+2).
+            // for caller balance (+2).
             //
-            // For DELEGATECALL opcode, has two extra call context lookups for current
-            // caller address and value, and one account read for callee balance (+3).
+            // For DELEGATECALL opcode, it has two extra call context lookups for current
+            // caller address and value (+2).
             //
-            // For STATICCALL opcode, it has one account read for callee balance (+1).
-            let rw_counter_delta = 21.expr()
+            // No extra lookups for STATICCALL opcode.
+            let rw_counter_delta = 20.expr()
                 + is_call.expr() * 3.expr()
                 + is_callcode.expr() * 2.expr()
-                + is_delegatecall.expr() * 3.expr()
-                + is_staticcall.expr();
+                + is_delegatecall.expr() * 2.expr();
             cb.require_step_state_transition(StepStateTransition {
                 rw_counter: Delta(rw_counter_delta),
                 program_counter: Delta(1.expr()),
@@ -376,17 +384,16 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
             // `transfer` call (+3).
             //
             // For CALLCODE opcode, it has an extra stack pop `value` and one account read
-            // for callee balance (+2).
+            // for caller balance (+2).
             //
-            // For DELEGATECALL opcode, has two extra call context lookups for current
-            // caller address and value, and one account read for callee balance (+3).
+            // For DELEGATECALL opcode, it has two extra call context lookups for current
+            // caller address and value (+2).
             //
-            // For STATICCALL opcode, it has one account read for callee balance (+1).
-            let rw_counter_delta = 41.expr()
+            // No extra lookups for STATICCALL opcode.
+            let rw_counter_delta = 40.expr()
                 + is_call.expr() * 3.expr()
                 + is_callcode.expr() * 2.expr()
-                + is_delegatecall.expr() * 3.expr()
-                + is_staticcall.expr();
+                + is_delegatecall.expr() * 2.expr();
             cb.require_step_state_transition(StepStateTransition {
                 rw_counter: Delta(rw_counter_delta),
                 call_id: To(callee_call_id.expr()),
@@ -426,10 +433,10 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
             rd_address,
             memory_expansion,
             transfer,
-            callee_balance,
-            callee_nonce,
+            caller_balance,
+            callee_exists,
             callee_code_hash,
-            is_empty_nonce_and_balance,
+            enough_transfer_balance,
             is_empty_code_hash,
             one_64th_gas,
             capped_callee_gas_left,
@@ -493,25 +500,51 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
             step.rw_indices[15 + rw_offset],
         ]
         .map(|idx| block.rws[idx].call_context_value());
-        let [caller_balance_pair, callee_balance_pair, (callee_balance, _)] = if is_call {
+        let (caller_balance_pair, callee_balance_pair, caller_balance) = if is_call {
+            rw_offset += 2;
+            let caller_balance_pair =
+                block.rws[step.rw_indices[14 + rw_offset]].account_value_pair();
+            let callee_balance_pair =
+                block.rws[step.rw_indices[15 + rw_offset]].account_value_pair();
+            (
+                caller_balance_pair,
+                callee_balance_pair,
+                caller_balance_pair.1,
+            )
+        } else if is_callcode {
             rw_offset += 1;
-            [
-                block.rws[step.rw_indices[15 + rw_offset]].account_value_pair(),
-                block.rws[step.rw_indices[16 + rw_offset]].account_value_pair(),
+            (
                 (U256::zero(), U256::zero()),
-            ]
+                (U256::zero(), U256::zero()),
+                block.rws[step.rw_indices[15 + rw_offset]]
+                    .account_value_pair()
+                    .0,
+            )
         } else {
-            [
+            (
                 (U256::zero(), U256::zero()),
                 (U256::zero(), U256::zero()),
-                block.rws[step.rw_indices[16 + rw_offset]].account_value_pair(),
-            ]
+                U256::zero(),
+            )
         };
-        let [(callee_nonce, _), (callee_code_hash, _)] = [
-            step.rw_indices[17 + rw_offset],
-            step.rw_indices[18 + rw_offset],
-        ]
-        .map(|idx| block.rws[idx].account_value_pair());
+        let (callee_code_hash, callee_exists) = match block.rws[step.rw_indices[16 + rw_offset]] {
+            Rw::Account {
+                field_tag: AccountFieldTag::CodeHash,
+                value,
+                ..
+            } => (
+                RandomLinearCombination::random_linear_combine(
+                    value.to_le_bytes(),
+                    block.randomness,
+                ),
+                true,
+            ),
+            Rw::Account {
+                field_tag: AccountFieldTag::NonExisting,
+                ..
+            } => (F::zero(), false),
+            _ => unreachable!(),
+        };
         self.opcode
             .assign(region, offset, Value::known(F::from(opcode.as_u64())))?;
         self.is_call.assign(
@@ -609,54 +642,20 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
             callee_balance_pair,
             value,
         )?;
-        self.callee_balance.assign(
+        self.caller_balance
+            .assign(region, offset, Some(caller_balance.to_le_bytes()))?;
+        self.callee_exists
+            .assign(region, offset, Value::known(F::from(callee_exists)))?;
+        self.callee_code_hash
+            .assign(region, offset, Value::known(callee_code_hash))?;
+        self.enough_transfer_balance
+            .assign(region, offset, value, caller_balance)?;
+        self.is_empty_code_hash.assign(
             region,
             offset,
-            Value::known(Word::random_linear_combine(
-                callee_balance.to_le_bytes(),
-                block.randomness,
-            )),
-        )?;
-        self.callee_nonce.assign(
-            region,
-            offset,
-            Value::known(
-                callee_nonce
-                    .to_scalar()
-                    .expect("unexpected U256 -> Scalar conversion failure"),
-            ),
-        )?;
-        self.callee_code_hash.assign(
-            region,
-            offset,
-            Value::known(Word::random_linear_combine(
-                callee_code_hash.to_le_bytes(),
-                block.randomness,
-            )),
-        )?;
-        let is_empty_nonce_and_balance = self.is_empty_nonce_and_balance.assign(
-            region,
-            offset,
-            [
-                F::from(callee_nonce.low_u64()),
-                Word::random_linear_combine(
-                    (if is_call {
-                        callee_balance_pair.1
-                    } else {
-                        callee_balance
-                    })
-                    .to_le_bytes(),
-                    block.randomness,
-                ),
-            ],
-        )?;
-        let is_empty_code_hash = self.is_empty_code_hash.assign(
-            region,
-            offset,
-            Word::random_linear_combine(callee_code_hash.to_le_bytes(), block.randomness),
+            callee_code_hash,
             Word::random_linear_combine(*EMPTY_HASH_LE, block.randomness),
         )?;
-        let is_empty_account = is_empty_nonce_and_balance * is_empty_code_hash;
         let has_value = !value.is_zero();
         let gas_cost = if is_warm_prev {
             GasCost::WARM_ACCESS.as_u64()
@@ -664,7 +663,8 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
             GasCost::COLD_ACCOUNT_ACCESS.as_u64()
         } + if has_value {
             GasCost::CALL_WITH_VALUE.as_u64()
-                + if is_empty_account == F::one() {
+                // Only CALL opcode could invoke transfer to make empty account into non-empty.
+                + if is_call && !callee_exists {
                     GasCost::NEW_ACCOUNT.as_u64()
                 } else {
                     0
@@ -809,12 +809,12 @@ mod test {
 
     fn callee(code: bytecode::Bytecode) -> Account {
         let code = code.to_vec();
-        let is_empty = code.is_empty();
+        let balance = if code.is_empty() { 0 } else { 0xdeadbeefu64 };
         Account {
             address: Address::repeat_byte(0xff),
+            balance: balance.into(),
             code: code.into(),
-            nonce: if is_empty { 0 } else { 1 }.into(),
-            balance: if is_empty { 0 } else { 0xdeadbeefu64 }.into(),
+            nonce: 1.into(),
             ..Default::default()
         }
     }

--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -223,7 +223,7 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
         // For CALLCODE opcode, verify caller balance is greater than or equal to stack
         // `value`.
         let enough_transfer_balance =
-            CmpWordsGadget::construct(cb, &value, &transfer.sender().balance_prev());
+            CmpWordsGadget::construct(cb, &value, transfer.sender().balance_prev());
         cb.condition(is_callcode.expr(), |cb| {
             cb.require_zero(
                 "transfer_value <= caller_balance for CALLCODE opcode",
@@ -634,7 +634,7 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
         self.callee_code_hash
             .assign(region, offset, Value::known(callee_code_hash))?;
         self.enough_transfer_balance
-            .assign(region, offset, value, caller_balance_pair.0)?;
+            .assign(region, offset, value, caller_balance_pair.1)?;
         self.is_empty_code_hash.assign(
             region,
             offset,

--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -227,7 +227,7 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
         // For both CALL and CALLCODE opcodes, verify caller balance is greater than or
         // equal to stack `value`.
         let enough_transfer_balance = CmpWordsGadget::construct(cb, &value, &caller_balance);
-        cb.condition(is_call.expr() + is_callcode.expr(), |cb| {
+        cb.condition(is_callcode.expr(), |cb| {
             cb.require_zero(
                 "transfer_value <= caller_balance for both CALL and CALLCODE opcodes",
                 1.expr() - enough_transfer_balance.eq.expr() - enough_transfer_balance.lt.expr(),

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -412,6 +412,10 @@ impl<F: Field> TransferGadget<F> {
         Self { sender, receiver }
     }
 
+    pub(crate) fn sender(&self) -> &UpdateBalanceGadget<F, 2, false> {
+        &self.sender
+    }
+
     pub(crate) fn receiver(&self) -> &UpdateBalanceGadget<F, 2, true> {
         &self.receiver
     }

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -1005,6 +1005,16 @@ impl<'a, F: Field> ConstraintBuilder<'a, F> {
         cell
     }
 
+    pub(crate) fn call_context_as_word(
+        &mut self,
+        call_id: Option<Expression<F>>,
+        field_tag: CallContextFieldTag,
+    ) -> Word<F> {
+        let word = self.query_word();
+        self.call_context_lookup(false.expr(), call_id, field_tag, word.expr());
+        word
+    }
+
     pub(crate) fn call_context_lookup(
         &mut self,
         is_write: Expression<F>,

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -1005,16 +1005,6 @@ impl<'a, F: Field> ConstraintBuilder<'a, F> {
         cell
     }
 
-    pub(crate) fn call_context_as_word(
-        &mut self,
-        call_id: Option<Expression<F>>,
-        field_tag: CallContextFieldTag,
-    ) -> Word<F> {
-        let word = self.query_word();
-        self.call_context_lookup(false.expr(), call_id, field_tag, word.expr());
-        word
-    }
-
     pub(crate) fn call_context_lookup(
         &mut self,
         is_write: Expression<F>,


### PR DESCRIPTION
Close https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/995

Spec PR https://github.com/privacy-scaling-explorations/zkevm-specs/pull/335

### Summary

1.  Fix to not invoke `transfer` for call related opcodes (`CALLCODE`, `DELEGATECALL` and `STATICCALL`) expect `CALL`.
2. Fix to use `current_call.value` to setup next-call context for `DELEGATECALL`.
3. Add function `call_context_as_word` and fix `current_value` to `Word` type in circuit.
4. Integrate non-existing proof (`AccountFieldTag::NonExisting`) with `callee`.