### PR TITLE
Fix/super circuit double assign

### DIFF
--- a/zkevm-circuits/src/state_circuit.rs
+++ b/zkevm-circuits/src/state_circuit.rs
@@ -407,10 +407,6 @@ impl<F: Field> SubCircuit<F> for StateCircuit<F> {
                     randomness,
                 )?;
 
-                config
-                    .mpt_table
-                    .load_with_region(&mut region, &self.updates, randomness)?;
-
                 config.assign_with_region(
                     &mut region,
                     &self.rows,
@@ -484,6 +480,9 @@ where
         mut layouter: impl Layouter<F>,
     ) -> Result<(), Error> {
         let challenges = challenges.values(&mut layouter);
+        config
+            .mpt_table
+            .load(&mut layouter, &self.updates, challenges.evm_word())?;
         self.synthesize_sub(&config, &challenges, &mut layouter)
     }
 }

--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -297,7 +297,6 @@ impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize, const MAX_RWS: u
             .synthesize_sub(&config.evm_circuit, &challenges, &mut layouter)?;
         self.pi_circuit
             .synthesize_sub(&config.pi_circuit, &challenges, &mut layouter)?;
-        self.evm_circuit.synthesize(config.evm_circuit, layouter)?;
         Ok(())
     }
 }

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -534,8 +534,9 @@ impl MptTable {
         updates: &MptUpdates,
         randomness: Value<F>,
     ) -> Result<(), Error> {
+        self.assign(region, 0, &MptUpdateRow([Value::known(F::zero()); 7]))?;
         for (offset, row) in updates.table_assignments(randomness).iter().enumerate() {
-            self.assign(region, offset, row)?;
+            self.assign(region, offset + 1, row)?;
         }
         Ok(())
     }

--- a/zkevm-circuits/src/witness/mpt.rs
+++ b/zkevm-circuits/src/witness/mpt.rs
@@ -37,7 +37,7 @@ pub struct MptUpdates(HashMap<Key, MptUpdate>);
 
 /// The field element encoding of an MPT update, which is used by the MptTable
 #[derive(Debug, Clone, Copy)]
-pub struct MptUpdateRow<F>([F; 7]);
+pub struct MptUpdateRow<F>(pub(crate) [F; 7]);
 
 impl MptUpdates {
     pub(crate) fn get(&self, row: &Rw) -> Option<MptUpdate> {


### PR DESCRIPTION
Resolves: #987 by removing the double-assignment of the `evm-circuit` and the `mpt-table`.

Still have a doubt about the `RWTable`. @lispc stated [here](https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/987#issuecomment-1352931915) that the `RWTable` was suffering from the same issue as the MPT one. 

But after checking for some time, seems that the `RWTable` is only assigned by the `State Circuit`. Therefore I don't see any issue with it but maybe I'm missing something.