### PR TITLE
feat(state): constrain non-exist proof for account and storage

### DIFF
--- a/bus-mapping/src/evm/opcodes/callop.rs
+++ b/bus-mapping/src/evm/opcodes/callop.rs
@@ -146,24 +146,21 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
             )?;
         }
 
-        if callee_exists {
-            let callee_code_hash_word = callee_code_hash.to_word();
-            state.account_read(
-                &mut exec_step,
-                callee_address,
-                AccountField::CodeHash,
-                callee_code_hash_word,
-                callee_code_hash_word,
-            )?;
+        let (callee_code_hash_word, is_empty_code_hash) = if callee_exists {
+            (
+                callee_code_hash.to_word(),
+                callee_code_hash.to_fixed_bytes() == *EMPTY_HASH,
+            )
         } else {
-            state.account_read(
-                &mut exec_step,
-                callee_address,
-                AccountField::NonExisting,
-                Word::zero(),
-                Word::zero(),
-            )?;
-        }
+            (Word::zero(), true)
+        };
+        state.account_read(
+            &mut exec_step,
+            callee_address,
+            AccountField::CodeHash,
+            callee_code_hash_word,
+            callee_code_hash_word,
+        )?;
 
         // Calculate next_memory_word_size and callee_gas_left manually in case
         // there isn't next geth_step (e.g. callee doesn't have code).
