### PR TITLE
state circuit allows non zero old_state_root

### DIFF
--- a/zkevm-circuits/src/state_circuit.rs
+++ b/zkevm-circuits/src/state_circuit.rs
@@ -8,13 +8,13 @@ mod random_linear_combination;
 mod test;
 
 use crate::{
-    evm_circuit::param::N_BYTES_WORD,
+    evm_circuit::{param::N_BYTES_WORD, util::rlc},
     table::{AccountFieldTag, LookupTable, MptTable, ProofType, RwTable, RwTableTag},
     util::{Challenges, Expr, SubCircuit, SubCircuitConfig},
     witness::{self, MptUpdates, Rw, RwMap},
 };
 use constraint_builder::{ConstraintBuilder, Queries};
-use eth_types::{Address, Field};
+use eth_types::{Address, Field, ToLittleEndian};
 use gadgets::{
     batched_is_zero::{BatchedIsZeroChip, BatchedIsZeroConfig},
     binary_number::{BinaryNumberChip, BinaryNumberConfig},
@@ -208,7 +208,8 @@ impl<F: Field> StateCircuitConfig<F> {
         let rows = rows.iter();
         let prev_rows = once(None).chain(rows.clone().map(Some));
 
-        let mut state_root = randomness.map(|_| F::zero());
+        let mut state_root =
+            randomness.map(|randomness| rlc::value(&updates.old_root().to_le_bytes(), randomness));
 
         for (offset, (row, prev_row)) in rows.zip(prev_rows).enumerate() {
             if offset >= padding_length {

--- a/zkevm-circuits/src/state_circuit/test.rs
+++ b/zkevm-circuits/src/state_circuit/test.rs
@@ -100,9 +100,9 @@ fn test_state_circuit_ok(
     });
 
     let circuit = StateCircuit::<Fr>::new(rw_map, N_ROWS);
-    let power_of_randomness = circuit.instance();
+    let instance = circuit.instance();
 
-    let prover = MockProver::<Fr>::run(19, &circuit, power_of_randomness).unwrap();
+    let prover = MockProver::<Fr>::run(19, &circuit, instance).unwrap();
     let verify_result = prover.verify();
     assert_eq!(verify_result, Ok(()));
 }
@@ -1005,9 +1005,9 @@ fn prover(rows: Vec<Rw>, overrides: HashMap<(AdviceColumn, isize), Fr>) -> MockP
         n_rows: N_ROWS,
         _marker: std::marker::PhantomData::default(),
     };
-    let power_of_randomness = circuit.instance();
+    let instance = circuit.instance();
 
-    MockProver::<Fr>::run(17, &circuit, power_of_randomness).unwrap()
+    MockProver::<Fr>::run(17, &circuit, instance).unwrap()
 }
 
 fn verify(rows: Vec<Rw>) -> Result<(), Vec<VerifyFailure>> {

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -245,7 +245,7 @@ impl From<RwTableTag> for usize {
 }
 
 /// Tag for an AccountField in RwTable
-#[derive(Clone, Copy, Debug, EnumIter, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, EnumIter, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum AccountFieldTag {
     /// Nonce field
     Nonce = 1,


### PR DESCRIPTION
and other improvements:

1. rename power_of_randomness to instance in state circuit tests. There is no power_of_randomness now.
2. change MptUpdates from HashMap to BTreeMap. So each run of tests produces same columns without non-deterministic. Useful for debugging.