### PR TITLE
fix stack value `address` to `Word` type in gadgets

### DIFF
--- a/bus-mapping/src/evm/opcodes/balance.rs
+++ b/bus-mapping/src/evm/opcodes/balance.rs
@@ -2,7 +2,7 @@ use crate::circuit_input_builder::{CircuitInputStateRef, ExecStep};
 use crate::evm::Opcode;
 use crate::operation::{AccountField, CallContextField, TxAccessListAccountOp, RW};
 use crate::Error;
-use eth_types::{GethExecStep, ToAddress, ToWord, Word, U256};
+use eth_types::{GethExecStep, ToAddress, Word, U256};
 
 #[derive(Debug, Copy, Clone)]
 pub(crate) struct Balance;
@@ -16,12 +16,9 @@ impl Opcode for Balance {
         let mut exec_step = state.new_step(geth_step)?;
 
         // Read account address from stack.
-        let address = geth_step.stack.last()?.to_address();
-        state.stack_read(
-            &mut exec_step,
-            geth_step.stack.last_filled(),
-            address.to_word(),
-        )?;
+        let address_word = geth_step.stack.last()?;
+        let address = address_word.to_address();
+        state.stack_read(&mut exec_step, geth_step.stack.last_filled(), address_word)?;
 
         // Read transaction ID, rw_counter_end_of_reversion, and is_persistent
         // from call context.
@@ -97,7 +94,7 @@ mod balance_tests {
     use crate::operation::{AccountOp, CallContextOp, StackOp};
     use eth_types::evm_types::{OpcodeId, StackAddress};
     use eth_types::geth_types::GethData;
-    use eth_types::{address, bytecode, Bytecode, Word, U256};
+    use eth_types::{address, bytecode, Bytecode, ToWord, Word, U256};
     use mock::TestContext;
     use pretty_assertions::assert_eq;
 

--- a/bus-mapping/src/evm/opcodes/extcodehash.rs
+++ b/bus-mapping/src/evm/opcodes/extcodehash.rs
@@ -21,8 +21,9 @@ impl Opcode for Extcodehash {
         let stack_address = step.stack.last_filled();
 
         // Pop external address off stack
-        let external_address = step.stack.last()?.to_address();
-        state.stack_read(&mut exec_step, stack_address, external_address.to_word())?;
+        let external_address_word = step.stack.last()?;
+        let external_address = external_address_word.to_address();
+        state.stack_read(&mut exec_step, stack_address, external_address_word)?;
 
         // Read transaction id, rw_counter_end_of_reversion, and is_persistent from call
         // context

--- a/bus-mapping/src/evm/opcodes/extcodesize.rs
+++ b/bus-mapping/src/evm/opcodes/extcodesize.rs
@@ -16,12 +16,9 @@ impl Opcode for Extcodesize {
         let mut exec_step = state.new_step(geth_step)?;
 
         // Read account address from stack.
-        let address = geth_step.stack.last()?.to_address();
-        state.stack_read(
-            &mut exec_step,
-            geth_step.stack.last_filled(),
-            address.to_word(),
-        )?;
+        let address_word = geth_step.stack.last()?;
+        let address = address_word.to_address();
+        state.stack_read(&mut exec_step, geth_step.stack.last_filled(), address_word)?;
 
         // Read transaction ID, rw_counter_end_of_reversion, and is_persistent from call
         // context.

--- a/zkevm-circuits/src/evm_circuit/execution/balance.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/balance.rs
@@ -6,19 +6,21 @@ use crate::evm_circuit::util::constraint_builder::Transition::Delta;
 use crate::evm_circuit::util::constraint_builder::{
     ConstraintBuilder, ReversionInfo, StepStateTransition,
 };
-use crate::evm_circuit::util::{from_bytes, select, CachedRegion, Cell, RandomLinearCombination};
+use crate::evm_circuit::util::{
+    from_bytes, select, CachedRegion, Cell, RandomLinearCombination, Word,
+};
 use crate::evm_circuit::witness::{Block, Call, ExecStep, Rw, Transaction};
 use crate::table::{AccountFieldTag, CallContextFieldTag};
 use crate::util::Expr;
 use eth_types::evm_types::GasCost;
-use eth_types::{Field, ToAddress, ToLittleEndian};
+use eth_types::{Field, ToLittleEndian};
 use halo2_proofs::circuit::Value;
 use halo2_proofs::plonk::Error;
 
 #[derive(Clone, Debug)]
 pub(crate) struct BalanceGadget<F> {
     same_context: SameContextGadget<F>,
-    address: RandomLinearCombination<F, N_BYTES_ACCOUNT_ADDRESS>,
+    address_word: Word<F>,
     reversion_info: ReversionInfo<F>,
     tx_id: Cell<F>,
     is_warm: Cell<F>,
@@ -32,15 +34,16 @@ impl<F: Field> ExecutionGadget<F> for BalanceGadget<F> {
     const EXECUTION_STATE: ExecutionState = ExecutionState::BALANCE;
 
     fn configure(cb: &mut ConstraintBuilder<F>) -> Self {
-        let address = cb.query_rlc();
-        cb.stack_pop(address.expr());
+        let address_word = cb.query_word();
+        let address = from_bytes::expr(&address_word.cells[..N_BYTES_ACCOUNT_ADDRESS]);
+        cb.stack_pop(address_word.expr());
 
         let tx_id = cb.call_context(None, CallContextFieldTag::TxId);
         let mut reversion_info = cb.reversion_info_read(None);
         let is_warm = cb.query_bool();
         cb.account_access_list_write(
             tx_id.expr(),
-            from_bytes::expr(&address.cells),
+            address.expr(),
             1.expr(),
             is_warm.expr(),
             Some(&mut reversion_info),
@@ -49,18 +52,10 @@ impl<F: Field> ExecutionGadget<F> for BalanceGadget<F> {
         let balance = cb.query_cell();
         let exists = cb.query_bool();
         cb.condition(exists.expr(), |cb| {
-            cb.account_read(
-                from_bytes::expr(&address.cells),
-                AccountFieldTag::Balance,
-                balance.expr(),
-            );
+            cb.account_read(address.expr(), AccountFieldTag::Balance, balance.expr());
         });
         cb.condition(1.expr() - exists.expr(), |cb| {
-            cb.account_read(
-                from_bytes::expr(&address.cells),
-                AccountFieldTag::NonExisting,
-                0.expr(),
-            );
+            cb.account_read(address, AccountFieldTag::NonExisting, 0.expr());
         });
 
         cb.stack_push(select::expr(exists.expr(), balance.expr(), 0.expr()));
@@ -85,7 +80,7 @@ impl<F: Field> ExecutionGadget<F> for BalanceGadget<F> {
 
         Self {
             same_context,
-            address,
+            address_word,
             reversion_info,
             tx_id,
             is_warm,
@@ -105,10 +100,9 @@ impl<F: Field> ExecutionGadget<F> for BalanceGadget<F> {
     ) -> Result<(), Error> {
         self.same_context.assign_exec_step(region, offset, step)?;
 
-        let address = block.rws[step.rw_indices[0]].stack_value().to_address();
-        let mut address_bytes = address.0;
-        address_bytes.reverse();
-        self.address.assign(region, offset, Some(address_bytes))?;
+        let address = block.rws[step.rw_indices[0]].stack_value();
+        self.address_word
+            .assign(region, offset, Some(address.to_le_bytes()))?;
 
         self.tx_id
             .assign(region, offset, Value::known(F::from(tx.id as u64)))?;


### PR DESCRIPTION
Close https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/1041

Fixed to not split `Address` (calling `to_address` function) when stack ~~push or~~ pop in both bus-mapping and assign exec step of circuit. The first 12-bytes may be lost.

Referenced [code_address](https://github.com/privacy-scaling-explorations/zkevm-circuits/blob/main/zkevm-circuits/src/evm_circuit/execution/callop.rs#L42) in `CallOpGadget`.