### PR TITLE
Exp circuit annotations

### DIFF
--- a/gadgets/src/mul_add.rs
+++ b/gadgets/src/mul_add.rs
@@ -363,6 +363,36 @@ impl<F: Field> MulAddChip<F> {
 
         Ok(())
     }
+
+    /// Returns the list of ALL the gadget advice columns.
+    fn advice_columns(&self) -> Vec<Column<Advice>> {
+        vec![
+            self.config.col0,
+            self.config.col1,
+            self.config.col2,
+            self.config.col3,
+            self.config.col4,
+        ]
+    }
+
+    /// Returns the String annotations associated to each column of the gadget.
+    pub fn annotations(&self) -> Vec<String> {
+        vec![
+            String::from("col0"),
+            String::from("col1"),
+            String::from("col2"),
+            String::from("col3"),
+            String::from("col4"),
+        ]
+    }
+
+    /// Annotates columns of this gadget embedded within a circuit region.
+    pub fn annotate_columns_in_region(&self, region: &mut Region<F>, prefix: &str) {
+        self.advice_columns()
+            .iter()
+            .zip(self.annotations().iter())
+            .for_each(|(&col, ann)| region.name_column(|| format!("{}_{}", prefix, ann), col))
+    }
 }
 
 #[cfg(test)]

--- a/zkevm-circuits/src/exp_circuit.rs
+++ b/zkevm-circuits/src/exp_circuit.rs
@@ -276,6 +276,8 @@ impl<F: Field> SubCircuitConfig<F> for ExpCircuitConfig<F> {
             ]))
         });
 
+        exp_table.annotate_columns(meta);
+
         Self {
             q_usable,
             exp_table,
@@ -305,6 +307,10 @@ impl<F: Field> ExpCircuitConfig<F> {
         layouter.assign_region(
             || "exponentiation circuit",
             |mut region| {
+                mul_chip.annotate_columns_in_region(&mut region, "EXP_mul");
+                parity_check_chip.annotate_columns_in_region(&mut region, "EXP_parity_check");
+                self.exp_table.annotate_columns_in_region(&mut region);
+
                 let mut offset = 0;
                 for exp_event in exp_events.iter() {
                     self.assign_exp_event(


### PR DESCRIPTION
### Description

Adds columns annotations to Exp circuit.

### Issue Link

Part of https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/1106

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Contents

- Adds columns annotations to Exp circuit.

### Rationale

Following example linked in issue.

### How Has This Been Tested?

Compilation didn't yield errors.

### Note

Not sure if calling `exp_table.annotate_columns(meta);` as has been done in execution gadget, I guess it can be done twice without problem.
