### PR TITLE
fix to check account empty for existence in `BALANCE` bus mapping

### DIFF
--- a/bus-mapping/src/evm/opcodes/balance.rs
+++ b/bus-mapping/src/evm/opcodes/balance.rs
@@ -1,7 +1,6 @@
 use crate::circuit_input_builder::{CircuitInputStateRef, ExecStep};
 use crate::evm::Opcode;
 use crate::operation::{AccountField, CallContextField, TxAccessListAccountOp, RW};
-use crate::state_db::Account;
 use crate::Error;
 use eth_types::{GethExecStep, ToAddress, ToWord, Word, U256};
 
@@ -59,14 +58,15 @@ impl Opcode for Balance {
         )?;
 
         // Read account balance.
-        let (exists, &Account { balance, .. }) = state.sdb.get_account(&address);
+        let account = state.sdb.get_account(&address).1;
+        let exists = !account.is_empty();
         if exists {
             state.account_read(
                 &mut exec_step,
                 address,
                 AccountField::Balance,
-                balance,
-                balance,
+                account.balance,
+                account.balance,
             )?;
         } else {
             state.account_read(

--- a/zkevm-circuits/src/evm_circuit/execution/balance.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/balance.rs
@@ -129,21 +129,21 @@ impl<F: Field> ExecutionGadget<F> for BalanceGadget<F> {
                 field_tag: AccountFieldTag::Balance,
                 value,
                 ..
-            } => (
-                RandomLinearCombination::random_linear_combine(
-                    value.to_le_bytes(),
-                    block.randomness,
-                ),
-                true,
-            ),
+            } => (value, true),
             Rw::Account {
                 field_tag: AccountFieldTag::NonExisting,
                 ..
-            } => (F::zero(), false),
+            } => (0.into(), false),
             _ => unreachable!(),
         };
-
-        self.balance.assign(region, offset, Value::known(balance))?;
+        self.balance.assign(
+            region,
+            offset,
+            Value::known(RandomLinearCombination::random_linear_combine(
+                balance.to_le_bytes(),
+                block.randomness,
+            )),
+        )?;
         self.exists
             .assign(region, offset, Value::known(F::from(exists)))?;
 

--- a/zkevm-circuits/src/evm_circuit/execution/balance.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/balance.rs
@@ -172,6 +172,15 @@ mod test {
     }
 
     #[test]
+    fn balance_gadget_empty_account() {
+        let account = Some(Account::default());
+
+        test_root_ok(&account, false);
+        test_internal_ok(0x20, 0x00, &account, false);
+        test_internal_ok(0x1010, 0xff, &account, false);
+    }
+
+    #[test]
     fn balance_gadget_cold_account() {
         let account = Some(Account {
             address: *TEST_ADDRESS,


### PR DESCRIPTION
Close https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/1006

As @han0110 mentioned in https://github.com/privacy-scaling-explorations/zkevm-circuits/pull/973#discussion_r1056040648, we should replace checking account existing in state DB with account `is_empty` in `BALANCE` bus-mapping.

Also referenced [eip-158](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-158.md).
