### PR TITLE
fix: Revert empty row inclusion in MPT table

### DIFF
--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -534,9 +534,8 @@ impl MptTable {
         updates: &MptUpdates,
         randomness: Value<F>,
     ) -> Result<(), Error> {
-        self.assign(region, 0, &MptUpdateRow([Value::known(F::zero()); 7]))?;
         for (offset, row) in updates.table_assignments(randomness).iter().enumerate() {
-            self.assign(region, offset + 1, row)?;
+            self.assign(region, offset, row)?;
         }
         Ok(())
     }


### PR DESCRIPTION
With the new halo2_proofs release added in #1094, we no longer need to have an empty row for the mpt table so that the error reporting functions don't panic on finding a Region with no rows.

Resolves: #1032