### PR TITLE
Annotate execution circuit q_step column

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -981,6 +981,7 @@ impl<F: Field> ExecutionConfig<F> {
             }
         }
 
+        region.name_column(|| "EVM_q_step", self.q_step);
         region.name_column(|| "EVM_num_rows_inv", self.num_rows_inv);
         region.name_column(|| "EVM_rows_until_next_step", self.num_rows_until_next_step);
         region.name_column(|| "Copy_Constr_const", self.constants);


### PR DESCRIPTION
### Description

Annotate execution circuit q_step column

### Issue Link

Part of https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/1106

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Contents

- Annotate execution circuit q_step column

### Rationale

Following example linked in issue.

### How Has This Been Tested?

Compilation didn't fail.

