### PR TITLE
Implement `RootCircuit` for `SuperCircuit` aggregation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2014,11 +2014,28 @@ dependencies = [
  "blake2b_simd",
  "ff",
  "group",
- "halo2curves",
+ "halo2curves 0.3.1",
  "rand_core",
  "rayon",
  "sha3 0.9.1",
  "tracing",
+]
+
+[[package]]
+name = "halo2curves"
+version = "0.2.1"
+source = "git+https://github.com/privacy-scaling-explorations/halo2curves?tag=0.3.0#83c72d49762343ffc9576ca11a2aa615efe1029b"
+dependencies = [
+ "ff",
+ "group",
+ "lazy_static",
+ "num-bigint",
+ "num-traits",
+ "pasta_curves",
+ "rand",
+ "rand_core",
+ "static_assertions",
+ "subtle",
 ]
 
 [[package]]
@@ -3217,6 +3234,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "poseidon"
+version = "0.2.0"
+source = "git+https://github.com/privacy-scaling-explorations/poseidon.git?tag=v2022_10_22#5d29df01a95e3df6334080d28e983407f56b5da3"
+dependencies = [
+ "group",
+ "halo2curves 0.2.1",
+ "subtle",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3976,6 +4003,24 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "snark-verifier"
+version = "0.1.0"
+source = "git+https://github.com/privacy-scaling-explorations/snark-verifier?tag=v2023_02_02#df03d898b841f71cbc36c2fb9fa07b8196f9623e"
+dependencies = [
+ "ecc",
+ "halo2_proofs 0.2.0",
+ "halo2curves 0.3.1",
+ "hex",
+ "itertools",
+ "lazy_static",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "poseidon",
+ "rand",
+]
 
 [[package]]
 name = "socket2"
@@ -4890,6 +4935,7 @@ dependencies = [
  "rand_chacha",
  "rand_xorshift",
  "sha3 0.10.6",
+ "snark-verifier",
  "strum",
  "strum_macros",
  "subtle",

--- a/zkevm-circuits/Cargo.toml
+++ b/zkevm-circuits/Cargo.toml
@@ -35,6 +35,7 @@ libsecp256k1 = "0.7"
 num-bigint = { version = "0.4" }
 subtle = "2.4"
 rand_chacha = "0.3"
+snark-verifier = { git = "https://github.com/privacy-scaling-explorations/snark-verifier", tag = "v2023_02_02", default-features = false, features = ["loader_halo2", "system_halo2"] }
 
 [dev-dependencies]
 bus-mapping = { path = "../bus-mapping", features = ["test"] }

--- a/zkevm-circuits/src/lib.rs
+++ b/zkevm-circuits/src/lib.rs
@@ -23,6 +23,7 @@ pub mod evm_circuit;
 pub mod exp_circuit;
 pub mod keccak_circuit;
 pub mod pi_circuit;
+pub mod root_circuit;
 pub mod state_circuit;
 pub mod super_circuit;
 pub mod table;

--- a/zkevm-circuits/src/root_circuit.rs
+++ b/zkevm-circuits/src/root_circuit.rs
@@ -1,0 +1,218 @@
+//! The Root circuit implementation.
+use halo2_proofs::{
+    arithmetic::Field,
+    circuit::{Layouter, SimpleFloorPlanner, Value},
+    halo2curves::serde::SerdeObject,
+    plonk::{Circuit, ConstraintSystem, Error},
+    poly::{commitment::ParamsProver, kzg::commitment::ParamsKZG},
+};
+use itertools::Itertools;
+use maingate::MainGateInstructions;
+use snark_verifier::{util::arithmetic::MultiMillerLoop, verifier::plonk::PlonkProtocol};
+use std::iter;
+
+mod aggregation;
+
+pub use aggregation::{
+    aggregate, AggregationConfig, EccChip, Halo2Loader, KzgAs, KzgDk, KzgSvk,
+    PlonkSuccinctVerifier, PlonkVerifier, PoseidonTranscript, Snark, SnarkWitness, BITS, LIMBS,
+};
+pub use snark_verifier::system::halo2::{compile, Config};
+
+#[cfg(any(feature = "test", test))]
+pub use aggregation::TestAggregationCircuit;
+
+/// RootCircuit for aggregating SuperCircuit into a much smaller proof.
+pub struct RootCircuit<'a, M: MultiMillerLoop> {
+    svk: KzgSvk<M>,
+    snark: SnarkWitness<'a, M::G1Affine>,
+    instances: Vec<M::Scalar>,
+}
+
+impl<'a, M: MultiMillerLoop> RootCircuit<'a, M>
+where
+    M::G1Affine: SerdeObject,
+    M::G2Affine: SerdeObject,
+{
+    /// Create a `RootCircuit` with accumulator computed given a `SuperCircuit`
+    /// proof and its instances. Returns `None` if given proof is invalid.
+    pub fn new(
+        params: &ParamsKZG<M>,
+        super_circuit_protocol: &'a PlonkProtocol<M::G1Affine>,
+        super_circuit_instances: Value<&'a Vec<Vec<M::Scalar>>>,
+        super_circuit_proof: Value<&'a [u8]>,
+    ) -> Option<Self> {
+        let mut instances = Some(Vec::new());
+        super_circuit_instances
+            .as_ref()
+            .zip(super_circuit_proof.as_ref())
+            .map(|(super_circuit_instances, super_circuit_proof)| {
+                let snark = Snark::new(
+                    super_circuit_protocol,
+                    super_circuit_instances,
+                    super_circuit_proof,
+                );
+                instances = aggregate::<M>(params, [snark]).map(|accumulator_limbs| {
+                    iter::empty()
+                        // Propagate `SuperCircuit`'s instances
+                        .chain(super_circuit_instances.iter().flatten().cloned())
+                        // Output aggregated accumulator limbs
+                        .chain(accumulator_limbs)
+                        .collect_vec()
+                });
+            });
+
+        instances.map(|instances| Self {
+            svk: KzgSvk::<M>::new(params.get_g()[0]),
+            snark: SnarkWitness::new(
+                super_circuit_protocol,
+                super_circuit_instances,
+                super_circuit_proof,
+            ),
+            instances,
+        })
+    }
+
+    /// Returns accumulator indices in instance columns, which will be in
+    /// the last `4 * LIMBS` rows of instance column in `MainGate`.
+    pub fn accumulator_indices(&self) -> Vec<(usize, usize)> {
+        let offset = self.snark.protocol().num_instance.iter().sum::<usize>();
+        (offset..).map(|idx| (0, idx)).take(4 * LIMBS).collect()
+    }
+
+    /// Returns number of instance
+    pub fn num_instance(&self) -> Vec<usize> {
+        vec![self.snark.protocol().num_instance.iter().sum::<usize>() + 4 * LIMBS]
+    }
+
+    /// Returns instances
+    pub fn instances(&self) -> Vec<Vec<M::Scalar>> {
+        vec![self.instances.clone()]
+    }
+}
+
+impl<'a, M: MultiMillerLoop> Circuit<M::Scalar> for RootCircuit<'a, M> {
+    type Config = AggregationConfig;
+    type FloorPlanner = SimpleFloorPlanner;
+
+    fn without_witnesses(&self) -> Self {
+        Self {
+            svk: self.svk,
+            snark: self.snark.without_witnesses(),
+            instances: vec![M::Scalar::zero(); self.instances.len()],
+        }
+    }
+
+    fn configure(meta: &mut ConstraintSystem<M::Scalar>) -> Self::Config {
+        AggregationConfig::configure::<M::G1Affine>(meta)
+    }
+
+    fn synthesize(
+        &self,
+        config: Self::Config,
+        mut layouter: impl Layouter<M::Scalar>,
+    ) -> Result<(), Error> {
+        config.load_table(&mut layouter)?;
+        let (instances, accumulator_limbs) =
+            config.aggregate::<M>(&mut layouter, &self.svk, [self.snark])?;
+
+        // Constrain equality to instance values
+        let main_gate = config.main_gate();
+        for (row, limb) in instances
+            .into_iter()
+            .flatten()
+            .flatten()
+            .chain(accumulator_limbs)
+            .enumerate()
+        {
+            main_gate.expose_public(layouter.namespace(|| ""), limb, row)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        root_circuit::{compile, Config, PoseidonTranscript, RootCircuit},
+        super_circuit::{super_circuit_tests::block_1tx, SuperCircuit},
+    };
+    use bus_mapping::circuit_input_builder::CircuitsParams;
+    use halo2_proofs::{
+        circuit::Value,
+        dev::MockProver,
+        halo2curves::bn256::Bn256,
+        plonk::{create_proof, keygen_pk, keygen_vk},
+        poly::kzg::{
+            commitment::{KZGCommitmentScheme, ParamsKZG},
+            multiopen::ProverGWC,
+        },
+    };
+    use itertools::Itertools;
+    use rand::rngs::OsRng;
+
+    #[ignore = "Due to high memory requirement"]
+    #[test]
+    fn test_root_circuit() {
+        let (params, protocol, proof, instance) = {
+            // Preprocess
+            const MAX_TXS: usize = 1;
+            const MAX_CALLDATA: usize = 32;
+            const TEST_MOCK_RANDOMNESS: u64 = 0x100;
+            let circuits_params = CircuitsParams {
+                max_txs: MAX_TXS,
+                max_calldata: MAX_CALLDATA,
+                max_rws: 256,
+                max_copy_rows: 256,
+                max_bytecode: 512,
+                keccak_padding: None,
+            };
+            let (k, circuit, instance, _) =
+                SuperCircuit::<_, MAX_TXS, MAX_CALLDATA, TEST_MOCK_RANDOMNESS>::build(
+                    block_1tx(),
+                    circuits_params,
+                )
+                .unwrap();
+            let params = ParamsKZG::<Bn256>::setup(k, OsRng);
+            let pk = keygen_pk(&params, keygen_vk(&params, &circuit).unwrap(), &circuit).unwrap();
+            let protocol = compile(
+                &params,
+                pk.get_vk(),
+                Config::kzg()
+                    .with_num_instance(instance.iter().map(|instances| instances.len()).collect()),
+            );
+
+            // Create proof
+            let proof = {
+                let mut transcript = PoseidonTranscript::new(Vec::new());
+                create_proof::<KZGCommitmentScheme<_>, ProverGWC<_>, _, _, _, _>(
+                    &params,
+                    &pk,
+                    &[circuit],
+                    &[&instance.iter().map(Vec::as_slice).collect_vec()],
+                    OsRng,
+                    &mut transcript,
+                )
+                .unwrap();
+                transcript.finalize()
+            };
+
+            (params, protocol, proof, instance)
+        };
+
+        let root_circuit = RootCircuit::new(
+            &params,
+            &protocol,
+            Value::known(&instance),
+            Value::known(&proof),
+        )
+        .unwrap();
+        assert_eq!(
+            MockProver::run(26, &root_circuit, root_circuit.instances())
+                .unwrap()
+                .verify_par(),
+            Ok(())
+        );
+    }
+}

--- a/zkevm-circuits/src/root_circuit/aggregation.rs
+++ b/zkevm-circuits/src/root_circuit/aggregation.rs
@@ -1,0 +1,706 @@
+use halo2_proofs::{
+    arithmetic::Field,
+    circuit::{AssignedCell, Layouter, SimpleFloorPlanner, Value},
+    halo2curves::{pairing::Engine, serde::SerdeObject, CurveAffine},
+    plonk::{Circuit, ConstraintSystem, Error},
+    poly::{commitment::ParamsProver, kzg::commitment::ParamsKZG},
+};
+use itertools::Itertools;
+use rand::{rngs::StdRng, SeedableRng};
+use snark_verifier::{
+    loader::{
+        self,
+        halo2::{
+            halo2_wrong_ecc::{self, integer::rns::Rns, maingate::*, EccConfig},
+            Scalar,
+        },
+        native::NativeLoader,
+    },
+    pcs::{
+        kzg::{self, *},
+        AccumulationDecider, AccumulationScheme, AccumulationSchemeProver,
+    },
+    system::halo2::transcript,
+    util::arithmetic::{fe_to_limbs, FieldExt, MultiMillerLoop},
+    verifier::{self, plonk::PlonkProtocol, SnarkVerifier},
+};
+use std::{iter, rc::Rc};
+
+/// Number of limbs to decompose a elliptic curve base field element into.
+pub const LIMBS: usize = 4;
+/// Number of bits of each decomposed limb.
+pub const BITS: usize = 68;
+
+/// KZG accumulation scheme with GWC19 multiopen.
+pub type KzgAs<M> = kzg::KzgAs<M, Gwc19>;
+/// KZG succinct verifying key
+pub type KzgSvk<M> = KzgSuccinctVerifyingKey<<M as Engine>::G1Affine>;
+/// KZG deciding key
+pub type KzgDk<M> = KzgDecidingKey<M>;
+/// Plonk succinct verifier with `KzgAs`
+pub type PlonkSuccinctVerifier<M> = verifier::plonk::PlonkSuccinctVerifier<KzgAs<M>>;
+/// Plonk verifier with `KzgAs` and `LimbsEncoding<LIMBS, BITS>`.
+pub type PlonkVerifier<M> = verifier::plonk::PlonkVerifier<KzgAs<M>, LimbsEncoding<LIMBS, BITS>>;
+
+const T: usize = 5;
+const RATE: usize = 4;
+const R_F: usize = 8;
+const R_P: usize = 60;
+
+/// `BaseFieldEccChip` with hardcoded `LIMBS` and `BITS` serving as `EccChip`
+/// for `Halo2Loader`.
+pub type EccChip<C> = halo2_wrong_ecc::BaseFieldEccChip<C, LIMBS, BITS>;
+/// `Halo2Loader` with hardcoded `EccChip`.
+pub type Halo2Loader<'a, C> = loader::halo2::Halo2Loader<'a, C, EccChip<C>>;
+/// `PoseidonTranscript` with hardcoded parameter with 128-bits security.
+pub type PoseidonTranscript<C, S> =
+    transcript::halo2::PoseidonTranscript<C, NativeLoader, S, T, RATE, R_F, R_P>;
+
+/// Snark contains the minimal information for verification
+#[derive(Clone, Copy)]
+pub struct Snark<'a, C: CurveAffine> {
+    protocol: &'a PlonkProtocol<C>,
+    instances: &'a Vec<Vec<C::Scalar>>,
+    proof: &'a [u8],
+}
+
+impl<'a, C: CurveAffine> Snark<'a, C> {
+    /// Construct `Snark` with each field.
+    pub fn new(
+        protocol: &'a PlonkProtocol<C>,
+        instances: &'a Vec<Vec<C::Scalar>>,
+        proof: &'a [u8],
+    ) -> Self {
+        Self {
+            protocol,
+            instances,
+            proof,
+        }
+    }
+}
+
+impl<'a, C: CurveAffine> From<Snark<'a, C>> for SnarkWitness<'a, C> {
+    fn from(snark: Snark<'a, C>) -> Self {
+        Self {
+            protocol: snark.protocol,
+            instances: Value::known(snark.instances),
+            proof: Value::known(snark.proof),
+        }
+    }
+}
+
+/// SnarkWitness
+#[derive(Clone, Copy)]
+pub struct SnarkWitness<'a, C: CurveAffine> {
+    protocol: &'a PlonkProtocol<C>,
+    instances: Value<&'a Vec<Vec<C::Scalar>>>,
+    proof: Value<&'a [u8]>,
+}
+
+impl<'a, C: CurveAffine> SnarkWitness<'a, C> {
+    /// Construct `SnarkWitness` with each field.
+    pub fn new(
+        protocol: &'a PlonkProtocol<C>,
+        instances: Value<&'a Vec<Vec<C::Scalar>>>,
+        proof: Value<&'a [u8]>,
+    ) -> Self {
+        Self {
+            protocol,
+            instances,
+            proof,
+        }
+    }
+
+    /// Returns `SnarkWitness` with all witness as `Value::unknown()`.
+    pub fn without_witnesses(&self) -> Self {
+        SnarkWitness {
+            protocol: self.protocol,
+            instances: Value::unknown(),
+            proof: Value::unknown(),
+        }
+    }
+
+    /// Returns protocol as reference.
+    pub fn protocol(&self) -> &PlonkProtocol<C> {
+        self.protocol
+    }
+
+    /// Returns proof as reference.
+    pub fn proof(&self) -> Value<&[u8]> {
+        self.proof
+    }
+
+    fn loaded_instances<'b>(
+        &self,
+        loader: &Rc<Halo2Loader<'b, C>>,
+    ) -> Vec<Vec<Scalar<'b, C, EccChip<C>>>> {
+        self.instances
+            .transpose_vec(self.protocol.num_instance.len())
+            .into_iter()
+            .zip(self.protocol.num_instance.iter())
+            .map(|(instances, num_instance)| {
+                instances
+                    .transpose_vec(*num_instance)
+                    .into_iter()
+                    .map(|instance| loader.assign_scalar(instance.copied()))
+                    .collect_vec()
+            })
+            .collect_vec()
+    }
+}
+
+/// Aggregation configuration.
+#[derive(Clone)]
+pub struct AggregationConfig {
+    /// MainGateConfig
+    pub main_gate_config: MainGateConfig,
+    /// RangeConfig
+    pub range_config: RangeConfig,
+}
+
+impl AggregationConfig {
+    /// Configure for `MainGate` and `RangeChip` with corresponding fixed lookup
+    /// table.
+    pub fn configure<C: CurveAffine>(meta: &mut ConstraintSystem<C::Scalar>) -> Self {
+        let main_gate_config = MainGate::<C::Scalar>::configure(meta);
+        let range_config = RangeChip::<C::Scalar>::configure(
+            meta,
+            &main_gate_config,
+            vec![BITS / LIMBS],
+            Rns::<C::Base, C::Scalar, LIMBS, BITS>::construct().overflow_lengths(),
+        );
+        Self {
+            main_gate_config,
+            range_config,
+        }
+    }
+
+    /// Returns `MainGate`.
+    pub fn main_gate<F: FieldExt>(&self) -> MainGate<F> {
+        MainGate::new(self.main_gate_config.clone())
+    }
+
+    /// Returns `RangeChip`.
+    pub fn range_chip<F: FieldExt>(&self) -> RangeChip<F> {
+        RangeChip::new(self.range_config.clone())
+    }
+
+    /// Returns `EccChip`.
+    pub fn ecc_chip<C: CurveAffine>(&self) -> EccChip<C> {
+        EccChip::new(EccConfig::new(
+            self.range_config.clone(),
+            self.main_gate_config.clone(),
+        ))
+    }
+
+    /// Load fixed lookup table for `RangeChip`
+    pub fn load_table<F: FieldExt>(&self, layouter: &mut impl Layouter<F>) -> Result<(), Error> {
+        self.range_chip().load_table(layouter)
+    }
+
+    /// Aggregate snarks into a single accumulator and decompose it into
+    /// `4 * LIMBS` limbs.
+    /// Returns assigned instances of snarks and aggregated accumulator limbs.
+    #[allow(clippy::type_complexity)]
+    pub fn aggregate<'a, M: MultiMillerLoop>(
+        &self,
+        layouter: &mut impl Layouter<M::Scalar>,
+        svk: &KzgSvk<M>,
+        snarks: impl IntoIterator<Item = SnarkWitness<'a, M::G1Affine>>,
+    ) -> Result<
+        (
+            Vec<Vec<Vec<AssignedCell<M::Scalar, M::Scalar>>>>,
+            Vec<AssignedCell<M::Scalar, M::Scalar>>,
+        ),
+        Error,
+    > {
+        type PoseidonTranscript<'a, C, S> =
+            transcript::halo2::PoseidonTranscript<C, Rc<Halo2Loader<'a, C>>, S, T, RATE, R_F, R_P>;
+        let snarks = snarks.into_iter().collect_vec();
+        layouter.assign_region(
+            || "Aggregate snarks",
+            |region| {
+                let ctx = RegionCtx::new(region, 0);
+
+                let ecc_chip = self.ecc_chip::<M::G1Affine>();
+                let loader = Halo2Loader::new(ecc_chip, ctx);
+
+                let (instances, accumulators) = snarks
+                    .iter()
+                    .map(|snark| {
+                        let protocol = snark.protocol.loaded(&loader);
+                        let instances = snark.loaded_instances(&loader);
+                        let mut transcript = PoseidonTranscript::new(&loader, snark.proof());
+                        let proof = PlonkSuccinctVerifier::<M>::read_proof(
+                            svk,
+                            &protocol,
+                            &instances,
+                            &mut transcript,
+                        )
+                        .unwrap();
+                        let accumulators =
+                            PlonkSuccinctVerifier::verify(svk, &protocol, &instances, &proof)
+                                .unwrap();
+                        (instances, accumulators)
+                    })
+                    .collect_vec()
+                    .into_iter()
+                    .unzip::<_, _, Vec<_>, Vec<_>>();
+                let accumulator = {
+                    let as_vk = Default::default();
+                    let as_proof = Vec::new();
+                    let accumulators = accumulators.into_iter().flatten().collect_vec();
+                    let mut transcript =
+                        PoseidonTranscript::new(&loader, Value::known(as_proof.as_slice()));
+                    let proof =
+                        KzgAs::<M>::read_proof(&as_vk, &accumulators, &mut transcript).unwrap();
+                    KzgAs::<M>::verify(&as_vk, &accumulators, &proof).unwrap()
+                };
+
+                let instances = instances
+                    .iter()
+                    .map(|instances| {
+                        instances
+                            .iter()
+                            .map(|instances| {
+                                instances
+                                    .iter()
+                                    .map(|instance| instance.assigned().to_owned())
+                                    .collect_vec()
+                            })
+                            .collect_vec()
+                    })
+                    .collect_vec();
+                let accumulator_limbs = [accumulator.lhs, accumulator.rhs]
+                    .iter()
+                    .map(|ec_point| {
+                        loader
+                            .ecc_chip()
+                            .assign_ec_point_to_limbs(&mut loader.ctx_mut(), ec_point.assigned())
+                    })
+                    .collect::<Result<Vec<_>, Error>>()?
+                    .into_iter()
+                    .flatten()
+                    .collect();
+
+                Ok((instances, accumulator_limbs))
+            },
+        )
+    }
+}
+
+/// Aggregate snarks into a single accumulator and decompose it into
+/// `4 * LIMBS` limbs.
+/// Returns `None` if any given snarks is invalid.
+pub fn aggregate<'a, M: MultiMillerLoop>(
+    params: &ParamsKZG<M>,
+    snarks: impl IntoIterator<Item = Snark<'a, M::G1Affine>>,
+) -> Option<[M::Scalar; 4 * LIMBS]>
+where
+    M::G1Affine: SerdeObject,
+    M::G2Affine: SerdeObject,
+{
+    let svk = KzgSvk::<M>::new(params.get_g()[0]);
+    let dk = KzgDk::new(svk, params.g2(), params.s_g2());
+
+    let accumulators = snarks
+        .into_iter()
+        .map(|snark| {
+            let mut transcript = PoseidonTranscript::new(snark.proof);
+            let proof = PlonkSuccinctVerifier::<M>::read_proof(
+                &svk,
+                snark.protocol,
+                snark.instances,
+                &mut transcript,
+            )?;
+            PlonkSuccinctVerifier::verify(&svk, snark.protocol, snark.instances, &proof)
+        })
+        .try_collect::<_, Vec<_>, _>()
+        .ok()?
+        .into_iter()
+        .flatten()
+        .collect_vec();
+
+    let accumulator = {
+        let as_pk = Default::default();
+        let rng = StdRng::from_seed(Default::default());
+        let mut transcript = PoseidonTranscript::new(Vec::new());
+        let accumulator =
+            KzgAs::<M>::create_proof(&as_pk, &accumulators, &mut transcript, rng).ok()?;
+        assert!(transcript.finalize().is_empty());
+        accumulator
+    };
+    KzgAs::<M>::decide(&dk, accumulator.clone()).ok()?;
+
+    let KzgAccumulator { lhs, rhs } = accumulator;
+    let accumulator_limbs = [lhs, rhs]
+        .into_iter()
+        .flat_map(|point| {
+            let coordinates = point.coordinates().unwrap();
+            [*coordinates.x(), *coordinates.y()]
+        })
+        .flat_map(fe_to_limbs::<_, _, LIMBS, BITS>)
+        .collect_vec()
+        .try_into()
+        .unwrap();
+    Some(accumulator_limbs)
+}
+
+/// Aggregation circuit for testing purpose.
+#[derive(Clone)]
+pub struct TestAggregationCircuit<'a, M: MultiMillerLoop> {
+    svk: KzgSvk<M>,
+    snarks: Vec<SnarkWitness<'a, M::G1Affine>>,
+    instances: Vec<M::Scalar>,
+}
+
+impl<'a, M: MultiMillerLoop> TestAggregationCircuit<'a, M>
+where
+    M::G1Affine: SerdeObject,
+    M::G2Affine: SerdeObject,
+{
+    /// Create an Aggregation circuit with aggregated accumulator computed.
+    /// Returns `None` if any given snark is invalid.
+    pub fn new(
+        params: &ParamsKZG<M>,
+        snarks: impl IntoIterator<Item = Snark<'a, M::G1Affine>>,
+    ) -> Option<Self> {
+        let snarks = snarks.into_iter().collect_vec();
+
+        let accumulator_limbs = aggregate(params, snarks.clone())?;
+        let instances = iter::empty()
+            // Propagate aggregated snarks' instances
+            .chain(
+                snarks
+                    .iter()
+                    .flat_map(|snark| snark.instances.clone())
+                    .flatten(),
+            )
+            // Output aggregated accumulator
+            .chain(accumulator_limbs)
+            .collect_vec();
+
+        Some(Self {
+            svk: KzgSvk::<M>::new(params.get_g()[0]),
+            snarks: snarks.into_iter().map_into().collect(),
+            instances,
+        })
+    }
+
+    /// Returns accumulator indices in instance columns, which will be in
+    /// the last 4 * LIMBS rows of MainGate's instance column.
+    pub fn accumulator_indices(&self) -> Vec<(usize, usize)> {
+        (self.instances.len() - 4 * LIMBS..)
+            .map(|idx| (0, idx))
+            .take(4 * LIMBS)
+            .collect()
+    }
+
+    /// Returns number of instance
+    pub fn num_instance(&self) -> Vec<usize> {
+        vec![self.instances.len()]
+    }
+
+    /// Returns instances
+    pub fn instances(&self) -> Vec<Vec<M::Scalar>> {
+        vec![self.instances.clone()]
+    }
+}
+
+impl<'a, M: MultiMillerLoop> Circuit<M::Scalar> for TestAggregationCircuit<'a, M> {
+    type Config = AggregationConfig;
+    type FloorPlanner = SimpleFloorPlanner;
+
+    fn without_witnesses(&self) -> Self {
+        Self {
+            svk: self.svk,
+            snarks: self
+                .snarks
+                .iter()
+                .map(SnarkWitness::without_witnesses)
+                .collect(),
+            instances: vec![M::Scalar::zero(); self.instances.len()],
+        }
+    }
+
+    fn configure(meta: &mut ConstraintSystem<M::Scalar>) -> Self::Config {
+        AggregationConfig::configure::<M::G1Affine>(meta)
+    }
+
+    fn synthesize(
+        &self,
+        config: Self::Config,
+        mut layouter: impl Layouter<M::Scalar>,
+    ) -> Result<(), Error> {
+        config.load_table(&mut layouter)?;
+        let (instances, accumulator_limbs) =
+            config.aggregate::<M>(&mut layouter, &self.svk, self.snarks.clone())?;
+
+        // Constrain equality to instance values
+        let main_gate = config.main_gate();
+        for (row, limb) in instances
+            .into_iter()
+            .flatten()
+            .flatten()
+            .chain(accumulator_limbs)
+            .enumerate()
+        {
+            main_gate.expose_public(layouter.namespace(|| ""), limb, row)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Contains TestAggregationCircuit to test whether aggregation is working for
+/// any given inputs.
+#[cfg(test)]
+pub mod test {
+    use crate::root_circuit::{PoseidonTranscript, Snark, TestAggregationCircuit};
+    use halo2_proofs::{
+        arithmetic::FieldExt,
+        circuit::{floor_planner::V1, Layouter, Value},
+        dev::{FailureLocation, MockProver, VerifyFailure},
+        halo2curves::{
+            bn256::{Bn256, Fr, G1Affine},
+            CurveAffine,
+        },
+        plonk::{
+            create_proof, keygen_pk, keygen_vk, Advice, Any, Circuit, Column, ConstraintSystem,
+            Error, Fixed,
+        },
+        poly::{
+            kzg::{
+                commitment::{KZGCommitmentScheme, ParamsKZG},
+                multiopen::ProverGWC,
+            },
+            Rotation,
+        },
+    };
+    use itertools::Itertools;
+    use rand::{rngs::OsRng, RngCore};
+    use snark_verifier::{
+        system::halo2::{compile, Config},
+        verifier::plonk::PlonkProtocol,
+    };
+    use std::iter;
+
+    #[derive(Clone)]
+    pub struct SnarkOwned<C: CurveAffine> {
+        protocol: PlonkProtocol<C>,
+        instances: Vec<Vec<C::Scalar>>,
+        proof: Vec<u8>,
+    }
+
+    impl<C: CurveAffine> SnarkOwned<C> {
+        pub fn new(
+            protocol: PlonkProtocol<C>,
+            instances: Vec<Vec<C::Scalar>>,
+            proof: Vec<u8>,
+        ) -> Self {
+            Self {
+                protocol,
+                instances,
+                proof,
+            }
+        }
+
+        pub fn as_snark(&self) -> Snark<C> {
+            Snark {
+                protocol: &self.protocol,
+                instances: &self.instances,
+                proof: &self.proof,
+            }
+        }
+    }
+
+    /// Configuration for `StandardPlonk`
+    #[derive(Clone)]
+    pub struct StandardPlonkConfig {
+        selectors: [Column<Fixed>; 5],
+        wires: [Column<Advice>; 3],
+    }
+
+    impl StandardPlonkConfig {
+        /// Configure for `StandardPlonk`
+        pub fn configure<F: FieldExt>(meta: &mut ConstraintSystem<F>) -> Self {
+            let [w_l, w_r, w_o] = [(); 3].map(|_| meta.advice_column());
+            let [q_l, q_r, q_o, q_m, q_c] = [(); 5].map(|_| meta.fixed_column());
+            let pi = meta.instance_column();
+            [w_l, w_r, w_o].map(|column| meta.enable_equality(column));
+            meta.create_gate(
+                "q_l·w_l + q_r·w_r + q_o·w_o + q_m·w_l·w_r + q_c + pi = 0",
+                |meta| {
+                    let [w_l, w_r, w_o] =
+                        [w_l, w_r, w_o].map(|column| meta.query_advice(column, Rotation::cur()));
+                    let [q_l, q_r, q_o, q_m, q_c] = [q_l, q_r, q_o, q_m, q_c]
+                        .map(|column| meta.query_fixed(column, Rotation::cur()));
+                    let pi = meta.query_instance(pi, Rotation::cur());
+                    Some(
+                        q_l * w_l.clone()
+                            + q_r * w_r.clone()
+                            + q_o * w_o
+                            + q_m * w_l * w_r
+                            + q_c
+                            + pi,
+                    )
+                },
+            );
+            StandardPlonkConfig {
+                selectors: [q_l, q_r, q_o, q_m, q_c],
+                wires: [w_l, w_r, w_o],
+            }
+        }
+    }
+
+    /// Standard plonk with few assignments for testing purpose.
+    #[derive(Clone, Copy)]
+    pub struct StandardPlonk<F>(F);
+
+    impl<F: FieldExt> StandardPlonk<F> {
+        /// Create a `StandardPlonk` with random instnace.
+        pub fn rand<R: RngCore>(mut rng: R) -> Self {
+            Self(F::from(rng.next_u32() as u64))
+        }
+
+        /// Returns instances.
+        pub fn instances(&self) -> Vec<Vec<F>> {
+            vec![vec![self.0]]
+        }
+    }
+
+    impl<F: FieldExt> Circuit<F> for StandardPlonk<F> {
+        type Config = StandardPlonkConfig;
+        type FloorPlanner = V1;
+
+        fn without_witnesses(&self) -> Self {
+            *self
+        }
+
+        fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+            meta.set_minimum_degree(4);
+            StandardPlonkConfig::configure(meta)
+        }
+
+        fn synthesize(
+            &self,
+            config: Self::Config,
+            mut layouter: impl Layouter<F>,
+        ) -> Result<(), Error> {
+            let [q_l, q_r, q_o, q_m, q_c] = config.selectors;
+            let [w_l, w_r, w_o] = config.wires;
+            layouter.assign_region(
+                || "",
+                |mut region| {
+                    let a = region.assign_advice(|| "", w_l, 0, || Value::known(self.0))?;
+                    region.assign_fixed(|| "", q_l, 0, || Value::known(-F::one()))?;
+                    a.copy_advice(|| "", &mut region, w_r, 1)?;
+                    a.copy_advice(|| "", &mut region, w_o, 2)?;
+                    region.assign_advice(|| "", w_l, 3, || Value::known(-F::from(5)))?;
+                    for (column, idx) in [q_l, q_r, q_o, q_m, q_c].iter().zip(1..) {
+                        region.assign_fixed(|| "", *column, 3, || Value::known(F::from(idx)))?;
+                    }
+                    Ok(())
+                },
+            )
+        }
+    }
+
+    /// Create random `StandardPlonk` and returns `Snark`s for them.
+    pub fn rand_standard_plonk_snarks(
+        params: &ParamsKZG<Bn256>,
+        n: usize,
+    ) -> Vec<SnarkOwned<G1Affine>> {
+        // Preprocess
+        let (pk, protocol) = {
+            let standard_plonk = StandardPlonk(Fr::zero());
+            let vk = keygen_vk(params, &standard_plonk).unwrap();
+            let pk = keygen_pk(params, vk, &standard_plonk).unwrap();
+            let protocol = compile(
+                params,
+                pk.get_vk(),
+                Config::kzg().with_num_instance(
+                    standard_plonk
+                        .instances()
+                        .iter()
+                        .map(|instances| instances.len())
+                        .collect(),
+                ),
+            );
+            (pk, protocol)
+        };
+
+        // Create snarks
+        iter::repeat_with(move || {
+            let standard_plonk = StandardPlonk::<Fr>::rand(OsRng);
+            let instances = standard_plonk.instances();
+            let proof = {
+                let mut transcript = PoseidonTranscript::new(Vec::new());
+                create_proof::<KZGCommitmentScheme<_>, ProverGWC<_>, _, _, _, _>(
+                    params,
+                    &pk,
+                    &[standard_plonk],
+                    &[&instances.iter().map(Vec::as_slice).collect_vec()],
+                    OsRng,
+                    &mut transcript,
+                )
+                .unwrap();
+                transcript.finalize()
+            };
+            SnarkOwned::new(protocol.clone(), instances, proof)
+        })
+        .take(n)
+        .collect()
+    }
+
+    #[test]
+    fn test_standard_plonk_aggregation() {
+        let params = ParamsKZG::<Bn256>::setup(8, OsRng);
+
+        // Create Aggregation circuit and compute aggregated accumulator
+        let snarks = rand_standard_plonk_snarks(&params, 2);
+        let aggregation =
+            TestAggregationCircuit::<Bn256>::new(&params, snarks.iter().map(SnarkOwned::as_snark))
+                .unwrap();
+        let instances = aggregation.instances();
+        assert_eq!(
+            MockProver::run(21, &aggregation, instances)
+                .unwrap()
+                .verify_par(),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn test_standard_plonk_aggregation_unmatched_instance() {
+        let params = ParamsKZG::<Bn256>::setup(8, OsRng);
+
+        // Create Aggregation circuit and compute aggregated accumulator
+        let snarks = rand_standard_plonk_snarks(&params, 2);
+        let aggregation =
+            TestAggregationCircuit::<Bn256>::new(&params, snarks.iter().map(SnarkOwned::as_snark))
+                .unwrap();
+        let mut instances = aggregation.instances();
+        // Change the propagated inner snark's instance
+        instances[0][0] += Fr::one();
+        // Then expect the verification to fail
+        assert_eq!(
+            MockProver::run(21, &aggregation, instances)
+                .unwrap()
+                .verify_par(),
+            Err(vec![
+                VerifyFailure::Permutation {
+                    column: (Any::advice(), 0).into(),
+                    location: FailureLocation::InRegion {
+                        region: (1, "Aggregate snarks").into(),
+                        offset: 0
+                    }
+                },
+                VerifyFailure::Permutation {
+                    column: (Any::Instance, 0).into(),
+                    location: FailureLocation::OutsideRegion { row: 0 }
+                }
+            ])
+        );
+    }
+}

--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -452,7 +452,7 @@ impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize, const MOCK_RANDO
 }
 
 #[cfg(test)]
-mod super_circuit_tests {
+pub(crate) mod super_circuit_tests {
     use super::*;
     use ethers_signers::{LocalWallet, Signer};
     use halo2_proofs::dev::MockProver;
@@ -496,7 +496,7 @@ mod super_circuit_tests {
         }
     }
 
-    fn block_1tx() -> GethData {
+    pub(crate) fn block_1tx() -> GethData {
         let mut rng = ChaCha20Rng::seed_from_u64(2);
 
         let chain_id = (*MOCK_CHAIN_ID).as_u64();


### PR DESCRIPTION
This PR aims to implement `RootCircuit` for `SuperCircuit` aggregation, to replace current one in `zkevm-chain` repo.

It uses the latest `snark-verifier` (previously `plonk-verifier`) so it requires to upgrade the `halo2` and `halo2wrong` tag, tho it doesn't require any change (it's just that we could use stable channel rust now but `zkevm-circuits` itself still requires nightly).

Resolves https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/664.