### PR TITLE
fix extcodecopy: non-exsit-proof, challenge api, and other fixes

### DIFF
--- a/bus-mapping/src/evm/opcodes/extcodecopy.rs
+++ b/bus-mapping/src/evm/opcodes/extcodecopy.rs
@@ -114,7 +114,6 @@ fn gen_extcodecopy_step(
     } else {
         H256::zero()
     };
-
     state.account_read(
         &mut exec_step,
         external_address,

--- a/bus-mapping/src/evm/opcodes/extcodecopy.rs
+++ b/bus-mapping/src/evm/opcodes/extcodecopy.rs
@@ -243,7 +243,11 @@ mod extcodecopy_tests {
         });
 
         let bytecode_ext = Bytecode::from(code_ext.to_vec());
-        let code_hash = keccak256(code_ext.clone());
+        let code_hash = if code_ext.is_empty() {
+            Default::default()
+        } else {
+            keccak256(code_ext.clone())
+        };
 
         // Get the execution steps from the external tracer
         let block: GethData = TestContext::<3, 1>::new(

--- a/bus-mapping/src/evm/opcodes/extcodecopy.rs
+++ b/bus-mapping/src/evm/opcodes/extcodecopy.rs
@@ -3,9 +3,8 @@ use crate::circuit_input_builder::{
     CircuitInputStateRef, CopyDataType, CopyEvent, ExecStep, NumberOrHash,
 };
 use crate::operation::{AccountField, CallContextField, TxAccessListAccountOp, RW};
-use crate::state_db::Account;
 use crate::Error;
-use eth_types::{Bytecode, GethExecStep, ToAddress, ToWord, U256};
+use eth_types::{Bytecode, GethExecStep, ToAddress, ToWord, H256, U256};
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct Extcodecopy;
@@ -108,7 +107,14 @@ fn gen_extcodecopy_step(
         },
     )?;
 
-    let &Account { code_hash, .. } = state.sdb.get_account(&external_address).1;
+    let account = state.sdb.get_account(&external_address).1;
+    let exists = !account.is_empty();
+    let code_hash = if exists {
+        account.code_hash
+    } else {
+        H256::zero()
+    };
+
     state.account_read(
         &mut exec_step,
         external_address,
@@ -154,8 +160,19 @@ fn gen_copy_event(
     let data_offset = geth_step.stack.nth_last(2)?.as_u64();
     let length = geth_step.stack.nth_last(3)?.as_u64();
 
-    let code_hash = state.sdb.get_account(&external_address).1.code_hash;
-    let code: Bytecode = state.code(code_hash)?.into();
+    let account = state.sdb.get_account(&external_address).1;
+    let exists = !account.is_empty();
+    let code_hash = if exists {
+        account.code_hash
+    } else {
+        H256::zero()
+    };
+
+    let code: Bytecode = if exists {
+        state.code(code_hash)?.into()
+    } else {
+        Bytecode::default()
+    };
     let src_addr_end = code.code.len() as u64;
     let mut exec_step = state.new_step(geth_step)?;
     let copy_steps = gen_copy_steps(

--- a/zkevm-circuits/src/evm_circuit/execution/extcodecopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodecopy.rs
@@ -119,6 +119,7 @@ impl<F: Field> ExecutionGadget<F> for ExtcodecopyGadget<F> {
             stack_pointer: Transition::Delta(4.expr()),
             memory_word_size: Transition::To(memory_expansion.next_memory_word_size()),
             gas_left: Transition::Delta(-gas_cost),
+            reversible_write_counter: Transition::Delta(1.expr()),
             ..Default::default()
         };
         let same_context = SameContextGadget::construct(cb, opcode, step_state_transition);
@@ -183,22 +184,22 @@ impl<F: Field> ExecutionGadget<F> for ExtcodecopyGadget<F> {
         self.is_warm
             .assign(region, offset, Value::known(F::from(is_warm as u64)))?;
 
-        let code_hash = block.rws[step.rw_indices[8]]
-            .table_assignment_aux(block.randomness)
-            .value;
+        let code_hash = block.rws[step.rw_indices[8]].account_value_pair().0;
         self.code_hash
-            .assign(region, offset, Value::known(code_hash))?;
+            .assign(region, offset, region.word_rlc(code_hash))?;
 
-        let (code, _) = block.rws[step.rw_indices[8]].account_value_pair();
-        let bytecode = block
-            .bytecodes
-            .get(&code)
-            .expect("could not find external bytecode");
-        self.code_size.assign(
-            region,
-            offset,
-            Value::known(F::from(bytecode.bytes.len() as u64)),
-        )?;
+        let bytecode_len = if code_hash.is_zero() {
+            0
+        } else {
+            block
+                .bytecodes
+                .get(&code_hash)
+                .expect("could not find external bytecode")
+                .bytes
+                .len()
+        };
+        self.code_size
+            .assign(region, offset, Value::known(F::from(bytecode_len as u64)))?;
 
         self.copy_rwc_inc.assign(
             region,
@@ -266,28 +267,37 @@ mod test {
             });
         }
         code.append(&bytecode! {
-            PUSH20(external_address.to_word())
-            PUSH32(memory_offset)
-            PUSH32(data_offset)
             PUSH32(length)
+            PUSH32(data_offset)
+            PUSH32(memory_offset)
+            PUSH20(external_address.to_word())
             #[start]
             EXTCODECOPY
             STOP
         });
 
-        let test_ctx = TestContext::<2, 1>::new(
+        let test_ctx = TestContext::<3, 1>::new(
             None,
             |accs| {
                 accs[0]
                     .address(address!("0x000000000000000000000000000000000000cafe"))
                     .code(code);
-
                 accs[1]
                     .address(address!("0x0000000000000000000000000000000000000010"))
                     .balance(Word::from(1u64 << 20));
+                accs[2].address(external_address);
+                if let Some(external_account) = external_account {
+                    accs[2]
+                        .balance(external_account.balance)
+                        .nonce(external_account.nonce)
+                        .code(external_account.code);
+                }
             },
             |mut txs, accs| {
-                txs[0].to(accs[0].address).from(accs[1].address);
+                txs[0]
+                    .to(accs[0].address)
+                    .from(accs[1].address)
+                    .gas(1_000_000.into());
             },
             |block, _tx| block.number(0x1111111),
         )


### PR DESCRIPTION
1.  use non-exist-proof
2. use challenge api
3. fix stack push order
4. add EXTERNAL_ADDRESS to TestContext
5. fix reversible_write_counter

previously, due to the incorrect param stack pushing order, an OOG error is triggered and handled by DummyGadget, so all the above errors cannot be catched by tests.