### PR TITLE
Propagate value of caller when `DELEGATECALL`

### DIFF
--- a/bus-mapping/src/circuit_input_builder/call.rs
+++ b/bus-mapping/src/circuit_input_builder/call.rs
@@ -101,6 +101,11 @@ impl Call {
     pub fn is_create(&self) -> bool {
         self.kind.is_create()
     }
+
+    /// This call is call with op DELEGATECALL
+    pub fn is_delegatecall(&self) -> bool {
+        matches!(self.kind, CallKind::DelegateCall)
+    }
 }
 
 /// Context of a [`Call`].

--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -595,7 +595,7 @@ impl<'a> CircuitInputStateRef<'a> {
                 step.stack.nth_last(2)?,
             ),
             CallKind::CallCode => (caller.address, caller.address, step.stack.nth_last(2)?),
-            CallKind::DelegateCall => (caller.caller_address, caller.address, Word::zero()),
+            CallKind::DelegateCall => (caller.caller_address, caller.address, caller.value),
             CallKind::StaticCall => (
                 caller.address,
                 step.stack.nth_last(1)?.to_address(),

--- a/bus-mapping/src/evm/opcodes/callop.rs
+++ b/bus-mapping/src/evm/opcodes/callop.rs
@@ -155,7 +155,7 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
         .max()
         .unwrap();
 
-        let has_value = !call.value.is_zero();
+        let has_value = !call.value.is_zero() && !call.is_delegatecall();
         let memory_expansion_gas_cost =
             memory_expansion_gas_cost(curr_memory_word_size, next_memory_word_size);
         let gas_cost = if is_warm {


### PR DESCRIPTION
This PR aims to fix `parse_call` to propagate caller's value to next call, and calculate the gas cost correctly (when it's delegate call with propagated value, no need to add extra gas).

Resolves #969.