@@ -203,7 +200,7 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
         match (
             insufficient_balance,
             state.is_precompiled(&call.address),
-            callee_code_hash.to_fixed_bytes() == *EMPTY_HASH,
+            is_empty_code_hash,
         ) {
             // 1. Call to precompiled.
             (false, true, _) => {

--- a/bus-mapping/src/evm/opcodes/extcodecopy.rs
+++ b/bus-mapping/src/evm/opcodes/extcodecopy.rs
@@ -7,6 +7,9 @@ use eth_types::{GethExecStep, ToAddress};
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct Extcodecopy;
 
+// TODO: Update to treat code_hash == 0 as account not_exists once the circuit
+// is implemented https://github.com/privacy-scaling-explorations/zkevm-circuits/pull/720
+
 impl Opcode for Extcodecopy {
     fn gen_associated_ops(
         state: &mut CircuitInputStateRef,

--- a/bus-mapping/src/evm/opcodes/extcodehash.rs
+++ b/bus-mapping/src/evm/opcodes/extcodehash.rs
@@ -270,45 +270,15 @@ mod extcodehash_tests {
                 RW::READ,
                 &AccountOp {
                     address: external_address,
-                    field: AccountField::Nonce,
-                    value: if exists { nonce } else { U256::zero() },
-                    value_prev: if exists { nonce } else { U256::zero() },
-                }
-            )
-        );
-        assert_eq!(
-            {
-                let operation = &container.account[indices[6].as_usize()];
-                (operation.rw(), operation.op())
-            },
-            (
-                RW::READ,
-                &AccountOp {
-                    address: external_address,
-                    field: AccountField::Balance,
-                    value: if exists { balance } else { U256::zero() },
-                    value_prev: if exists { balance } else { U256::zero() },
-                }
-            )
-        );
-        assert_eq!(
-            {
-                let operation = &container.account[indices[7].as_usize()];
-                (operation.rw(), operation.op())
-            },
-            (
-                RW::READ,
-                &AccountOp {
-                    address: external_address,
                     field: AccountField::CodeHash,
-                    value: code_hash,
-                    value_prev: code_hash,
+                    value: if exists { code_hash } else { U256::zero() },
+                    value_prev: if exists { code_hash } else { U256::zero() },
                 }
             )
         );
         assert_eq!(
             {
-                let operation = &container.stack[indices[8].as_usize()];
+                let operation = &container.stack[indices[6].as_usize()];
                 (operation.rw(), operation.op())
             },
             (

--- a/gadgets/src/batched_is_zero.rs
+++ b/gadgets/src/batched_is_zero.rs
@@ -1,0 +1,240 @@
+//! BatchedIsZero chip works as follows:
+//!
+//! Given a list of `values` to be checked if they are all zero:
+//! - nonempty_witness = `inv(value)` for some non-zero `value` from `values` if
+//!   it exists, `0` otherwise
+//! - is_zero: 1 if all `values` are `0`, `0` otherwise
+
+use halo2_proofs::{
+    arithmetic::FieldExt,
+    circuit::{Region, Value},
+    plonk::{Advice, Column, ConstraintSystem, Error, Expression, Phase, VirtualCells},
+    poly::Rotation,
+};
+use std::marker::PhantomData;
+
+use crate::util::Expr;
+
+// TODO: Configurable Phase
+
+/// BatchedIsZeroChip configuration
+#[derive(Clone, Debug)]
+pub struct BatchedIsZeroConfig {
+    /// All the values are 0
+    pub is_zero: Column<Advice>,
+    /// If some value is non-zero, this is its inverse
+    pub nonempty_witness: Column<Advice>,
+}
+
+/// Verify that a list of values are all 0.
+pub struct BatchedIsZeroChip<F, const N: usize> {
+    config: BatchedIsZeroConfig,
+    _marker: PhantomData<F>,
+}
+
+impl<F: FieldExt, const N: usize> BatchedIsZeroChip<F, N> {
+    /// Configure the BatchedIsZeroChip
+    pub fn configure<P: Phase>(
+        meta: &mut ConstraintSystem<F>,
+        // Phases for is_zero and nonempty_witness advice columns.
+        (phase_a, phase_b): (P, P), // TODO: Remove once Phase is Copy
+        q_enable: impl Fn(&mut VirtualCells<'_, F>) -> Expression<F>,
+        values: impl Fn(&mut VirtualCells<'_, F>) -> [Expression<F>; N],
+    ) -> BatchedIsZeroConfig {
+        let is_zero = meta.advice_column_in(phase_a);
+        let nonempty_witness = meta.advice_column_in(phase_b);
+        meta.create_gate("is_zero is bool", |meta| {
+            let is_zero = meta.query_advice(is_zero, Rotation::cur());
+            [q_enable(meta) * is_zero.clone() * (is_zero - 1.expr())]
+        });
+
+        meta.create_gate("is_zero is 0 if there is any non-zero value", |meta| {
+            let is_zero = meta.query_advice(is_zero, Rotation::cur());
+            values(meta)
+                .iter()
+                .map(|value| q_enable(meta) * is_zero.clone() * value.clone())
+                .collect::<Vec<_>>()
+        });
+
+        meta.create_gate("is_zero is 1 if values are all zero", |meta| {
+            let is_zero = meta.query_advice(is_zero, Rotation::cur());
+            let nonempty_witness = meta.query_advice(nonempty_witness, Rotation::cur());
+            [q_enable(meta)
+                * values(meta).iter().fold(1.expr() - is_zero, |acc, value| {
+                    acc * (1.expr() - value.clone() * nonempty_witness.clone())
+                })]
+        });
+
+        BatchedIsZeroConfig {
+            is_zero,
+            nonempty_witness,
+        }
+    }
+
+    /// Assign the BatchedIsZeroChip
+    pub fn assign(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        values: Value<[F; N]>,
+    ) -> Result<(), Error> {
+        let config = &self.config;
+        let is_zero_nonempty_witness = values.map(|values| {
+            if let Some(inverse) = values
+                .iter()
+                .find_map(|value| Option::<F>::from(value.invert()))
+            {
+                (F::zero(), inverse)
+            } else {
+                (F::one(), F::zero())
+            }
+        });
+        region.assign_advice(
+            || "is_zero",
+            config.is_zero,
+            offset,
+            || is_zero_nonempty_witness.map(|v| v.0),
+        )?;
+        region.assign_advice(
+            || "nonempty_witness",
+            config.nonempty_witness,
+            offset,
+            || is_zero_nonempty_witness.map(|v| v.1),
+        )?;
+        Ok(())
+    }
+
+    /// Given an `BatchedIsZeroConfig`, construct the chip.
+    pub fn construct(config: BatchedIsZeroConfig) -> Self {
+        BatchedIsZeroChip {
+            config,
+            _marker: PhantomData,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use halo2_proofs::{
+        arithmetic::FieldExt,
+        circuit::{Layouter, SimpleFloorPlanner, Value},
+        dev::MockProver,
+        halo2curves::bn256::Fr,
+        plonk::{Advice, Circuit, Column, ConstraintSystem, Error, FirstPhase, Selector},
+        poly::Rotation,
+    };
+
+    #[derive(Clone, Debug)]
+    struct TestCircuitConfig<const N: usize> {
+        q_enable: Selector,
+        values: [Column<Advice>; N],
+        is_zero: BatchedIsZeroConfig,
+        expect_is_zero: Column<Advice>,
+    }
+
+    #[derive(Default)]
+    struct TestCircuit<F: FieldExt, const N: usize> {
+        values: Option<[u64; N]>,
+        expect_is_zero: Option<bool>,
+        _marker: PhantomData<F>,
+    }
+
+    impl<F: FieldExt, const N: usize> Circuit<F> for TestCircuit<F, N> {
+        type Config = TestCircuitConfig<N>;
+        type FloorPlanner = SimpleFloorPlanner;
+
+        fn without_witnesses(&self) -> Self {
+            Self::default()
+        }
+
+        fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+            let q_enable = meta.complex_selector();
+            let values = [(); N].map(|_| meta.advice_column());
+            let expect_is_zero = meta.advice_column();
+
+            let is_zero = BatchedIsZeroChip::configure(
+                meta,
+                (FirstPhase, FirstPhase),
+                |meta| meta.query_selector(q_enable),
+                |meta| values.map(|value| meta.query_advice(value, Rotation::cur())),
+            );
+
+            let config = Self::Config {
+                q_enable,
+                values,
+                expect_is_zero,
+                is_zero,
+            };
+
+            meta.create_gate("check is_zero", |meta| {
+                let q_enable = meta.query_selector(q_enable);
+
+                // This verifies is_zero is calculated correctly
+                let expect_is_zero = meta.query_advice(config.expect_is_zero, Rotation::cur());
+                let is_zero = meta.query_advice(config.is_zero.is_zero, Rotation::cur());
+                vec![q_enable * (is_zero - expect_is_zero)]
+            });
+
+            config
+        }
+
+        fn synthesize(
+            &self,
+            config: Self::Config,
+            mut layouter: impl Layouter<F>,
+        ) -> Result<(), Error> {
+            let is_zero = BatchedIsZeroChip::construct(config.is_zero);
+
+            let values: [F; N] = self
+                .values
+                .as_ref()
+                .map(|values| values.map(|value| F::from(value)))
+                .ok_or(Error::Synthesis)?;
+            let expect_is_zero = self.expect_is_zero.as_ref().ok_or(Error::Synthesis)?;
+
+            layouter.assign_region(
+                || "witness",
+                |mut region| {
+                    config.q_enable.enable(&mut region, 0)?;
+                    region.assign_advice(
+                        || "expect_is_zero",
+                        config.expect_is_zero,
+                        0,
+                        || Value::known(F::from(*expect_is_zero)),
+                    )?;
+                    for (value_column, value) in config.values.iter().zip(values.iter()) {
+                        region.assign_advice(
+                            || "value",
+                            *value_column,
+                            0,
+                            || Value::known(*value),
+                        )?;
+                    }
+                    is_zero.assign(&mut region, 0, Value::known(values))?;
+                    Ok(())
+                },
+            )
+        }
+    }
+
+    fn test_circuit<const N: usize>(values: [u64; N], expect_is_zero: bool) {
+        let circuit = TestCircuit::<Fr, N> {
+            values: Some(values),
+            expect_is_zero: Some(expect_is_zero),
+            _marker: PhantomData,
+        };
+        let k = 4;
+        let prover = MockProver::<Fr>::run(k, &circuit, vec![]).unwrap();
+        assert_eq!(prover.verify(), Ok(()));
+    }
+
+    #[test]
+    fn test_batched_is_zero() {
+        test_circuit([0, 0], true);
+        test_circuit([0, 0, 0], true);
+        test_circuit([1, 0], false);
+        test_circuit([1, 0, 0], false);
+        test_circuit([1, 0, 8], false);
+    }
+}

--- a/gadgets/src/lib.rs
+++ b/gadgets/src/lib.rs
@@ -11,6 +11,7 @@
 #![deny(unsafe_code)]
 #![deny(clippy::debug_assert_with_mut_call)]
 
+pub mod batched_is_zero;
 pub mod binary_number;
 pub mod evm_word;
 pub mod is_zero;

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -466,15 +466,15 @@ pub mod test {
         .unwrap();
 
         let k = log2_ceil(NUM_BLINDING_ROWS + rows_needed);
-        dbg!([
-            num_rows_required_for_rw_table,
-            num_rows_required_for_fixed_table,
-            num_rows_required_for_bytecode_table,
-            num_rows_required_for_copy_table,
-            num_rows_required_for_keccak_table,
-            num_rows_required_for_tx_table,
-            num_rows_required_for_exp_table
-        ]);
+        // dbg!([
+        //     num_rows_required_for_rw_table,
+        //     num_rows_required_for_fixed_table,
+        //     num_rows_required_for_bytecode_table,
+        //     num_rows_required_for_copy_table,
+        //     num_rows_required_for_keccak_table,
+        //     num_rows_required_for_tx_table,
+        //     num_rows_required_for_exp_table
+        // ]);
         log::debug!("evm circuit uses k = {}, rows = {}", k, rows_needed);
         k
     }

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -466,15 +466,17 @@ pub mod test {
         .unwrap();
 
         let k = log2_ceil(NUM_BLINDING_ROWS + rows_needed);
-        // dbg!([
-        //     num_rows_required_for_rw_table,
-        //     num_rows_required_for_fixed_table,
-        //     num_rows_required_for_bytecode_table,
-        //     num_rows_required_for_copy_table,
-        //     num_rows_required_for_keccak_table,
-        //     num_rows_required_for_tx_table,
-        //     num_rows_required_for_exp_table
-        // ]);
+        log::debug!(
+            "num_rows_requred_for rw_table={}, fixed_table={}, bytecode_table={}, \
+            copy_table={}, keccak_table={}, tx_table={}, exp_table={}",
+            num_rows_required_for_rw_table,
+            num_rows_required_for_fixed_table,
+            num_rows_required_for_bytecode_table,
+            num_rows_required_for_copy_table,
+            num_rows_required_for_keccak_table,
+            num_rows_required_for_tx_table,
+            num_rows_required_for_exp_table
+        );
         log::debug!("evm circuit uses k = {}, rows = {}", k, rows_needed);
         k
     }

--- a/zkevm-circuits/src/evm_circuit/execution/balance.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/balance.rs
@@ -7,8 +7,7 @@ use crate::evm_circuit::util::constraint_builder::{
     ConstraintBuilder, ReversionInfo, StepStateTransition,
 };
 use crate::evm_circuit::util::{
-    from_bytes, math_gadget::IsZeroGadget, not, select, CachedRegion, Cell,
-    RandomLinearCombination, Word,
+    from_bytes, math_gadget::IsZeroGadget, not, select, CachedRegion, Cell, Word,
 };
 use crate::evm_circuit::witness::{Block, Call, ExecStep, Transaction};
 use crate::table::{AccountFieldTag, CallContextFieldTag};

--- a/zkevm-circuits/src/evm_circuit/execution/balance.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/balance.rs
@@ -123,18 +123,15 @@ impl<F: Field> ExecutionGadget<F> for BalanceGadget<F> {
         self.is_warm
             .assign(region, offset, Value::known(F::from(is_warm)))?;
 
-        let code_hash = block.rws[step.rw_indices[5]]
-            .table_assignment_aux(block.randomness)
-            .value;
+        let code_hash = block.rws[step.rw_indices[5]].account_value_pair().0;
         self.code_hash
-            .assign(region, offset, Value::known(code_hash))?;
-        self.not_exists.assign(region, offset, code_hash)?;
-        let balance = if code_hash.is_zero_vartime() {
-            F::zero()
+            .assign(region, offset, region.word_rlc(code_hash))?;
+        self.not_exists
+            .assign_value(region, offset, region.word_rlc(code_hash))?;
+        let balance = if code_hash.is_zero() {
+            eth_types::Word::zero()
         } else {
-            block.rws[step.rw_indices[6]]
-                .table_assignment_aux(block.randomness)
-                .value
+            block.rws[step.rw_indices[6]].account_value_pair().0
         };
         self.balance
             .assign(region, offset, region.word_rlc(balance))?;

--- a/zkevm-circuits/src/evm_circuit/execution/balance.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/balance.rs
@@ -182,8 +182,8 @@ mod test {
         });
 
         test_root_ok(&account, false);
-        // test_internal_ok(0x20, 0x00, &account, false);
-        // test_internal_ok(0x1010, 0xff, &account, false);
+        test_internal_ok(0x20, 0x00, &account, false);
+        test_internal_ok(0x1010, 0xff, &account, false);
     }
 
     #[test]

--- a/zkevm-circuits/src/evm_circuit/execution/balance.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/balance.rs
@@ -6,8 +6,11 @@ use crate::evm_circuit::util::constraint_builder::Transition::Delta;
 use crate::evm_circuit::util::constraint_builder::{
     ConstraintBuilder, ReversionInfo, StepStateTransition,
 };
-use crate::evm_circuit::util::{from_bytes, select, CachedRegion, Cell, Word};
-use crate::evm_circuit::witness::{Block, Call, ExecStep, Rw, Transaction};
+use crate::evm_circuit::util::{
+    from_bytes, math_gadget::IsZeroGadget, not, select, CachedRegion, Cell,
+    RandomLinearCombination, Word,
+};
+use crate::evm_circuit::witness::{Block, Call, ExecStep, Transaction};
 use crate::table::{AccountFieldTag, CallContextFieldTag};
 use crate::util::Expr;
 use eth_types::evm_types::GasCost;
@@ -22,8 +25,9 @@ pub(crate) struct BalanceGadget<F> {
     reversion_info: ReversionInfo<F>,
     tx_id: Cell<F>,
     is_warm: Cell<F>,
+    code_hash: Cell<F>,
+    not_exists: IsZeroGadget<F>,
     balance: Cell<F>,
-    exists: Cell<F>,
 }
 
 impl<F: Field> ExecutionGadget<F> for BalanceGadget<F> {
@@ -46,17 +50,19 @@ impl<F: Field> ExecutionGadget<F> for BalanceGadget<F> {
             is_warm.expr(),
             Some(&mut reversion_info),
         );
-
+        let code_hash = cb.query_cell();
+        cb.account_read(address.expr(), AccountFieldTag::CodeHash, code_hash.expr());
+        let not_exists = IsZeroGadget::construct(cb, code_hash.expr());
+        let exists = not::expr(not_exists.expr());
         let balance = cb.query_cell();
-        let exists = cb.query_bool();
         cb.condition(exists.expr(), |cb| {
             cb.account_read(address.expr(), AccountFieldTag::Balance, balance.expr());
         });
-        cb.condition(1.expr() - exists.expr(), |cb| {
-            cb.account_read(address, AccountFieldTag::NonExisting, 0.expr());
+        cb.condition(not_exists.expr(), |cb| {
+            cb.require_zero("balance is zero when non_exists", balance.expr());
         });
 
-        cb.stack_push(select::expr(exists.expr(), balance.expr(), 0.expr()));
+        cb.stack_push(balance.expr());
 
         let gas_cost = select::expr(
             is_warm.expr(),
@@ -65,7 +71,7 @@ impl<F: Field> ExecutionGadget<F> for BalanceGadget<F> {
         );
 
         let step_state_transition = StepStateTransition {
-            rw_counter: Delta(7.expr()),
+            rw_counter: Delta(7.expr() + exists.expr()),
             program_counter: Delta(1.expr()),
             stack_pointer: Delta(0.expr()),
             gas_left: Delta(-gas_cost),
@@ -82,8 +88,9 @@ impl<F: Field> ExecutionGadget<F> for BalanceGadget<F> {
             reversion_info,
             tx_id,
             is_warm,
+            code_hash,
+            not_exists,
             balance,
-            exists,
         }
     }
 
@@ -96,6 +103,10 @@ impl<F: Field> ExecutionGadget<F> for BalanceGadget<F> {
         call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
+        // dbg!(&step);
+        // for i in 0..7 {
+        //     dbg!(block.rws[step.rw_indices[i]]);
+        // }
         self.same_context.assign_exec_step(region, offset, step)?;
 
         let address = block.rws[step.rw_indices[0]].stack_value();
@@ -116,22 +127,21 @@ impl<F: Field> ExecutionGadget<F> for BalanceGadget<F> {
         self.is_warm
             .assign(region, offset, Value::known(F::from(is_warm)))?;
 
-        let (balance, exists) = match block.rws[step.rw_indices[5]] {
-            Rw::Account {
-                field_tag: AccountFieldTag::Balance,
-                value,
-                ..
-            } => (value, true),
-            Rw::Account {
-                field_tag: AccountFieldTag::NonExisting,
-                ..
-            } => (0.into(), false),
-            _ => unreachable!(),
+        let (code_hash, _) = block.rws[step.rw_indices[5]].account_value_pair();
+        let code_hash_rlc = RandomLinearCombination::random_linear_combine(
+            code_hash.to_le_bytes(),
+            block.randomness,
+        );
+        self.code_hash
+            .assign(region, offset, Value::known(code_hash_rlc))?;
+        self.not_exists.assign(region, offset, code_hash_rlc)?;
+        let balance = if code_hash.is_zero() {
+            eth_types::Word::zero()
+        } else {
+            block.rws[step.rw_indices[6]].account_value_pair().0
         };
         self.balance
             .assign(region, offset, region.word_rlc(balance))?;
-        self.exists
-            .assign(region, offset, Value::known(F::from(exists)))?;
 
         Ok(())
     }
@@ -145,6 +155,7 @@ mod test {
     use eth_types::{address, bytecode, Address, Bytecode, ToWord, Word, U256};
     use lazy_static::lazy_static;
     use mock::TestContext;
+    use pretty_assertions::assert_eq;
 
     lazy_static! {
         static ref TEST_ADDRESS: Address = address!("0xaabbccddee000000000000000000000000000000");
@@ -175,8 +186,8 @@ mod test {
         });
 
         test_root_ok(&account, false);
-        test_internal_ok(0x20, 0x00, &account, false);
-        test_internal_ok(0x1010, 0xff, &account, false);
+        // test_internal_ok(0x20, 0x00, &account, false);
+        // test_internal_ok(0x1010, 0xff, &account, false);
     }
 
     #[test]

--- a/zkevm-circuits/src/evm_circuit/execution/codecopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/codecopy.rs
@@ -66,7 +66,8 @@ impl<F: Field> ExecutionGadget<F> for CodeCopyGadget<F> {
         let code_hash = cb.curr.state.code_hash.clone();
 
         // Fetch the bytecode length from the bytecode table.
-        let code_size = cb.bytecode_length(code_hash.expr());
+        let code_size = cb.query_cell();
+        cb.bytecode_length(code_hash.expr(), code_size.expr());
 
         // Calculate the next memory size and the gas cost for this memory
         // access. This also accounts for the dynamic gas required to copy bytes to

--- a/zkevm-circuits/src/evm_circuit/execution/codesize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/codesize.rs
@@ -36,7 +36,8 @@ impl<F: Field> ExecutionGadget<F> for CodesizeGadget<F> {
         let codesize_bytes = array_init(|_| cb.query_byte());
 
         let code_hash = cb.curr.state.code_hash.clone();
-        let codesize = cb.bytecode_length(code_hash.expr());
+        let codesize = cb.query_cell();
+        cb.bytecode_length(code_hash.expr(), codesize.expr());
 
         cb.require_equal(
             "Constraint: bytecode length lookup == codesize",

--- a/zkevm-circuits/src/evm_circuit/execution/error_invalid_jump.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_invalid_jump.rs
@@ -74,7 +74,8 @@ impl<F: Field> ExecutionGadget<F> for ErrorInvalidJumpGadget<F> {
         });
 
         // look up bytecode length
-        let code_length = cb.bytecode_length(cb.curr.state.code_hash.expr());
+        let code_length = cb.query_cell();
+        cb.bytecode_length(cb.curr.state.code_hash.expr(), code_length.expr());
         let dest_value = from_bytes::expr(&destination.cells);
 
         let within_range = LtGadget::construct(cb, dest_value.expr(), code_length.expr());

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_call.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_call.rs
@@ -181,7 +181,6 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGCallGadget<F> {
             rd_length,
             step.memory_word_size(),
             callee_code_hash_word,
-            F::from(callee_exists),
         )?;
 
         self.opcode

--- a/zkevm-circuits/src/evm_circuit/execution/extcodehash.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodehash.rs
@@ -111,11 +111,9 @@ impl<F: Field> ExecutionGadget<F> for ExtcodehashGadget<F> {
         self.is_warm
             .assign(region, offset, Value::known(F::from(is_warm)))?;
 
-        let code_hash = block.rws[step.rw_indices[5]]
-            .table_assignment_aux(block.randomness)
-            .value;
+        let code_hash = block.rws[step.rw_indices[5]].account_value_pair().0;
         self.code_hash
-            .assign(region, offset, Value::known(code_hash))?;
+            .assign(region, offset, region.word_rlc(code_hash))?;
 
         Ok(())
     }

--- a/zkevm-circuits/src/evm_circuit/execution/extcodehash.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodehash.rs
@@ -8,9 +8,7 @@ use crate::{
             constraint_builder::{
                 ConstraintBuilder, ReversionInfo, StepStateTransition, Transition::Delta,
             },
-            from_bytes,
-            math_gadget::BatchedIsZeroGadget,
-            CachedRegion, Cell, Word,
+            from_bytes, CachedRegion, Cell, Word,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
@@ -27,10 +25,7 @@ pub(crate) struct ExtcodehashGadget<F> {
     tx_id: Cell<F>,
     reversion_info: ReversionInfo<F>,
     is_warm: Cell<F>,
-    nonce: Cell<F>,
-    balance: Cell<F>,
     code_hash: Cell<F>,
-    is_empty: BatchedIsZeroGadget<F, 3>, // boolean for if the external account is empty
 }
 
 impl<F: Field> ExecutionGadget<F> for ExtcodehashGadget<F> {
@@ -55,27 +50,10 @@ impl<F: Field> ExecutionGadget<F> for ExtcodehashGadget<F> {
             Some(&mut reversion_info),
         );
 
-        let nonce = cb.query_cell();
-        cb.account_read(address.expr(), AccountFieldTag::Nonce, nonce.expr());
-        let balance = cb.query_cell();
-        cb.account_read(address.expr(), AccountFieldTag::Balance, balance.expr());
         let code_hash = cb.query_cell();
+        // For non-existing accounts the code_hash must be 0 in the rw_table.
         cb.account_read(address, AccountFieldTag::CodeHash, code_hash.expr());
-
-        // Note that balance is RLC encoded, but RLC(x) = 0 iff x = 0, so we don't need
-        // go to the work of writing out the RLC expression
-        let is_empty = BatchedIsZeroGadget::construct(
-            cb,
-            [
-                nonce.expr(),
-                balance.expr(),
-                code_hash.expr() - cb.empty_hash_rlc(),
-            ],
-        );
-
-        // The stack push is 0 if the external account is empty. Otherwise, it's the
-        // code hash
-        cb.stack_push((1.expr() - is_empty.expr()) * code_hash.expr());
+        cb.stack_push(code_hash.expr());
 
         let gas_cost = is_warm.expr() * GasCost::WARM_ACCESS.expr()
             + (1.expr() - is_warm.expr()) * GasCost::COLD_ACCOUNT_ACCESS.expr();
@@ -97,10 +75,7 @@ impl<F: Field> ExecutionGadget<F> for ExtcodehashGadget<F> {
             tx_id,
             reversion_info,
             is_warm,
-            nonce,
-            balance,
             code_hash,
-            is_empty,
         }
     }
 
@@ -136,21 +111,11 @@ impl<F: Field> ExecutionGadget<F> for ExtcodehashGadget<F> {
         self.is_warm
             .assign(region, offset, Value::known(F::from(is_warm)))?;
 
-        let [nonce, balance, code_hash] = [5, 6, 7].map(|i| {
-            block.rws[step.rw_indices[i]]
-                .table_assignment(region.challenges().evm_word())
-                .value
-        });
-
-        self.nonce.assign(region, offset, nonce)?;
-        self.balance.assign(region, offset, balance)?;
-        self.code_hash.assign(region, offset, code_hash)?;
-
-        self.is_empty.assign_value(
-            region,
-            offset,
-            [nonce, balance, code_hash - region.empty_hash_rlc()],
-        )?;
+        let code_hash = block.rws[step.rw_indices[5]]
+            .table_assignment_aux(block.randomness)
+            .value;
+        self.code_hash
+            .assign(region, offset, Value::known(code_hash))?;
 
         Ok(())
     }

--- a/zkevm-circuits/src/evm_circuit/execution/extcodesize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodesize.rs
@@ -1,5 +1,5 @@
 use crate::evm_circuit::execution::ExecutionGadget;
-use crate::evm_circuit::param::N_BYTES_ACCOUNT_ADDRESS;
+use crate::evm_circuit::param::{N_BYTES_ACCOUNT_ADDRESS, N_BYTES_U64};
 use crate::evm_circuit::step::ExecutionState;
 use crate::evm_circuit::util::common_gadget::SameContextGadget;
 use crate::evm_circuit::util::constraint_builder::Transition::Delta;
@@ -27,7 +27,7 @@ pub(crate) struct ExtcodesizeGadget<F> {
     is_warm: Cell<F>,
     code_hash: Cell<F>,
     not_exists: IsZeroGadget<F>,
-    code_size: RandomLinearCombination<F, 8>,
+    code_size: RandomLinearCombination<F, N_BYTES_U64>,
 }
 
 impl<F: Field> ExecutionGadget<F> for ExtcodesizeGadget<F> {

--- a/zkevm-circuits/src/evm_circuit/execution/extcodesize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodesize.rs
@@ -6,11 +6,13 @@ use crate::evm_circuit::util::constraint_builder::Transition::Delta;
 use crate::evm_circuit::util::constraint_builder::{
     ConstraintBuilder, ReversionInfo, StepStateTransition,
 };
-use crate::evm_circuit::util::{from_bytes, select, CachedRegion, Cell, Word};
-use crate::evm_circuit::witness::{Block, Call, ExecStep, Rw, Transaction};
+use crate::evm_circuit::util::math_gadget::IsZeroGadget;
+use crate::evm_circuit::util::{
+    from_bytes, not, select, CachedRegion, Cell, RandomLinearCombination, Word,
+};
+use crate::evm_circuit::witness::{Block, Call, ExecStep, Transaction};
 use crate::table::{AccountFieldTag, CallContextFieldTag};
 use crate::util::Expr;
-use array_init::array_init;
 use eth_types::evm_types::GasCost;
 use eth_types::{Field, ToLittleEndian};
 use halo2_proofs::circuit::Value;
@@ -23,10 +25,9 @@ pub(crate) struct ExtcodesizeGadget<F> {
     reversion_info: ReversionInfo<F>,
     tx_id: Cell<F>,
     is_warm: Cell<F>,
-    exists: Cell<F>,
     code_hash: Cell<F>,
-    code_size: Cell<F>,
-    code_size_bytes: [Cell<F>; 8],
+    not_exists: IsZeroGadget<F>,
+    code_size: RandomLinearCombination<F, 8>,
 }
 
 impl<F: Field> ExecutionGadget<F> for ExtcodesizeGadget<F> {
@@ -50,27 +51,21 @@ impl<F: Field> ExecutionGadget<F> for ExtcodesizeGadget<F> {
             Some(&mut reversion_info),
         );
 
-        let exists = cb.query_bool();
         let code_hash = cb.query_cell();
-        let code_size = cb.condition(exists.expr(), |cb| {
-            cb.account_read(address.expr(), AccountFieldTag::CodeHash, code_hash.expr());
-            cb.bytecode_length(code_hash.expr())
-        });
-        cb.condition(1.expr() - exists.expr(), |cb| {
-            cb.account_read(address, AccountFieldTag::NonExisting, 0.expr());
-        });
-        let code_size_bytes = array_init(|_| cb.query_byte());
+        // For non-existing accounts the code_hash must be 0 in the rw_table.
+        cb.account_read(address.expr(), AccountFieldTag::CodeHash, code_hash.expr());
+        let not_exists = IsZeroGadget::construct(cb, code_hash.expr());
+        let exists = not::expr(not_exists.expr());
 
-        cb.require_equal(
-            "Constrain bytecode_length lookup == code_size",
-            from_bytes::expr(&code_size_bytes),
-            code_size.expr(),
-        );
-        cb.stack_push(select::expr(
-            exists.expr(),
-            cb.word_rlc(code_size_bytes.clone().map(|c| c.expr())),
-            0.expr(),
-        ));
+        let code_size = cb.query_rlc();
+        cb.condition(exists.expr(), |cb| {
+            cb.bytecode_length(code_hash.expr(), from_bytes::expr(&code_size.cells));
+        });
+        cb.condition(not_exists.expr(), |cb| {
+            cb.require_zero("code_size is zero when non_exists", code_size.expr());
+        });
+
+        cb.stack_push(code_size.expr());
 
         let gas_cost = select::expr(
             is_warm.expr(),
@@ -96,10 +91,9 @@ impl<F: Field> ExecutionGadget<F> for ExtcodesizeGadget<F> {
             tx_id,
             reversion_info,
             is_warm,
-            exists,
             code_hash,
+            not_exists,
             code_size,
-            code_size_bytes,
         }
     }
 
@@ -132,34 +126,16 @@ impl<F: Field> ExecutionGadget<F> for ExtcodesizeGadget<F> {
         self.is_warm
             .assign(region, offset, Value::known(F::from(is_warm)))?;
 
-        let (exists, code_hash) = match block.rws[step.rw_indices[5]] {
-            Rw::Account {
-                field_tag: AccountFieldTag::CodeHash,
-                value,
-                ..
-            } => (true, value),
-            Rw::Account {
-                field_tag: AccountFieldTag::NonExisting,
-                ..
-            } => (false, 0.into()),
-            _ => unreachable!(),
-        };
+        let code_hash = block.rws[step.rw_indices[5]]
+            .table_assignment_aux(block.randomness)
+            .value;
+        self.code_hash
+            .assign(region, offset, Value::known(code_hash))?;
+        self.not_exists.assign(region, offset, code_hash)?;
 
         let code_size = block.rws[step.rw_indices[6]].stack_value().as_u64();
-
-        self.exists
-            .assign(region, offset, Value::known(F::from(exists)))?;
-        self.code_hash
-            .assign(region, offset, region.word_rlc(code_hash))?;
         self.code_size
-            .assign(region, offset, Value::known(F::from(code_size)))?;
-        for (c, b) in self
-            .code_size_bytes
-            .iter()
-            .zip(code_size.to_le_bytes().into_iter())
-        {
-            c.assign(region, offset, Value::known(u64::from(b).into()))?;
-        }
+            .assign(region, offset, Some(code_size.to_le_bytes()))?;
 
         Ok(())
     }

--- a/zkevm-circuits/src/evm_circuit/execution/stop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/stop.rs
@@ -34,7 +34,8 @@ impl<F: Field> ExecutionGadget<F> for StopGadget<F> {
     const EXECUTION_STATE: ExecutionState = ExecutionState::STOP;
 
     fn configure(cb: &mut ConstraintBuilder<F>) -> Self {
-        let code_length = cb.bytecode_length(cb.curr.state.code_hash.expr());
+        let code_length = cb.query_cell();
+        cb.bytecode_length(cb.curr.state.code_hash.expr(), code_length.expr());
         let is_out_of_range = IsZeroGadget::construct(
             cb,
             code_length.expr() - cb.curr.state.program_counter.expr(),

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -612,8 +612,7 @@ impl<'a, F: Field> ConstraintBuilder<'a, F> {
         )
     }
 
-    pub(crate) fn bytecode_length(&mut self, code_hash: Expression<F>) -> Cell<F> {
-        let cell = self.query_cell();
+    pub(crate) fn bytecode_length(&mut self, code_hash: Expression<F>, value: Expression<F>) {
         self.add_lookup(
             "Bytecode (length)",
             Lookup::Bytecode {
@@ -621,10 +620,9 @@ impl<'a, F: Field> ConstraintBuilder<'a, F> {
                 tag: BytecodeFieldTag::Length.expr(),
                 index: 0.expr(),
                 is_code: 0.expr(),
-                value: cell.expr(),
+                value,
             },
         );
-        cell
     }
 
     // Tx context

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget.rs
@@ -25,7 +25,7 @@ mod test_util;
 
 pub(crate) use abs_word::AbsWordGadget;
 pub(crate) use add_words::AddWordsGadget;
-pub(crate) use batched_is_zero::BatchedIsZeroGadget;
+pub use batched_is_zero::BatchedIsZeroGadget;
 pub(crate) use byte_size::ByteSizeGadget;
 pub(crate) use cmp_words::CmpWordsGadget;
 pub(crate) use comparison::ComparisonGadget;

--- a/zkevm-circuits/src/state_circuit.rs
+++ b/zkevm-circuits/src/state_circuit.rs
@@ -60,7 +60,7 @@ pub struct StateCircuitConfig<F> {
     // new value are zero. Will do lookup for ProofType::StorageDoesNotExist if
     // non-existing, otherwise do lookup for ProofType::StorageChanged.
     is_non_exist: BatchedIsZeroConfig,
-    // Intermediarey witness used to reduce mpt lookup expression degree
+    // Intermediary witness used to reduce mpt lookup expression degree
     mpt_proof_type: Column<Advice>,
     state_root: Column<Advice>,
     lexicographic_ordering: LexicographicOrderingConfig,

--- a/zkevm-circuits/src/state_circuit/constraint_builder.rs
+++ b/zkevm-circuits/src/state_circuit/constraint_builder.rs
@@ -354,8 +354,17 @@ impl<F: Field> ConstraintBuilder<F> {
             * generate_lagrange_base_polynomial(
                 q.field_tag(),
                 AccountFieldTag::CodeHash as usize,
-                AccountFieldTag::iter().map(|t| t as usize),
+                [
+                    AccountFieldTag::Nonce,
+                    AccountFieldTag::Balance,
+                    AccountFieldTag::CodeHash,
+                ]
+                .iter()
+                .map(|t| *t as usize),
             );
+        // is_non_exist degree = 4
+        //   q.is_non_exist() degree = 1
+        //   generate_lagrange_base_polynomial() degree = 3
 
         self.condition(q.last_access(), |cb| {
             cb.add_lookup(
@@ -370,6 +379,7 @@ impl<F: Field> ConstraintBuilder<F> {
                         q.mpt_update_table.storage_key.clone(),
                     ),
                     (
+                        // degree = max(4, 4 + 1) = 5
                         is_non_exist.expr() * ProofType::AccountDoesNotExist.expr()
                             + (1.expr() - is_non_exist) * q.field_tag(),
                         q.mpt_update_table.proof_type.clone(),

--- a/zkevm-circuits/src/state_circuit/constraint_builder.rs
+++ b/zkevm-circuits/src/state_circuit/constraint_builder.rs
@@ -345,6 +345,9 @@ impl<F: Field> ConstraintBuilder<F> {
             set::<F, AccountFieldTag>(),
         );
 
+        // NOTE: This expression, when used in the lookup causes the state circuit
+        // degree to go from 9 to 13.  A possible solution to avoid this would
+        // be to use intermediary witnesses to split the expressions.
         // We use code_hash = 0 as non-existing account state.  code_hash: 0->0
         // transition requires a non-existing proof.
         let is_non_exist = q.is_non_exist()

--- a/zkevm-circuits/src/state_circuit/test.rs
+++ b/zkevm-circuits/src/state_circuit/test.rs
@@ -113,7 +113,7 @@ fn test_state_circuit_ok(
 fn degree() {
     let mut meta = ConstraintSystem::<Fr>::default();
     StateCircuit::<Fr>::configure(&mut meta);
-    assert_eq!(meta.degree(), 12);
+    assert_eq!(meta.degree(), 9);
 }
 
 #[test]

--- a/zkevm-circuits/src/state_circuit/test.rs
+++ b/zkevm-circuits/src/state_circuit/test.rs
@@ -24,8 +24,7 @@ use rand::SeedableRng;
 use std::collections::{BTreeSet, HashMap};
 use strum::IntoEnumIterator;
 
-const N_ROWS: usize = 1 << 16; // TODO: Uncomment
-                               // const N_ROWS: usize = 1 << 8;
+const N_ROWS: usize = 1 << 16;
 
 #[derive(Hash, Eq, PartialEq, Clone, Debug)]
 pub enum AdviceColumn {
@@ -106,7 +105,6 @@ fn test_state_circuit_ok(
     let prover = MockProver::<Fr>::run(19, &circuit, power_of_randomness).unwrap();
     let verify_result = prover.verify();
     assert_eq!(verify_result, Ok(()));
-    // prover.assert_satisfied();
 }
 
 #[test]

--- a/zkevm-circuits/src/state_circuit/test.rs
+++ b/zkevm-circuits/src/state_circuit/test.rs
@@ -113,7 +113,7 @@ fn test_state_circuit_ok(
 fn degree() {
     let mut meta = ConstraintSystem::<Fr>::default();
     StateCircuit::<Fr>::configure(&mut meta);
-    assert_eq!(meta.degree(), 13);
+    assert_eq!(meta.degree(), 12);
 }
 
 #[test]

--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -426,7 +426,7 @@ mod super_circuit_tests {
         SuperCircuit::<_, 1, 32, 256>::configure(&mut cs);
         log::info!("super circuit degree: {}", cs.degree());
         log::info!("super circuit minimum_rows: {}", cs.minimum_rows());
-        assert!(cs.degree() <= 13);
+        assert!(cs.degree() <= 12);
     }
 
     fn test_super_circuit<const MAX_TXS: usize, const MAX_CALLDATA: usize, const MAX_RWS: usize>(

--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -426,7 +426,7 @@ mod super_circuit_tests {
         SuperCircuit::<_, 1, 32, 256>::configure(&mut cs);
         log::info!("super circuit degree: {}", cs.degree());
         log::info!("super circuit minimum_rows: {}", cs.minimum_rows());
-        assert!(cs.degree() <= 12);
+        assert!(cs.degree() <= 9);
     }
 
     fn test_super_circuit<const MAX_TXS: usize, const MAX_CALLDATA: usize, const MAX_RWS: usize>(

--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -426,7 +426,7 @@ mod super_circuit_tests {
         SuperCircuit::<_, 1, 32, 256>::configure(&mut cs);
         log::info!("super circuit degree: {}", cs.degree());
         log::info!("super circuit minimum_rows: {}", cs.minimum_rows());
-        assert!(cs.degree() <= 9);
+        assert!(cs.degree() <= 13);
     }
 
     fn test_super_circuit<const MAX_TXS: usize, const MAX_CALLDATA: usize, const MAX_RWS: usize>(


### PR DESCRIPTION
Add BatchedIsZeroChip in gadgets
Update the following opcode gadgets to handle non-existing accounts via code_hash == 0:
- BALANCE
- EXTCODEHASH
- EXTCODESIZE
- callop (CALLCODE, DELEGATECALL, STATICCALL, CALL)

Missing:
- EXTCODECOPY (the circuit is currently not implemented, I'll update it once https://github.com/privacy-scaling-explorations/zkevm-circuits/pull/720 is merged)

Important note: By handling the non-existence proofs from the state circuit (which requires detecting the special case of storage 0->0 or account,code_hash 0->0 to swap the proof type to non existence in the MPT lookup), the state circuit degree has increased from 9 to 12.  I could keep it at 9 by introducing an intermediate column and splitting the degree >9 expression.  Is it a problem to keep the degree at 12?  Should I keep it at 9 in an update to this PR?

Update: I've brought back the degree to 9, at the cost of introducing a new column in the State circuit (to hold an intermediary witness and splitting the highest degree expression).

Corresponding specs PR https://github.com/privacy-scaling-explorations/zkevm-specs/pull/354