### PR TITLE
feat: panic on invalid account lookups

### DIFF
--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -276,8 +276,8 @@ impl<'a> CircuitInputStateRef<'a> {
             }
         }
         let account = self.sdb.get_account_mut(&op.address).1;
-        if false {
-            // DBG
+        // Here starts the sanity check
+        if true {
             let account_value_prev = match op.field {
                 AccountField::Nonce => account.nonce,
                 AccountField::Balance => account.balance,

--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -266,7 +266,9 @@ impl<'a> CircuitInputStateRef<'a> {
     /// account in the StateDB, then if the rw operation is a write, apply
     /// it to the corresponding account in the StateDB.
     fn check_update_sdb_account(&mut self, rw: RW, op: &AccountOp) {
-        // Verify that a READ dosn't change the field value
+        let account = self.sdb.get_account_mut(&op.address).1;
+        // -- sanity check begin --
+        // Verify that a READ doesn't change the field value
         if matches!(rw, RW::READ) {
             if op.value_prev != op.value {
                 panic!(
@@ -275,44 +277,41 @@ impl<'a> CircuitInputStateRef<'a> {
                 )
             }
         }
-        let account = self.sdb.get_account_mut(&op.address).1;
-        // Here starts the sanity check
-        if true {
-            let account_value_prev = match op.field {
-                AccountField::Nonce => account.nonce,
-                AccountField::Balance => account.balance,
-                AccountField::CodeHash => {
-                    if account.is_empty() {
-                        Word::zero()
-                    } else {
-                        account.code_hash.to_word()
-                    }
+        let account_value_prev = match op.field {
+            AccountField::Nonce => account.nonce,
+            AccountField::Balance => account.balance,
+            AccountField::CodeHash => {
+                if account.is_empty() {
+                    Word::zero()
+                } else {
+                    account.code_hash.to_word()
                 }
-            };
-            // Verify that the previous value matches the account field value in the StateDB
-            if op.value_prev != account_value_prev {
-                panic!("RWTable Account field {:?} lookup doesn't match account value account: {:?}, rwc: {}, op: {:?}",
+            }
+        };
+        // Verify that the previous value matches the account field value in the StateDB
+        if op.value_prev != account_value_prev {
+            panic!("RWTable Account field {:?} lookup doesn't match account value account: {:?}, rwc: {}, op: {:?}",
                 rw,
                 account,
                 self.block_ctx.rwc.0,
                 op
             );
-            }
-            // Verify that no read is done to a field other than CodeHash to a non-existing
-            // account (only CodeHash reads with value=0 can be done to non-existing
-            // accounts, which the State Circuit translates to MPT
-            // AccountNonExisting proofs lookups).
-            if !matches!(op.field, AccountField::CodeHash)
-                && (matches!(rw, RW::READ) || (op.value_prev.is_zero() && op.value.is_zero()))
-            {
-                if account.is_empty() {
-                    panic!(
+        }
+        // Verify that no read is done to a field other than CodeHash to a non-existing
+        // account (only CodeHash reads with value=0 can be done to non-existing
+        // accounts, which the State Circuit translates to MPT
+        // AccountNonExisting proofs lookups).
+        if !matches!(op.field, AccountField::CodeHash)
+            && (matches!(rw, RW::READ) || (op.value_prev.is_zero() && op.value.is_zero()))
+        {
+            if account.is_empty() {
+                panic!(
                     "RWTable Account field {:?} lookup to non-existing account rwc: {}, op: {:?}",
                     rw, self.block_ctx.rwc.0, op
                 );
-                }
             }
         }
+        // -- sanity check end --
         // Perform the write to the account in the StateDB
         if matches!(rw, RW::WRITE) {
             match op.field {
@@ -816,7 +815,6 @@ impl<'a> CircuitInputStateRef<'a> {
                     AccountField::Nonce => account.nonce = op.value,
                     AccountField::Balance => account.balance = op.value,
                     AccountField::CodeHash => account.code_hash = op.value.to_be_bytes().into(),
-                    // AccountField::NonExisting => (),
                 }
             }
             OpEnum::TxRefund(op) => {

--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -100,6 +100,9 @@ impl<'a> CircuitInputStateRef<'a> {
     /// bus-mapping instance of the current [`ExecStep`].  Then increase the
     /// block_ctx [`RWCounter`](crate::operation::RWCounter) by one.
     pub fn push_op<T: Op>(&mut self, step: &mut ExecStep, rw: RW, op: T) {
+        if let OpEnum::Account(op) = op.clone().into_enum() {
+            self.check_update_sdb_account(rw, &op)
+        }
         let op_ref =
             self.block
                 .container
@@ -334,7 +337,6 @@ impl<'a> CircuitInputStateRef<'a> {
         value_prev: Word,
     ) -> Result<(), Error> {
         let op = AccountOp::new(address, field, value, value_prev);
-        self.check_update_sdb_account(RW::READ, &op);
         self.push_op(step, RW::READ, op);
         Ok(())
     }
@@ -354,7 +356,6 @@ impl<'a> CircuitInputStateRef<'a> {
         value_prev: Word,
     ) -> Result<(), Error> {
         let op = AccountOp::new(address, field, value, value_prev);
-        self.check_update_sdb_account(RW::WRITE, &op);
         self.push_op(step, RW::WRITE, op);
         Ok(())
     }

--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -352,8 +352,8 @@ pub fn gen_begin_tx_ops(state: &mut CircuitInputStateRef) -> Result<ExecStep, Er
         &mut exec_step,
         caller_address,
         AccountField::Nonce,
-        (nonce_prev + 1).into(),
-        nonce_prev.into(),
+        nonce_prev + 1,
+        nonce_prev,
     )?;
 
     // Add caller and callee into access list

--- a/bus-mapping/src/evm/opcodes/error_oog_call.rs
+++ b/bus-mapping/src/evm/opcodes/error_oog_call.rs
@@ -4,7 +4,7 @@ use crate::{
     operation::{AccountField, CallContextField, TxAccessListAccountOp, RW},
     Error,
 };
-use eth_types::{GethExecStep, ToAddress, ToWord};
+use eth_types::{GethExecStep, ToAddress, ToWord, Word};
 
 /// Placeholder structure used to implement [`Opcode`] trait over it
 /// corresponding to the `OpcodeId::CALL` `OpcodeId`.
@@ -60,6 +60,23 @@ impl Opcode for OOGCall {
             (0u64).into(), // must fail
         )?;
 
+        let (_, callee_account) = state.sdb.get_account(&call_address);
+        let callee_exists = !callee_account.is_empty();
+        let callee_code_hash = callee_account.code_hash;
+        let callee_code_hash_word = if callee_exists {
+            callee_code_hash.to_word()
+        } else {
+            Word::zero()
+        };
+
+        state.account_read(
+            &mut exec_step,
+            call_address,
+            AccountField::CodeHash,
+            callee_code_hash_word,
+            callee_code_hash_word,
+        )?;
+
         let is_warm = state.sdb.check_account_in_access_list(&call_address);
         state.push_op(
             &mut exec_step,
@@ -71,15 +88,6 @@ impl Opcode for OOGCall {
                 is_warm_prev: is_warm,
             },
         );
-
-        let (_, callee_account) = state.sdb.get_account(&call_address);
-        let callee_code_hash = callee_account.code_hash;
-        for (field, value) in [
-            (AccountField::Balance, callee_account.balance),
-            (AccountField::CodeHash, callee_code_hash.to_word()),
-        ] {
-            state.account_read(&mut exec_step, call_address, field, value, value)?;
-        }
 
         state.gen_restore_context_ops(&mut exec_step, geth_steps)?;
         state.handle_return(geth_step)?;

--- a/bus-mapping/src/operation.rs
+++ b/bus-mapping/src/operation.rs
@@ -539,8 +539,6 @@ pub enum AccountField {
     Balance,
     /// Account Code Hash
     CodeHash,
-    // /// Account non existing
-    // NonExisting,
 }
 
 /// Represents a change in the Account field implied by a `BeginTx`,

--- a/bus-mapping/src/operation.rs
+++ b/bus-mapping/src/operation.rs
@@ -531,7 +531,7 @@ impl Op for TxRefundOp {
 
 /// Represents a field parameter of the Account that can be accessed via EVM
 /// execution.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum AccountField {
     /// Account Nonce
     Nonce,
@@ -539,8 +539,8 @@ pub enum AccountField {
     Balance,
     /// Account Code Hash
     CodeHash,
-    /// Account non existing
-    NonExisting,
+    // /// Account non existing
+    // NonExisting,
 }
 
 /// Represents a change in the Account field implied by a `BeginTx`,

--- a/bus-mapping/src/state_db.rs
+++ b/bus-mapping/src/state_db.rs
@@ -178,7 +178,7 @@ impl StateDB {
     }
 
     /// Get nonce of account with `addr`.
-    pub fn get_nonce(&mut self, addr: &Address) -> u64 {
+    pub fn get_nonce(&self, addr: &Address) -> u64 {
         let (_, account) = self.get_account(addr);
         account.nonce.as_u64()
     }

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -424,6 +424,15 @@ pub mod test {
             .handle_block(&block.eth_block, &block.geth_traces)
             .unwrap();
         let block = block_convert::<Fr>(&builder.block, &builder.code_db).unwrap();
+        // for step in &block.txs[0].steps {
+        //     println!(
+        //         "DBG step {:?} rwc: {}",
+        //         step.execution_state, step.rw_counter
+        //     );
+        //     for rw_ref in &step.rw_indices {
+        //         println!("    - {:?}", block.rws[*rw_ref]);
+        //     }
+        // }
         run_test_circuit(block)
     }
 

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -424,15 +424,6 @@ pub mod test {
             .handle_block(&block.eth_block, &block.geth_traces)
             .unwrap();
         let block = block_convert::<Fr>(&builder.block, &builder.code_db).unwrap();
-        // for step in &block.txs[0].steps {
-        //     println!(
-        //         "DBG step {:?} rwc: {}",
-        //         step.execution_state, step.rw_counter
-        //     );
-        //     for rw_ref in &step.rw_indices {
-        //         println!("    - {:?}", block.rws[*rw_ref]);
-        //     }
-        // }
         run_test_circuit(block)
     }
 

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -216,7 +216,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             }
 
             cb.require_step_state_transition(StepStateTransition {
-                // 23 reads and writes:
+                // 22-23 reads and writes:
                 //   - Write CallContext TxId
                 //   - Write CallContext RwCounterEndOfReversion
                 //   - Write CallContext IsPersistent
@@ -226,7 +226,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                 //   - Write TxAccessListAccount
                 //   - Write Account Balance
                 //   - Write Account Balance
-                //   - Read Account CodeHash
+                //   - Read Account CodeHash (only if tx is not create)
                 //   - Write CallContext Depth
                 //   - Write CallContext CallerAddress
                 //   - Write CallContext CalleeAddress

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -10,7 +10,7 @@ use crate::{
                 Transition::{Delta, To},
             },
             math_gadget::{IsEqualGadget, IsZeroGadget, MulWordByU64Gadget, RangeCheckGadget},
-            select, CachedRegion, Cell, Word,
+            not, select, CachedRegion, Cell, Word,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
@@ -135,6 +135,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             None,
         );
 
+        // TODO: If value is 0, skip transfer, just like callop.
         // Transfer value from caller to callee
         let transfer_with_gas_fee = TransferWithGasFeeGadget::construct(
             cb,
@@ -150,11 +151,13 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
 
         // Read code_hash of callee
         let phase2_code_hash = cb.query_cell_phase2();
-        cb.account_read(
-            tx_callee_address.expr(),
-            AccountFieldTag::CodeHash,
-            phase2_code_hash.expr(),
-        );
+        cb.condition(not::expr(tx_is_create.expr()), |cb| {
+            cb.account_read(
+                tx_callee_address.expr(),
+                AccountFieldTag::CodeHash,
+                phase2_code_hash.expr(),
+            );
+        });
 
         let is_empty_code_hash =
             IsEqualGadget::construct(cb, phase2_code_hash.expr(), cb.empty_hash_rlc());
@@ -237,7 +240,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                 //   - Write CallContext IsRoot
                 //   - Write CallContext IsCreate
                 //   - Write CallContext CodeHash
-                rw_counter: Delta(23.expr()),
+                rw_counter: Delta(22.expr() + (1.expr() - tx_is_create.expr())),
                 call_id: To(call_id.expr()),
                 is_root: To(true.expr()),
                 is_create: To(tx_is_create.expr()),
@@ -280,9 +283,13 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
         step: &ExecStep,
     ) -> Result<(), Error> {
         let gas_fee = tx.gas_price * tx.gas;
-        let [caller_balance_pair, callee_balance_pair, (callee_code_hash, _)] =
-            [step.rw_indices[7], step.rw_indices[8], step.rw_indices[9]]
-                .map(|idx| block.rws[idx].account_value_pair());
+        let [caller_balance_pair, callee_balance_pair] =
+            [step.rw_indices[7], step.rw_indices[8]].map(|idx| block.rws[idx].account_value_pair());
+        let callee_code_hash = if tx.is_create {
+            call.code_hash
+        } else {
+            block.rws[step.rw_indices[9]].account_value_pair().0
+        };
 
         self.tx_id
             .assign(region, offset, Value::known(F::from(tx.id as u64)))?;

--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -445,7 +445,6 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
         call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
-        // dbg!(offset);
         let opcode = step.opcode.unwrap();
         let is_call = opcode == OpcodeId::CALL;
         let is_callcode = opcode == OpcodeId::CALLCODE;

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_call.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_call.rs
@@ -73,7 +73,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGCallGadget<F> {
         );
 
         // Verify gas cost
-        let gas_cost = call_gadget.gas_cost_expr(cb, is_warm.expr(), 1.expr());
+        let gas_cost = call_gadget.gas_cost_expr(is_warm.expr(), 1.expr());
 
         // Check if the amount of gas available is less than the amount of gas required
         let insufficient_gas = LtGadget::construct(cb, cb.curr.state.gas_left.expr(), gas_cost);

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_call.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_call.rs
@@ -60,14 +60,6 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGCallGadget<F> {
             is_warm.expr(),
         );
 
-        // TODO: Why is calle balance read here? There's no constraint related to this
-        // balance let balance = cb.query_word_rlc();
-        // cb.account_read(
-        //     call_gadget.callee_address_expr(),
-        //     AccountFieldTag::Balance,
-        //     balance.expr(),
-        // );
-
         // Verify gas cost
         let gas_cost = call_gadget.gas_cost_expr(is_warm.expr(), 1.expr());
 

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_call.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_call.rs
@@ -26,7 +26,6 @@ pub(crate) struct ErrorOOGCallGadget<F> {
     is_static: Cell<F>,
     call: CommonCallGadget<F, false>,
     is_warm: Cell<F>,
-    // balance: Word<F>,
     insufficient_gas: LtGadget<F, N_BYTES_GAS>,
     rw_counter_end_of_reversion: Cell<F>,
     restore_context: RestoreContextGadget<F>,
@@ -137,7 +136,6 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGCallGadget<F> {
             is_static,
             call: call_gadget,
             is_warm,
-            // balance,
             insufficient_gas,
             rw_counter_end_of_reversion,
             restore_context,
@@ -200,9 +198,6 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGCallGadget<F> {
         self.is_warm
             .assign(region, offset, Value::known(F::from(is_warm as u64)))?;
 
-        // new assignment
-        // self.balance
-        //     .assign(region, offset, Some(callee_balance_pair.0.to_le_bytes()))?;
         let has_value = !value.is_zero();
         let gas_cost = self.call.cal_gas_cost_for_assignment(
             memory_expansion_gas_cost,

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_call.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_call.rs
@@ -1,27 +1,23 @@
-use crate::table::{AccountFieldTag, CallContextFieldTag};
-use crate::util::Expr;
-use crate::{
-    evm_circuit::{
-        execution::ExecutionGadget,
-        param::N_BYTES_GAS,
-        step::ExecutionState,
-        util::{
-            common_gadget::{CommonCallGadget, RestoreContextGadget},
-            constraint_builder::{
-                ConstraintBuilder, StepStateTransition,
-                Transition::{Delta, Same},
-            },
-            math_gadget::LtGadget,
-            CachedRegion, Cell, Word,
+use crate::evm_circuit::{
+    execution::ExecutionGadget,
+    param::N_BYTES_GAS,
+    step::ExecutionState,
+    util::{
+        common_gadget::{CommonCallGadget, RestoreContextGadget},
+        constraint_builder::{
+            ConstraintBuilder, StepStateTransition,
+            Transition::{Delta, Same},
         },
-        witness::{Block, Call, ExecStep, Transaction},
+        math_gadget::LtGadget,
+        CachedRegion, Cell,
     },
-    witness::Rw,
+    witness::{Block, Call, ExecStep, Transaction},
 };
+use crate::table::CallContextFieldTag;
+use crate::util::Expr;
 use bus_mapping::evm::OpcodeId;
-use eth_types::{Field, ToLittleEndian, U256};
+use eth_types::{Field, U256};
 use halo2_proofs::{circuit::Value, plonk::Error};
-use keccak256::EMPTY_HASH_LE;
 
 #[derive(Clone, Debug)]
 pub(crate) struct ErrorOOGCallGadget<F> {
@@ -30,7 +26,7 @@ pub(crate) struct ErrorOOGCallGadget<F> {
     is_static: Cell<F>,
     call: CommonCallGadget<F, false>,
     is_warm: Cell<F>,
-    balance: Word<F>,
+    // balance: Word<F>,
     insufficient_gas: LtGadget<F, N_BYTES_GAS>,
     rw_counter_end_of_reversion: Cell<F>,
     restore_context: RestoreContextGadget<F>,
@@ -65,12 +61,13 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGCallGadget<F> {
             is_warm.expr(),
         );
 
-        let balance = cb.query_word_rlc();
-        cb.account_read(
-            call_gadget.callee_address_expr(),
-            AccountFieldTag::Balance,
-            balance.expr(),
-        );
+        // TODO: Why is calle balance read here? There's no constraint related to this
+        // balance let balance = cb.query_word_rlc();
+        // cb.account_read(
+        //     call_gadget.callee_address_expr(),
+        //     AccountFieldTag::Balance,
+        //     balance.expr(),
+        // );
 
         // Verify gas cost
         let gas_cost = call_gadget.gas_cost_expr(is_warm.expr(), 1.expr());
@@ -106,8 +103,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGCallGadget<F> {
             // Do step state transition
             cb.require_step_state_transition(StepStateTransition {
                 call_id: Same,
-                rw_counter: Delta(15.expr() + cb.curr.state.reversible_write_counter.expr()),
-
+                rw_counter: Delta(13.expr() + cb.curr.state.reversible_write_counter.expr()),
                 ..StepStateTransition::any()
             });
         });
@@ -141,7 +137,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGCallGadget<F> {
             is_static,
             call: call_gadget,
             is_warm,
-            balance,
+            // balance,
             insufficient_gas,
             rw_counter_end_of_reversion,
             restore_context,
@@ -172,21 +168,11 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGCallGadget<F> {
         ]
         .map(|idx| block.rws[idx].stack_value());
 
-        let (is_warm, is_warm_prev) = block.rws[step.rw_indices[10]].tx_access_list_value_pair();
-        let callee_balance_pair = block.rws[step.rw_indices[11]].account_value_pair();
-        let (callee_code_hash, callee_exists) = match block.rws[step.rw_indices[12]] {
-            Rw::Account {
-                field_tag: AccountFieldTag::CodeHash,
-                value,
-                ..
-            } => (value.to_le_bytes(), true),
-            Rw::Account {
-                field_tag: AccountFieldTag::NonExisting,
-                ..
-            } => (*EMPTY_HASH_LE, false),
-            _ => unreachable!(),
-        };
-        let callee_code_hash_word = region.word_rlc(U256::from_little_endian(&callee_code_hash));
+        let callee_code_hash = block.rws[step.rw_indices[10]].account_value_pair().0;
+        let callee_exists = !callee_code_hash.is_zero();
+
+        let (is_warm, is_warm_prev) = block.rws[step.rw_indices[11]].tx_access_list_value_pair();
+
         let memory_expansion_gas_cost = self.call.assign(
             region,
             offset,
@@ -199,7 +185,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGCallGadget<F> {
             rd_offset,
             rd_length,
             step.memory_word_size(),
-            callee_code_hash_word,
+            region.word_rlc(callee_code_hash),
         )?;
 
         self.opcode
@@ -215,8 +201,8 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGCallGadget<F> {
             .assign(region, offset, Value::known(F::from(is_warm as u64)))?;
 
         // new assignment
-        self.balance
-            .assign(region, offset, Some(callee_balance_pair.0.to_le_bytes()))?;
+        // self.balance
+        //     .assign(region, offset, Some(callee_balance_pair.0.to_le_bytes()))?;
         let has_value = !value.is_zero();
         let gas_cost = self.call.cal_gas_cost_for_assignment(
             memory_expansion_gas_cost,
@@ -240,7 +226,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGCallGadget<F> {
         )?;
 
         self.restore_context
-            .assign(region, offset, block, call, step, 15)?;
+            .assign(region, offset, block, call, step, 13)?;
         Ok(())
     }
 }
@@ -254,6 +240,7 @@ mod test {
     use halo2_proofs::halo2curves::bn256::Fr;
     use itertools::Itertools;
     use mock::TestContext;
+    use pretty_assertions::assert_eq;
     use std::default::Default;
 
     #[derive(Clone, Copy, Debug, Default)]
@@ -342,8 +329,8 @@ mod test {
         builder
             .handle_block(&block_data.eth_block, &block_data.geth_traces)
             .unwrap();
-        let block = block_convert::<Fr>(&builder.block, &builder.code_db);
-        assert_eq!(run_test_circuit(block.unwrap()), Ok(()));
+        let block = block_convert::<Fr>(&builder.block, &builder.code_db).unwrap();
+        assert_eq!(run_test_circuit(block), Ok(()));
     }
 
     #[test]

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_call.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_call.rs
@@ -102,7 +102,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGCallGadget<F> {
             // Do step state transition
             cb.require_step_state_transition(StepStateTransition {
                 call_id: Same,
-                rw_counter: Delta(13.expr() + cb.curr.state.reversible_write_counter.expr()),
+                rw_counter: Delta(14.expr() + cb.curr.state.reversible_write_counter.expr()),
                 ..StepStateTransition::any()
             });
         });
@@ -221,7 +221,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGCallGadget<F> {
         )?;
 
         self.restore_context
-            .assign(region, offset, block, call, step, 13)?;
+            .assign(region, offset, block, call, step, 14)?;
         Ok(())
     }
 }

--- a/zkevm-circuits/src/evm_circuit/execution/error_stack.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_stack.rs
@@ -345,8 +345,17 @@ mod test {
         builder
             .handle_block(&block_data.eth_block, &block_data.geth_traces)
             .unwrap();
-        let block = block_convert::<Fr>(&builder.block, &builder.code_db);
-        assert_eq!(run_test_circuit(block.unwrap()), Ok(()));
+        let block = block_convert::<Fr>(&builder.block, &builder.code_db).unwrap();
+        for step in &block.txs[0].steps {
+            println!(
+                "DBG step {:?} rwc: {}",
+                step.execution_state, step.rw_counter
+            );
+            for rw_ref in &step.rw_indices {
+                println!("    - {:?}", block.rws[*rw_ref]);
+            }
+        }
+        assert_eq!(run_test_circuit(block), Ok(()));
     }
 
     fn callee(code: Bytecode) -> Account {

--- a/zkevm-circuits/src/evm_circuit/execution/error_stack.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_stack.rs
@@ -346,15 +346,15 @@ mod test {
             .handle_block(&block_data.eth_block, &block_data.geth_traces)
             .unwrap();
         let block = block_convert::<Fr>(&builder.block, &builder.code_db).unwrap();
-        for step in &block.txs[0].steps {
-            println!(
-                "DBG step {:?} rwc: {}",
-                step.execution_state, step.rw_counter
-            );
-            for rw_ref in &step.rw_indices {
-                println!("    - {:?}", block.rws[*rw_ref]);
-            }
-        }
+        // for step in &block.txs[0].steps {
+        //     println!(
+        //         "DBG step {:?} rwc: {}",
+        //         step.execution_state, step.rw_counter
+        //     );
+        //     for rw_ref in &step.rw_indices {
+        //         println!("    - {:?}", block.rws[*rw_ref]);
+        //     }
+        // }
         assert_eq!(run_test_circuit(block), Ok(()));
     }
 

--- a/zkevm-circuits/src/evm_circuit/execution/error_stack.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_stack.rs
@@ -346,15 +346,6 @@ mod test {
             .handle_block(&block_data.eth_block, &block_data.geth_traces)
             .unwrap();
         let block = block_convert::<Fr>(&builder.block, &builder.code_db).unwrap();
-        // for step in &block.txs[0].steps {
-        //     println!(
-        //         "DBG step {:?} rwc: {}",
-        //         step.execution_state, step.rw_counter
-        //     );
-        //     for rw_ref in &step.rw_indices {
-        //         println!("    - {:?}", block.rws[*rw_ref]);
-        //     }
-        // }
         assert_eq!(run_test_circuit(block), Ok(()));
     }
 

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -504,7 +504,6 @@ impl<F: Field, const IS_SUCCESS_CALL: bool> CommonCallGadget<F, IS_SUCCESS_CALL>
         } else {
             0.expr()
         });
-        // DBG rwc=45
 
         // Recomposition of random linear combination to integer
         let gas_is_u64 = IsZeroGadget::construct(cb, sum::expr(&gas_word.cells[N_BYTES_GAS..]));

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -504,6 +504,7 @@ impl<F: Field, const IS_SUCCESS_CALL: bool> CommonCallGadget<F, IS_SUCCESS_CALL>
         } else {
             0.expr()
         });
+        // DBG rwc=45
 
         // Recomposition of random linear combination to integer
         let gas_is_u64 = IsZeroGadget::construct(cb, sum::expr(&gas_word.cells[N_BYTES_GAS..]));

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -522,6 +522,11 @@ impl<F: Field, const IS_SUCCESS_CALL: bool> CommonCallGadget<F, IS_SUCCESS_CALL>
         );
 
         let phase2_callee_code_hash = cb.query_cell_with_type(CellType::StoragePhase2);
+        cb.account_read(
+            from_bytes::expr(&callee_address_word.cells[..N_BYTES_ACCOUNT_ADDRESS]),
+            AccountFieldTag::CodeHash,
+            phase2_callee_code_hash.expr(),
+        );
         let is_empty_code_hash =
             IsEqualGadget::construct(cb, phase2_callee_code_hash.expr(), cb.empty_hash_rlc());
         let callee_not_exists = IsZeroGadget::construct(cb, phase2_callee_code_hash.expr());
@@ -553,16 +558,9 @@ impl<F: Field, const IS_SUCCESS_CALL: bool> CommonCallGadget<F, IS_SUCCESS_CALL>
 
     pub fn gas_cost_expr(
         &self,
-        cb: &mut ConstraintBuilder<F>,
         is_warm_prev: Expression<F>,
         is_call: Expression<F>,
     ) -> Expression<F> {
-        cb.account_read(
-            self.callee_address_expr(),
-            AccountFieldTag::CodeHash,
-            self.phase2_callee_code_hash.expr(),
-        );
-
         select::expr(
             is_warm_prev,
             GasCost::WARM_ACCESS.expr(),

--- a/zkevm-circuits/src/witness/block.rs
+++ b/zkevm-circuits/src/witness/block.rs
@@ -53,6 +53,21 @@ pub struct Block<F> {
     pub eth_block: eth_types::Block<eth_types::Transaction>,
 }
 
+impl<F: Field> Block<F> {
+    /// For each tx, for each step, print the rwc at the beginning of the step,
+    /// and all the rw operations of the step.
+    pub(crate) fn debug_print_txs_steps_rw_ops(&self) {
+        for (tx_idx, tx) in self.txs.iter().enumerate() {
+            println!("tx {}", tx_idx);
+            for step in &tx.steps {
+                println!(" step {:?} rwc: {}", step.execution_state, step.rw_counter);
+                for rw_ref in &step.rw_indices {
+                    println!("  - {:?}", self.rws[*rw_ref]);
+                }
+            }
+        }
+    }
+}
 /// Block context for execution
 #[derive(Debug, Default, Clone)]
 pub struct BlockContext {

--- a/zkevm-circuits/src/witness/rw.rs
+++ b/zkevm-circuits/src/witness/rw.rs
@@ -691,7 +691,6 @@ impl From<&operation::OperationContainer> for RwMap {
                         AccountField::Nonce => AccountFieldTag::Nonce,
                         AccountField::Balance => AccountFieldTag::Balance,
                         AccountField::CodeHash => AccountFieldTag::CodeHash,
-                        // AccountField::NonExisting => AccountFieldTag::NonExisting,
                     },
                     value: op.op().value,
                     value_prev: op.op().value_prev,

--- a/zkevm-circuits/src/witness/rw.rs
+++ b/zkevm-circuits/src/witness/rw.rs
@@ -691,7 +691,7 @@ impl From<&operation::OperationContainer> for RwMap {
                         AccountField::Nonce => AccountFieldTag::Nonce,
                         AccountField::Balance => AccountFieldTag::Balance,
                         AccountField::CodeHash => AccountFieldTag::CodeHash,
-                        AccountField::NonExisting => AccountFieldTag::NonExisting,
+                        // AccountField::NonExisting => AccountFieldTag::NonExisting,
                     },
                     value: op.op().value,
                     value_prev: op.op().value_prev,


### PR DESCRIPTION
After this was merged https://github.com/privacy-scaling-explorations/zkevm-specs/pull/354 the rule for opcodes that can access non-existing accounts is to first read the CodeHash, and only if it's not 0 (meaning that the account exists), proceed with other account field reads.  If a field read is performed to a non-existing account, this may end up mapping to an MPT account field proof for a non-existing account (which are not supported); so the MPT proof would be impossible to generate.  We can add some checks to make sure we don't implement any circuit that generates this situation; but we can even add more sanity checks to detect possible bugs early.  In particular we can check for each account field lookup (either read or write): 

- That a READ doesn't change the field value
- That the previous value matches the account field value in the StateDB
- That no read is done to a field other than CodeHash to a non-existing
  account (only CodeHash reads with value=0 can be done to non-existing
  accounts, which the State Circuit translates to MPT
  AccountNonExisting proofs lookups).

If any of these two points don't hold, the corresponding chain of MPT proofs
can't be generated.

In order to perform this checks in a single place, I've moved the logic to update the accounts in the StateDB performed by the circuit input builder in a single place, after the check (instead of requiring each bus-mapping opcode implementation to do it by themselves).

With these checks I found some bugs in the `callop` and `error_oog_call`, which I have fixed.

As a bonus I added the method `debug_print_txs_steps_rw_ops` to the `witness::Block` which prints all the rw operations (with their content) of each step in each tx, which was very useful for debugging.

Resolve https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/1084

Depends on https://github.com/privacy-scaling-explorations/zkevm-circuits/pull/1069