### PR TITLE
dummy error gadgets not works well

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_call.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_call.rs
@@ -360,7 +360,7 @@ mod test {
             PUSH32(stack.value)
             PUSH32(Address::repeat_byte(0xff).to_word())
             PUSH32(Word::from(stack.gas))
-            CALL
+            DELEGATECALL
             PUSH1(0)
             PUSH1(0)
             .write_op(terminator)
@@ -481,7 +481,7 @@ mod test {
             PUSH32(stack.value)
             PUSH32(Address::repeat_byte(0xfe).to_word())
             PUSH32(Word::from(stack.gas))
-            CALL // make this call out of gas
+            DELEGATECALL // make this call out of gas
             PUSH32(Word::from(0))
             PUSH32(Word::from(0))
         };


### PR DESCRIPTION
```
cargo test -p zkevm-circuits --all-features --release call_oog -- --nocapture
```

should pass