### PR TITLE
fix: add comment for special case of `x = -2^255` to `AbsWord` gadget

### DIFF
--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/abs_word.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/abs_word.rs
@@ -6,8 +6,13 @@ use crate::{
 };
 use eth_types::{Field, ToLittleEndian, Word};
 use halo2_proofs::plonk::Error;
+
 /// Construction of 256-bit word original and absolute values, which is useful
 /// for opcodes operated on signed values.
+/// For a special case, when `x = -2^255` then absolute value should be `2^255`.
+/// But a signed word could only express value from `-2^255` to `2^255 - 1`.
+/// So in this case both `x` and `x_abs` should be equal to `-2^255`
+/// (expressed as an U256 of `2^255`).
 #[derive(Clone, Debug)]
 pub(crate) struct AbsWordGadget<F> {
     x: util::Word<F>,
@@ -160,6 +165,17 @@ mod tests {
     #[test]
     fn test_abs_word_low_max() {
         try_test!(AbsWordGadgetContainer<Fr, false>, [WORD_LOW_MAX, WORD_LOW_MAX], true);
+    }
+
+    #[test]
+    fn test_abs_word_signed_max() {
+        try_test!(AbsWordGadgetContainer<Fr, false>, [WORD_SIGNED_MAX, WORD_SIGNED_MAX], true);
+    }
+
+    // In this special case both `x` and `x_abs` are equal to `-2^255`.
+    #[test]
+    fn test_abs_word_signed_min() {
+        try_test!(AbsWordGadgetContainer<Fr, true>, [WORD_SIGNED_MIN, WORD_SIGNED_MIN], true);
     }
 
     #[test]

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/test_util.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/test_util.rs
@@ -31,6 +31,10 @@ pub(crate) const WORD_CELL_MAX: Word = U256([
     0x30644e72e131a029,
 ]);
 
+// I256::MAX = 2^255 - 1, and I256::MIN = 2^255.
+pub(crate) const WORD_SIGNED_MAX: Word = U256([u64::MAX, u64::MAX, u64::MAX, i64::MAX as _]);
+pub(crate) const WORD_SIGNED_MIN: Word = U256([0, 0, 0, i64::MIN as _]);
+
 pub(crate) fn generate_power_of_randomness<F: Field>(randomness: F) -> Vec<F> {
     (1..32).map(|exp| randomness.pow(&[exp, 0, 0, 0])).collect()
 }


### PR DESCRIPTION
Close https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/1021

Add a comment for `AbsWord` special case, and corresponding test cases.

Referenced [I256::MAX](https://docs.rs/ethers-core/latest/src/ethers_core/types/i256.rs.html#105) and [I256::MIN](https://docs.rs/ethers-core/latest/src/ethers_core/types/i256.rs.html#108) of [ethers_core](https://docs.rs/ethers-core/latest/ethers_core/) for test constant `WORD_SIGNED_MAX` and `WORD_SIGNED_MIN`.
