### PR TITLE
chore: Update halo2_proofs & halo2wrong to latest releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
- "block-padding",
+ "block-padding 0.1.5",
  "byte-tools 0.3.1",
  "byteorder",
  "generic-array 0.12.4",
@@ -290,6 +290,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
+ "block-padding 0.2.1",
  "generic-array 0.14.6",
 ]
 
@@ -310,6 +311,12 @@ checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 dependencies = [
  "byte-tools 0.3.1",
 ]
+
+[[package]]
+name = "block-padding"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "borsh"
@@ -1166,7 +1173,7 @@ dependencies = [
 [[package]]
 name = "ecc"
 version = "0.1.0"
-source = "git+https://github.com/privacy-scaling-explorations/halo2wrong?tag=v2022_09_09#2d708b4453387f03059aad68d6d87441db112a2f"
+source = "git+https://github.com/privacy-scaling-explorations/halo2wrong?tag=v2023_01_20#aa1699b0ce988f7959d155f0db23d212cb7139ee"
 dependencies = [
  "group",
  "integer",
@@ -1180,7 +1187,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.1.0"
-source = "git+https://github.com/privacy-scaling-explorations/halo2wrong?tag=v2022_09_09#2d708b4453387f03059aad68d6d87441db112a2f"
+source = "git+https://github.com/privacy-scaling-explorations/halo2wrong?tag=v2023_01_20#aa1699b0ce988f7959d155f0db23d212cb7139ee"
 dependencies = [
  "ecc",
  "group",
@@ -1985,7 +1992,7 @@ dependencies = [
 [[package]]
 name = "halo2_proofs"
 version = "0.2.0"
-source = "git+https://github.com/privacy-scaling-explorations/halo2.git?tag=v2022_09_10#a9e99a72a65d7c98e8a4258c2c94269c834d1c10"
+source = "git+https://github.com/privacy-scaling-explorations/halo2.git?tag=v2023_01_20#c7e42e41f8141745ba0b90213438f240d55cb347"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -1993,13 +2000,14 @@ dependencies = [
  "halo2curves",
  "rand_core",
  "rayon",
+ "sha3 0.9.1",
  "tracing",
 ]
 
 [[package]]
 name = "halo2curves"
-version = "0.2.1"
-source = "git+https://github.com/privacy-scaling-explorations/halo2curves?tag=0.2.1#f75ed26c961179186e9cec02cc3f841ca9e3fec1"
+version = "0.3.1"
+source = "git+https://github.com/privacy-scaling-explorations/halo2curves.git?tag=0.3.1#9b67e19bca30a35208b0c1b41c1723771e2c9f49"
 dependencies = [
  "ff",
  "group",
@@ -2016,7 +2024,7 @@ dependencies = [
 [[package]]
 name = "halo2wrong"
 version = "0.1.0"
-source = "git+https://github.com/privacy-scaling-explorations/halo2wrong?tag=v2022_09_09#2d708b4453387f03059aad68d6d87441db112a2f"
+source = "git+https://github.com/privacy-scaling-explorations/halo2wrong?tag=v2023_01_20#aa1699b0ce988f7959d155f0db23d212cb7139ee"
 dependencies = [
  "group",
  "halo2_proofs 0.2.0",
@@ -2321,7 +2329,7 @@ dependencies = [
 [[package]]
 name = "integer"
 version = "0.1.0"
-source = "git+https://github.com/privacy-scaling-explorations/halo2wrong?tag=v2022_09_09#2d708b4453387f03059aad68d6d87441db112a2f"
+source = "git+https://github.com/privacy-scaling-explorations/halo2wrong?tag=v2023_01_20#aa1699b0ce988f7959d155f0db23d212cb7139ee"
 dependencies = [
  "group",
  "maingate",
@@ -2576,7 +2584,7 @@ dependencies = [
 [[package]]
 name = "maingate"
 version = "0.1.0"
-source = "git+https://github.com/privacy-scaling-explorations/halo2wrong?tag=v2022_09_09#2d708b4453387f03059aad68d6d87441db112a2f"
+source = "git+https://github.com/privacy-scaling-explorations/halo2wrong?tag=v2023_01_20#aa1699b0ce988f7959d155f0db23d212cb7139ee"
 dependencies = [
  "group",
  "halo2wrong",
@@ -3892,6 +3900,18 @@ dependencies = [
  "byte-tools 0.2.0",
  "digest 0.7.6",
  "keccak",
+]
+
+[[package]]
+name = "sha3"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "keccak",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [patch.crates-io]
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2022_09_10" }
+halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_01_20" }
 
 # Definition of benchmarks profile to use.
 [profile.bench]

--- a/bus-mapping/Cargo.toml
+++ b/bus-mapping/Cargo.toml
@@ -13,7 +13,7 @@ mock = { path = "../mock", optional = true }
 
 ethers-core = "0.17.0"
 ethers-providers = "0.17.0"
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2022_09_10" }
+halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_01_20" }
 itertools = "0.10"
 lazy_static = "1.4"
 log = "0.4.14"

--- a/circuit-benchmarks/Cargo.toml
+++ b/circuit-benchmarks/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2022_09_10" }
+halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_01_20" }
 ark-std = { version = "0.3", features = ["print-trace"] }
 zkevm-circuits = { path = "../zkevm-circuits", features = ["test"]}
 keccak256 = { path = "../keccak256" }

--- a/eth-types/Cargo.toml
+++ b/eth-types/Cargo.toml
@@ -10,7 +10,7 @@ ethers-core = "0.17.0"
 ethers-signers = "0.17.0"
 hex = "0.4"
 lazy_static = "1.4"
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2022_09_10" }
+halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_01_20" }
 regex = "1.5.4"
 serde = {version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.66"

--- a/gadgets/Cargo.toml
+++ b/gadgets/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["The appliedzkp team"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2022_09_10" }
+halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_01_20" }
 sha3 = "0.7.2"
 eth-types = { path = "../eth-types" }
 digest = "0.7.6"

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -19,7 +19,7 @@ url = "2.2.2"
 pretty_assertions = "1.0.0"
 log = "0.4.14"
 env_logger = "0.9"
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2022_09_10" }
+halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_01_20" }
 rand_chacha = "0.3"
 paste = "1.0"
 rand_xorshift = "0.3.0"

--- a/testool/Cargo.toml
+++ b/testool/Cargo.toml
@@ -33,7 +33,7 @@ yaml-rust = "0.4.5"
 zkevm-circuits = { path="../zkevm-circuits", features=["test"] }
 rand_chacha = "0.3"
 rand = "0.8"
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2022_09_10" }
+halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_01_20" }
 
 
 [features]

--- a/zkevm-circuits/Cargo.toml
+++ b/zkevm-circuits/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2022_09_10" }
+halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_01_20" }
 num = "0.4"
 sha3 = "0.10"
 array-init = "2.0.0"
@@ -27,10 +27,10 @@ lazy_static = "1.4"
 keccak256 = { path = "../keccak256"}
 log = "0.4"
 env_logger = "0.9"
-ecdsa = { git = "https://github.com/privacy-scaling-explorations/halo2wrong", tag = "v2022_09_09" }
-ecc =       { git = "https://github.com/privacy-scaling-explorations/halo2wrong", tag = "v2022_09_09" }
-maingate =  { git = "https://github.com/privacy-scaling-explorations/halo2wrong", tag = "v2022_09_09" }
-integer =   { git = "https://github.com/privacy-scaling-explorations/halo2wrong", tag = "v2022_09_09" }
+ecdsa = { git = "https://github.com/privacy-scaling-explorations/halo2wrong", tag = "v2023_01_20" }
+ecc =       { git = "https://github.com/privacy-scaling-explorations/halo2wrong", tag = "v2023_01_20" }
+maingate =  { git = "https://github.com/privacy-scaling-explorations/halo2wrong", tag = "v2023_01_20" }
+integer =   { git = "https://github.com/privacy-scaling-explorations/halo2wrong", tag = "v2023_01_20" }
 libsecp256k1 = "0.7"
 num-bigint = { version = "0.4" }
 subtle = "2.4"


### PR DESCRIPTION
Updates:
- halo2_proofs to `v2023_01_20`
- halo2wrong to `v2023_01_20`

Resolves: #1085