### PR TITLE
WIP change default mock randomness to 0x10000

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -36,12 +36,12 @@ pub(crate) struct CallOpGadget<F> {
     reversion_info: ReversionInfo<F>,
     current_callee_address: Cell<F>,
     current_caller_address: Cell<F>,
-    current_value: Cell<F>,
     is_static: Cell<F>,
     depth: Cell<F>,
     gas: Word<F>,
     code_address: Word<F>,
     value: Word<F>,
+    current_value: Word<F>,
     is_success: Cell<F>,
     gas_is_u64: IsZeroGadget<F>,
     is_warm: Cell<F>,
@@ -108,7 +108,7 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
         let (current_caller_address, current_value) = cb.condition(is_delegatecall.expr(), |cb| {
             (
                 cb.call_context(None, CallContextFieldTag::CallerAddress),
-                cb.call_context(None, CallContextFieldTag::Value),
+                cb.call_context_as_word(None, CallContextFieldTag::Value),
             )
         });
 
@@ -573,15 +573,8 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
                     .expect("unexpected Address -> Scalar conversion failure"),
             ),
         )?;
-        self.current_value.assign(
-            region,
-            offset,
-            Value::known(
-                current_value
-                    .to_scalar()
-                    .expect("unexpected U256 -> Scalar conversion failure"),
-            ),
-        )?;
+        self.current_value
+            .assign(region, offset, Some(current_value.to_le_bytes()))?;
         self.is_static
             .assign(region, offset, Value::known(F::from(is_static.low_u64())))?;
         self.depth

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -1005,6 +1005,16 @@ impl<'a, F: Field> ConstraintBuilder<'a, F> {
         cell
     }
 
+    pub(crate) fn call_context_as_word(
+        &mut self,
+        call_id: Option<Expression<F>>,
+        field_tag: CallContextFieldTag,
+    ) -> Word<F> {
+        let word = self.query_word();
+        self.call_context_lookup(false.expr(), call_id, field_tag, word.expr());
+        word
+    }
+
     pub(crate) fn call_context_lookup(
         &mut self,
         is_write: Expression<F>,

--- a/zkevm-circuits/src/witness/block.rs
+++ b/zkevm-circuits/src/witness/block.rs
@@ -169,7 +169,7 @@ pub fn block_convert(
 ) -> Result<Block<Fr>, Error> {
     Ok(Block {
         // randomness: Fr::from(0xcafeu64), // TODO: Uncomment
-        randomness: Fr::from(0x100), // Special value to reveal elements after RLC
+        randomness: Fr::from(0x10000), // Special value to reveal elements after RLC
         context: block.into(),
         rws: RwMap::from(&block.container),
         txs: block


### PR DESCRIPTION
0x100 is a bad choice... It makes RLC and original value same... Use another value to help find bugs.

 this test case failed.  @silathdiir will fix it.

```
cargo test -p zkevm-circuits --all-features --release callop_simple -- --nocapture
```