### PR TITLE
Refactor/column annotation

### DIFF
--- a/gadgets/src/binary_number.rs
+++ b/gadgets/src/binary_number.rs
@@ -2,7 +2,7 @@
 //! in binary bits, which can be compared against a value or expression for
 //! equality.
 
-use crate::util::{and, not, Expr};
+use crate::util::{and, assign_advice, not, Expr};
 use eth_types::Field;
 use halo2_proofs::{
     circuit::{Region, Value},
@@ -176,12 +176,13 @@ where
         value: &T,
     ) -> Result<(), Error> {
         for (&bit, &column) in value.as_bits().iter().zip(&self.config.bits) {
-            region.name_column(|| format!("GADGETS_binary_number_{:?}", column), column);
-            region.assign_advice(
+            assign_advice(
+                region,
                 || format!("binary number {:?}", column),
                 column,
                 offset,
                 || Value::known(F::from(bit)),
+                || "GADGETS".to_string(),
             )?;
         }
         Ok(())

--- a/gadgets/src/util.rs
+++ b/gadgets/src/util.rs
@@ -237,7 +237,8 @@ pub fn split_u256_limb64(value: &U256) -> [U256; 4] {
     ]
 }
 
-/// wrap up multiple Region.assign_advice and a single Region.name_column
+/// wrap up Region.assign_advice and Region.name_column
+/// it supports to assign multiple values to a single column
 pub fn assign_advice_multi_value<VR, AR, F: Field>(
     region: &mut Region<F>,
     annotation: impl Fn() -> AR,
@@ -267,7 +268,7 @@ where
     Ok(assigned_cells)
 }
 
-/// wrap up a single Region.assign_advice and a single Region.name_column
+/// wrap up Region.assign_advice and Region.name_column
 pub fn assign_advice<VR, V, AR, F: Field>(
     region: &mut Region<F>,
     annotation: impl Fn() -> AR,
@@ -288,7 +289,8 @@ where
     region.assign_advice(&|| annotation().into(), column, offset, to)
 }
 
-/// wrap up multiple Region.assign_fixed and a single Region.name_column
+/// wrap up Region.assign_fixed andRegion.name_column
+/// it supports to assign multiple values to a single column
 pub fn assign_fixed_multi_value<VR, AR, F: Field>(
     region: &mut Region<F>,
     annotation: impl Fn() -> AR,
@@ -318,7 +320,7 @@ where
     Ok(assigned_cells)
 }
 
-/// wrap up a single Region.assign_advice and a single Region.name_column
+/// wrap up Region.assign_advice and Region.name_column
 pub fn assign_fixed<VR, V, AR, F: Field>(
     region: &mut Region<F>,
     annotation: impl Fn() -> AR,

--- a/gadgets/src/util.rs
+++ b/gadgets/src/util.rs
@@ -238,7 +238,7 @@ pub fn split_u256_limb64(value: &U256) -> [U256; 4] {
 }
 
 /// wrap up multiple Region.assign_advice and a single Region.name_column
-pub fn assign_advice<VR, AR, F: Field>(
+pub fn assign_advice_multi_value<VR, AR, F: Field>(
     region: &mut Region<F>,
     annotation: impl Fn() -> AR,
     column: Column<Advice>,
@@ -260,9 +260,7 @@ where
         .iter()
         .zip(offsets.iter())
         .map(|(v, offset)| {
-            region.assign_advice(&|| annotation().into(), column, offset.clone(), || {
-                v.clone()
-            })
+            region.assign_advice(&|| annotation().into(), column, *offset, || v.clone())
         })
         .collect::<Result<Vec<_>, _>>()?;
 
@@ -270,7 +268,7 @@ where
 }
 
 /// wrap up a single Region.assign_advice and a single Region.name_column
-pub fn assign_advice_single<VR, V, AR, F: Field>(
+pub fn assign_advice<VR, V, AR, F: Field>(
     region: &mut Region<F>,
     annotation: impl Fn() -> AR,
     column: Column<Advice>,
@@ -291,7 +289,7 @@ where
 }
 
 /// wrap up multiple Region.assign_fixed and a single Region.name_column
-pub fn assign_fixed<VR, AR, F: Field>(
+pub fn assign_fixed_multi_value<VR, AR, F: Field>(
     region: &mut Region<F>,
     annotation: impl Fn() -> AR,
     column: Column<Fixed>,
@@ -313,9 +311,7 @@ where
         .iter()
         .zip(offsets.iter())
         .map(|(v, offset)| {
-            region.assign_fixed(&|| annotation().into(), column, offset.clone(), || {
-                v.clone()
-            })
+            region.assign_fixed(&|| annotation().into(), column, *offset, || v.clone())
         })
         .collect::<Result<Vec<_>, _>>()?;
 
@@ -323,7 +319,7 @@ where
 }
 
 /// wrap up a single Region.assign_advice and a single Region.name_column
-pub fn assign_fixed_single<VR, V, AR, F: Field>(
+pub fn assign_fixed<VR, V, AR, F: Field>(
     region: &mut Region<F>,
     annotation: impl Fn() -> AR,
     column: Column<Fixed>,

--- a/zkevm-circuits/src/state_circuit.rs
+++ b/zkevm-circuits/src/state_circuit.rs
@@ -18,7 +18,7 @@ use eth_types::{Address, Field, ToLittleEndian};
 use gadgets::{
     batched_is_zero::{BatchedIsZeroChip, BatchedIsZeroConfig},
     binary_number::{BinaryNumberChip, BinaryNumberConfig},
-    util::{assign_advice_single, assign_fixed_single},
+    util::{assign_advice, assign_fixed},
 };
 use halo2_proofs::{
     circuit::{Layouter, Region, SimpleFloorPlanner, Value},
@@ -225,7 +225,7 @@ impl<F: Field> StateCircuitConfig<F> {
                 log::trace!("state circuit assign offset:{} row:{:#?}", offset, row);
             }
 
-            assign_fixed_single(
+            assign_fixed(
                 region,
                 || "selector",
                 self.selector,
@@ -261,7 +261,7 @@ impl<F: Field> StateCircuitConfig<F> {
                 let is_first_access =
                     !matches!(index, LimbIndex::RwCounter0 | LimbIndex::RwCounter1);
 
-                assign_advice_single(
+                assign_advice(
                     region,
                     || "not_first_access",
                     self.not_first_access,
@@ -300,7 +300,7 @@ impl<F: Field> StateCircuitConfig<F> {
                     .map(|u| u.value_assignments(randomness).1)
                     .unwrap_or_default()
             });
-            assign_advice_single(
+            assign_advice(
                 region,
                 || "initial_value",
                 self.initial_value,
@@ -345,7 +345,7 @@ impl<F: Field> StateCircuitConfig<F> {
                     _ => 0,
                 })
             });
-            assign_advice_single(
+            assign_advice(
                 region,
                 || "mpt_proof_type",
                 self.mpt_proof_type,
@@ -358,7 +358,7 @@ impl<F: Field> StateCircuitConfig<F> {
             // State root assignment is at previous row (offset - 1) because the state root
             // changes on the last access row.
             if offset != 0 {
-                assign_advice_single(
+                assign_advice(
                     region,
                     || "state_root",
                     self.state_root,
@@ -378,7 +378,7 @@ impl<F: Field> StateCircuitConfig<F> {
                         new_root
                     });
                 }
-                assign_advice_single(
+                assign_advice(
                     region,
                     || "last row state_root",
                     self.state_root,
@@ -489,7 +489,7 @@ impl<F: Field> SubCircuit<F> for StateCircuit<F> {
                         let offset =
                             usize::try_from(isize::try_from(padding_length).unwrap() + *row_offset)
                                 .unwrap();
-                        assign_advice_single(
+                        assign_advice(
                             &mut region,
                             || "override",
                             advice_column,

--- a/zkevm-circuits/src/state_circuit/lookups.rs
+++ b/zkevm-circuits/src/state_circuit/lookups.rs
@@ -1,6 +1,6 @@
 use crate::table::CallContextFieldTag;
 use eth_types::Field;
-use gadgets::util::assign_fixed;
+use gadgets::util::assign_fixed_multi_value;
 use halo2_proofs::{
     circuit::{Layouter, Value},
     plonk::{Column, ConstraintSystem, Error, Expression, Fixed, VirtualCells},
@@ -110,7 +110,7 @@ impl<F: Field> Chip<F> {
                     for i in 0..(1 << exponent) {
                         offsets.push(i as usize);
                     }
-                    assign_fixed(
+                    assign_fixed_multi_value(
                         &mut region,
                         || format!("fixed_u{}", exponent),
                         column,
@@ -132,7 +132,7 @@ impl<F: Field> Chip<F> {
                 for field_tag in CallContextFieldTag::iter() {
                     offsets.push(field_tag as usize);
                 }
-                assign_fixed(
+                assign_fixed_multi_value(
                     &mut region,
                     || "call_context_field_tag",
                     self.config.call_context_field_tag,

--- a/zkevm-circuits/src/state_circuit/multiple_precision_integer.rs
+++ b/zkevm-circuits/src/state_circuit/multiple_precision_integer.rs
@@ -2,6 +2,7 @@ use super::lookups;
 use super::{N_LIMBS_ACCOUNT_ADDRESS, N_LIMBS_RW_COUNTER};
 use crate::util::Expr;
 use eth_types::{Address, Field};
+use gadgets::util::assign_advice;
 use halo2_proofs::{
     circuit::{Layouter, Region, Value},
     plonk::{Advice, Column, ConstraintSystem, Error, Expression, Fixed, VirtualCells},
@@ -67,12 +68,13 @@ impl Config<Address, N_LIMBS_ACCOUNT_ADDRESS> {
         value: Address,
     ) -> Result<(), Error> {
         for (i, &limb) in value.to_limbs().iter().enumerate() {
-            region.name_column(|| format!("STATE_MPI_limb[{}]_address", i), self.limbs[i]);
-            region.assign_advice(
-                || format!("limb[{}] in address mpi", i),
+            assign_advice(
+                region,
+                || format!("limb[{}]_address", i),
                 self.limbs[i],
                 offset,
                 || Value::known(F::from(limb as u64)),
+                || "STATE_MPI".to_string(),
             )?;
         }
         Ok(())
@@ -87,12 +89,13 @@ impl Config<u32, N_LIMBS_RW_COUNTER> {
         value: u32,
     ) -> Result<(), Error> {
         for (i, &limb) in value.to_limbs().iter().enumerate() {
-            region.name_column(|| format!("STATE_MPI_limb[{}]_u32", i), self.limbs[i]);
-            region.assign_advice(
-                || format!("limb[{}] in u32 mpi", i),
+            assign_advice(
+                region,
+                || format!("limb[{}]_u32", i),
                 self.limbs[i],
                 offset,
                 || Value::known(F::from(limb as u64)),
+                || "STATE_MPI".to_string(),
             )?;
         }
         Ok(())

--- a/zkevm-circuits/src/state_circuit/random_linear_combination.rs
+++ b/zkevm-circuits/src/state_circuit/random_linear_combination.rs
@@ -1,5 +1,6 @@
 use crate::evm_circuit::util::rlc;
 use eth_types::{Field, ToLittleEndian, U256};
+use gadgets::util::assign_advice;
 use halo2_proofs::{
     circuit::{Layouter, Region, Value},
     plonk::{Advice, Column, ConstraintSystem, Error, Expression, Fixed, VirtualCells},
@@ -38,12 +39,13 @@ impl<const N: usize> Config<N> {
     ) -> Result<(), Error> {
         let bytes = value.to_le_bytes();
         for (i, &byte) in bytes.iter().enumerate() {
-            region.name_column(|| format!("STATE_RLC_byte[{}]", i), self.bytes[i]);
-            region.assign_advice(
-                || format!("byte[{}] in rlc", i),
+            assign_advice(
+                region,
+                || format!("byte[{}]", i),
                 self.bytes[i],
                 offset,
                 || Value::known(F::from(byte as u64)),
+                || "STATE_RLC".to_string(),
             )?;
         }
         Ok(())


### PR DESCRIPTION
### Description

Trying to mitigating the effort of adding column annotation. Having a set of util functions, `assign_fixed`, `assign_advice`, `assign_fixed_multi_value` and `assign_advice_multi_value`. It calls `name_column` and `assign_fixed` or `assign_advice` accordingly in these utils functions 
- pros:
  - it's easier to add annotations
- cons:
  - it would be missing the annotation for each cell, like [here](https://github.com/privacy-scaling-explorations/zkevm-circuits/pull/1174/files#diff-c6e71bd5ec1e036ab77c032b5f67c9c7a772d54d81dcb08e9246e22dcd3d9d5eL107), but Han has confirmed that on one is using it right now. 

### Issue Link

na

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Contents

- Embedding `name_column` in util functions.

### Rationale

mitigating the effort of adding column annotation and to avoid missing any column annotation.

### How Has This Been Tested?

Pass all the test cases.
