### PR TITLE
Add a pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,11 +1,42 @@
-### What was wrong?
+_PR description_
 
-> 1. Reference the issue to resolve
-> 2. Please give a concise description to the problem. The target readers could be the future developers, reviewers, and auditors. By reading your description, they should easily understand the changes proposed in this pull request.
+### Contents
 
-### How was it fixed?
+- _item_
 
-> Please include 
-> 1. What types of design choices you faced
-> 2. What decisions you have made
-> 3. Any valuable information that could help reviewers to think critically
+### Rationale
+
+_design decisions and extended information_
+
+
+<hr>
+
+## How to fill a PR description (remove this)
+
+Please give a concise description of your PR.
+
+The target readers could be future developers, reviewers, and auditors. By reading your description, they should easily understand the changes proposed in this pull request.
+
+MUST: Reference the issue to resolve
+
+### Single responsability
+
+Is RECOMMENDED to create single responsibility commits, but not mandatory.
+
+Anyway, you MUST enumerate the changes in a unitary way, e.g.
+
+```
+This PR contains:
+
+- Cleanup of xxxx, yyyy
+- Changed xxxx to yyyy in order to bla bla
+- Added xxxx function to ...
+- Refactored ....
+```
+
+### Design choices
+
+RECOMMENDED to:
+- What types of design choices did you face?
+- What decisions you have made?
+- Any valuable information that could help reviewers to think critically

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,11 @@
+### What was wrong?
+
+> 1. Reference the issue to resolve
+> 2. Please give a concise description to the problem. The target readers could be the future developers, reviewers, and auditors. By reading your description, they should easily understand the changes proposed in this pull request.
+
+### How was it fixed?
+
+> Please include 
+> 1. What types of design choices you faced
+> 2. What decisions you have made
+> 3. Any valuable information that could help reviewers to think critically


### PR DESCRIPTION
We add a PR template to guide code contributors to write better descriptions.

### Contents

- Added a PR template

### Rationale

In a previous retrospective meeting, we realized writing helpful descriptions in the PRs can bring much value. That value includes but is not limited to the following:

- Better description helps reviewers understand the pull request and think critically. We could improve the review quality by detecting more critical bugs early.
- Developers can better reason why a change was made to the code base. They can use tools like CodeLens to look up the merge commits and the corresponding PR to the change. A good PR description helps this process.
- Auditors can also learn about the codebase by reading the description of a PR merged long ago. 

Here's what we considered to add in the template:

- It's important to point out the problems and solutions the PR is trying to tackle.
- Point out the target readers: current reviewers, devs, and future devs and auditors. So that the PR author knows who their communication targets are.
- @ed255 pointed out that the authors' design choices and tech decisions are helpful for the reviewing process. Without writing them down, the reviewers were usually unaware of them and didn't think critically about them.

For reviewers, it would be great to think about the followings:

- Does the template suit your workflow?
- What would be valuable to include in the template?

