### PR TITLE
uniform log messages for benchmark proof generation/verification

### DIFF
--- a/circuit-benchmarks/src/bytecode_circuit.rs
+++ b/circuit-benchmarks/src/bytecode_circuit.rs
@@ -31,6 +31,9 @@ mod tests {
             .parse()
             .expect("Cannot parse DEGREE env var as u32");
 
+        //Unique string used by bench results module for parsing the result
+        const BENCHMARK_ID: &str = "Bytecode Circuit";
+
         // Contract code size exceeds 24576 bytes may not be deployable on Mainnet.
         const MAX_BYTECODE_LEN: usize = 24576;
 
@@ -67,7 +70,7 @@ mod tests {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!("Bytecode Circuit Proof generation with {} rows", degree);
+        let proof_message = format!("{} Proof generation with degree = {}",BENCHMARK_ID, degree);
         let start2 = start_timer!(|| proof_message);
         create_proof::<
             KZGCommitmentScheme<Bn256>,
@@ -88,8 +91,8 @@ mod tests {
         let proof = transcript.finalize();
         end_timer!(start2);
 
-        // Bench verification time
-        let start3 = start_timer!(|| "Bytecode Circuit Proof verification");
+        // Bench verification time      
+        let start3 = start_timer!(|| format!("{} Proof verification", BENCHMARK_ID));
         let mut verifier_transcript = Blake2bRead::<_, G1Affine, Challenge255<_>>::init(&proof[..]);
         let strategy = SingleStrategy::new(&general_params);
 

--- a/circuit-benchmarks/src/bytecode_circuit.rs
+++ b/circuit-benchmarks/src/bytecode_circuit.rs
@@ -70,7 +70,7 @@ mod tests {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!("{} Proof generation with degree = {}",BENCHMARK_ID, degree);
+        let proof_message = format!("{} Proof generation with degree = {}", BENCHMARK_ID, degree);
         let start2 = start_timer!(|| proof_message);
         create_proof::<
             KZGCommitmentScheme<Bn256>,
@@ -91,7 +91,7 @@ mod tests {
         let proof = transcript.finalize();
         end_timer!(start2);
 
-        // Bench verification time      
+        // Bench verification time
         let start3 = start_timer!(|| format!("{} Proof verification", BENCHMARK_ID));
         let mut verifier_transcript = Blake2bRead::<_, G1Affine, Challenge255<_>>::init(&proof[..]);
         let strategy = SingleStrategy::new(&general_params);

--- a/circuit-benchmarks/src/bytecode_circuit.rs
+++ b/circuit-benchmarks/src/bytecode_circuit.rs
@@ -67,7 +67,7 @@ mod tests {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!("Bytecode Proof generation with {} rows", degree);
+        let proof_message = format!("Bytecode Circuit Proof generation with {} rows", degree);
         let start2 = start_timer!(|| proof_message);
         create_proof::<
             KZGCommitmentScheme<Bn256>,
@@ -89,7 +89,7 @@ mod tests {
         end_timer!(start2);
 
         // Bench verification time
-        let start3 = start_timer!(|| "Bytecode Proof verification");
+        let start3 = start_timer!(|| "Bytecode Circuit Proof verification");
         let mut verifier_transcript = Blake2bRead::<_, G1Affine, Challenge255<_>>::init(&proof[..]);
         let strategy = SingleStrategy::new(&general_params);
 

--- a/circuit-benchmarks/src/copy_circuit.rs
+++ b/circuit-benchmarks/src/copy_circuit.rs
@@ -62,7 +62,7 @@ mod tests {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!("{} Proof generation with degree = {}",BENCHMARK_ID, degree);
+        let proof_message = format!("{} Proof generation with degree = {}", BENCHMARK_ID, degree);
         let start2 = start_timer!(|| proof_message);
         create_proof::<
             KZGCommitmentScheme<Bn256>,
@@ -76,7 +76,7 @@ mod tests {
         let proof = transcript.finalize();
         end_timer!(start2);
 
-        // Bench verification time      
+        // Bench verification time
         let start3 = start_timer!(|| format!("{} Proof verification", BENCHMARK_ID));
         let mut verifier_transcript = Blake2bRead::<_, G1Affine, Challenge255<_>>::init(&proof[..]);
         let strategy = SingleStrategy::new(&general_params);

--- a/circuit-benchmarks/src/copy_circuit.rs
+++ b/circuit-benchmarks/src/copy_circuit.rs
@@ -35,6 +35,9 @@ mod tests {
             .parse()
             .expect("Cannot parse DEGREE env var as u32");
 
+        //Unique string used by bench results module for parsing the result
+        const BENCHMARK_ID: &str = "Copy Circuit";
+
         // Initialize the polynomial commitment parameters
         let mut rng = XorShiftRng::from_seed([
             0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06,
@@ -59,7 +62,7 @@ mod tests {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!("Copy Circuit Proof generation with {} rows", degree);
+        let proof_message = format!("{} Proof generation with degree = {}",BENCHMARK_ID, degree);
         let start2 = start_timer!(|| proof_message);
         create_proof::<
             KZGCommitmentScheme<Bn256>,
@@ -73,8 +76,8 @@ mod tests {
         let proof = transcript.finalize();
         end_timer!(start2);
 
-        // Bench verification time
-        let start3 = start_timer!(|| "Copy Circuit Proof verification");
+        // Bench verification time      
+        let start3 = start_timer!(|| format!("{} Proof verification", BENCHMARK_ID));
         let mut verifier_transcript = Blake2bRead::<_, G1Affine, Challenge255<_>>::init(&proof[..]);
         let strategy = SingleStrategy::new(&general_params);
 

--- a/circuit-benchmarks/src/copy_circuit.rs
+++ b/circuit-benchmarks/src/copy_circuit.rs
@@ -59,7 +59,7 @@ mod tests {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!("Copy_circuit Proof generation with {} rows", degree);
+        let proof_message = format!("Copy Circuit Proof generation with {} rows", degree);
         let start2 = start_timer!(|| proof_message);
         create_proof::<
             KZGCommitmentScheme<Bn256>,
@@ -74,7 +74,7 @@ mod tests {
         end_timer!(start2);
 
         // Bench verification time
-        let start3 = start_timer!(|| "Copy_circuit Proof verification");
+        let start3 = start_timer!(|| "Copy Circuit Proof verification");
         let mut verifier_transcript = Blake2bRead::<_, G1Affine, Challenge255<_>>::init(&proof[..]);
         let strategy = SingleStrategy::new(&general_params);
 

--- a/circuit-benchmarks/src/evm_circuit.rs
+++ b/circuit-benchmarks/src/evm_circuit.rs
@@ -69,7 +69,7 @@ mod evm_circ_benches {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!("{} Proof generation with degree = {}",BENCHMARK_ID, degree);
+        let proof_message = format!("{} Proof generation with degree = {}", BENCHMARK_ID, degree);
         let start2 = start_timer!(|| proof_message);
         create_proof::<
             KZGCommitmentScheme<Bn256>,
@@ -90,7 +90,7 @@ mod evm_circ_benches {
         let proof = transcript.finalize();
         end_timer!(start2);
 
-        // Bench verification time      
+        // Bench verification time
         let start3 = start_timer!(|| format!("{} Proof verification", BENCHMARK_ID));
         let mut verifier_transcript = Blake2bRead::<_, G1Affine, Challenge255<_>>::init(&proof[..]);
         let strategy = SingleStrategy::new(&general_params);

--- a/circuit-benchmarks/src/evm_circuit.rs
+++ b/circuit-benchmarks/src/evm_circuit.rs
@@ -66,7 +66,7 @@ mod evm_circ_benches {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!("EVM circuit Proof generation with degree = {}", degree);
+        let proof_message = format!("EVM Circuit Proof generation with degree = {}", degree);
         let start2 = start_timer!(|| proof_message);
         create_proof::<
             KZGCommitmentScheme<Bn256>,
@@ -88,7 +88,7 @@ mod evm_circ_benches {
         end_timer!(start2);
 
         // Bench verification time
-        let start3 = start_timer!(|| "EVM circuit Proof verification");
+        let start3 = start_timer!(|| "EVM Circuit Proof verification");
         let mut verifier_transcript = Blake2bRead::<_, G1Affine, Challenge255<_>>::init(&proof[..]);
         let strategy = SingleStrategy::new(&general_params);
 

--- a/circuit-benchmarks/src/evm_circuit.rs
+++ b/circuit-benchmarks/src/evm_circuit.rs
@@ -25,6 +25,9 @@ mod evm_circ_benches {
     #[cfg_attr(not(feature = "benches"), ignore)]
     #[test]
     fn bench_evm_circuit_prover() {
+        //Unique string used by bench results module for parsing the result
+        const BENCHMARK_ID: &str = "EVM Circuit";
+
         let degree: u32 = var("DEGREE")
             .expect("No DEGREE env var was provided")
             .parse()
@@ -66,7 +69,7 @@ mod evm_circ_benches {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!("EVM Circuit Proof generation with degree = {}", degree);
+        let proof_message = format!("{} Proof generation with degree = {}",BENCHMARK_ID, degree);
         let start2 = start_timer!(|| proof_message);
         create_proof::<
             KZGCommitmentScheme<Bn256>,
@@ -87,8 +90,8 @@ mod evm_circ_benches {
         let proof = transcript.finalize();
         end_timer!(start2);
 
-        // Bench verification time
-        let start3 = start_timer!(|| "EVM Circuit Proof verification");
+        // Bench verification time      
+        let start3 = start_timer!(|| format!("{} Proof verification", BENCHMARK_ID));
         let mut verifier_transcript = Blake2bRead::<_, G1Affine, Challenge255<_>>::init(&proof[..]);
         let strategy = SingleStrategy::new(&general_params);
 

--- a/circuit-benchmarks/src/exp_circuit.rs
+++ b/circuit-benchmarks/src/exp_circuit.rs
@@ -66,7 +66,7 @@ mod tests {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!("{} Proof generation with degree = {}",BENCHMARK_ID, DEGREE);
+        let proof_message = format!("{} Proof generation with degree = {}", BENCHMARK_ID, DEGREE);
         let start2 = start_timer!(|| proof_message);
         create_proof::<
             KZGCommitmentScheme<Bn256>,
@@ -87,7 +87,7 @@ mod tests {
         let proof = transcript.finalize();
         end_timer!(start2);
 
-        // Bench verification time      
+        // Bench verification time
         let start3 = start_timer!(|| format!("{} Proof verification", BENCHMARK_ID));
         let mut verifier_transcript = Blake2bRead::<_, G1Affine, Challenge255<_>>::init(&proof[..]);
         let strategy = SingleStrategy::new(&general_params);

--- a/circuit-benchmarks/src/exp_circuit.rs
+++ b/circuit-benchmarks/src/exp_circuit.rs
@@ -33,6 +33,9 @@ mod tests {
     fn bench_exp_circuit_prover() {
         env_logger::Builder::from_env(Env::default().default_filter_or("debug")).init();
 
+        //Unique string used by bench results module for parsing the result
+        const BENCHMARK_ID: &str = "Exp Circuit";
+
         // Initialize the circuit
 
         let base = Word::from(132);
@@ -63,7 +66,7 @@ mod tests {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!("Exp Circuit Proof generation with degree = {}", DEGREE);
+        let proof_message = format!("{} Proof generation with degree = {}",BENCHMARK_ID, DEGREE);
         let start2 = start_timer!(|| proof_message);
         create_proof::<
             KZGCommitmentScheme<Bn256>,
@@ -84,8 +87,8 @@ mod tests {
         let proof = transcript.finalize();
         end_timer!(start2);
 
-        // Bench verification time
-        let start3 = start_timer!(|| "Exp Circuit Proof verification");
+        // Bench verification time      
+        let start3 = start_timer!(|| format!("{} Proof verification", BENCHMARK_ID));
         let mut verifier_transcript = Blake2bRead::<_, G1Affine, Challenge255<_>>::init(&proof[..]);
         let strategy = SingleStrategy::new(&general_params);
 

--- a/circuit-benchmarks/src/packed_multi_keccak.rs
+++ b/circuit-benchmarks/src/packed_multi_keccak.rs
@@ -56,7 +56,7 @@ mod tests {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!("{} Proof generation with degree = {}",BENCHMARK_ID, degree);
+        let proof_message = format!("{} Proof generation with degree = {}", BENCHMARK_ID, degree);
         let start2 = start_timer!(|| proof_message);
         create_proof::<
             KZGCommitmentScheme<Bn256>,
@@ -77,7 +77,7 @@ mod tests {
         let proof = transcript.finalize();
         end_timer!(start2);
 
-        // Bench verification time      
+        // Bench verification time
         let start3 = start_timer!(|| format!("{} Proof verification", BENCHMARK_ID));
         let mut verifier_transcript = Blake2bRead::<_, G1Affine, Challenge255<_>>::init(&proof[..]);
         let strategy = SingleStrategy::new(&general_params);

--- a/circuit-benchmarks/src/packed_multi_keccak.rs
+++ b/circuit-benchmarks/src/packed_multi_keccak.rs
@@ -22,6 +22,9 @@ mod tests {
     #[cfg_attr(not(feature = "benches"), ignore)]
     #[test]
     fn bench_packed_multi_keccak_circuit_prover() {
+        //Unique string used by bench results module for parsing the result
+        const BENCHMARK_ID: &str = "Packed Multi-Keccak Circuit";
+
         let degree: u32 = var("DEGREE")
             .expect("No DEGREE env var was provided")
             .parse()
@@ -53,10 +56,7 @@ mod tests {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!(
-            "Packed Multi-Keccak Circuit Proof generation with degree = {}",
-            degree
-        );
+        let proof_message = format!("{} Proof generation with degree = {}",BENCHMARK_ID, degree);
         let start2 = start_timer!(|| proof_message);
         create_proof::<
             KZGCommitmentScheme<Bn256>,
@@ -77,8 +77,8 @@ mod tests {
         let proof = transcript.finalize();
         end_timer!(start2);
 
-        // Bench verification time
-        let start3 = start_timer!(|| "Packed Multi-Keccak Circuit Proof verification");
+        // Bench verification time      
+        let start3 = start_timer!(|| format!("{} Proof verification", BENCHMARK_ID));
         let mut verifier_transcript = Blake2bRead::<_, G1Affine, Challenge255<_>>::init(&proof[..]);
         let strategy = SingleStrategy::new(&general_params);
 

--- a/circuit-benchmarks/src/packed_multi_keccak.rs
+++ b/circuit-benchmarks/src/packed_multi_keccak.rs
@@ -54,7 +54,7 @@ mod tests {
 
         // Bench proof generation time
         let proof_message = format!(
-            "Packed Multi-Keccak Proof generation with degree = {}",
+            "Packed Multi-Keccak Circuit Proof generation with degree = {}",
             degree
         );
         let start2 = start_timer!(|| proof_message);
@@ -78,7 +78,7 @@ mod tests {
         end_timer!(start2);
 
         // Bench verification time
-        let start3 = start_timer!(|| "Packed Multi-Keccak Proof verification");
+        let start3 = start_timer!(|| "Packed Multi-Keccak Circuit Proof verification");
         let mut verifier_transcript = Blake2bRead::<_, G1Affine, Challenge255<_>>::init(&proof[..]);
         let strategy = SingleStrategy::new(&general_params);
 

--- a/circuit-benchmarks/src/pi_circuit.rs
+++ b/circuit-benchmarks/src/pi_circuit.rs
@@ -66,7 +66,7 @@ mod tests {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!("{} Proof generation with degree = {}",BENCHMARK_ID, DEGREE);
+        let proof_message = format!("{} Proof generation with degree = {}", BENCHMARK_ID, DEGREE);
         let start2 = start_timer!(|| proof_message);
         create_proof::<
             KZGCommitmentScheme<Bn256>,
@@ -87,7 +87,7 @@ mod tests {
         let proof = transcript.finalize();
         end_timer!(start2);
 
-        // Bench verification time      
+        // Bench verification time
         let start3 = start_timer!(|| format!("{} Proof verification", BENCHMARK_ID));
         let mut verifier_transcript = Blake2bRead::<_, G1Affine, Challenge255<_>>::init(&proof[..]);
         let strategy = SingleStrategy::new(&general_params);

--- a/circuit-benchmarks/src/pi_circuit.rs
+++ b/circuit-benchmarks/src/pi_circuit.rs
@@ -26,6 +26,9 @@ mod tests {
     #[cfg_attr(not(feature = "benches"), ignore)]
     #[test]
     fn bench_pi_circuit_prover() {
+        //Unique string used by bench results module for parsing the result
+        const BENCHMARK_ID: &str = "Pi Circuit";
+
         const MAX_TXS: usize = 10;
         const MAX_CALLDATA: usize = 128;
 
@@ -63,7 +66,7 @@ mod tests {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!("PI Circuit Proof generation with {} rows", DEGREE);
+        let proof_message = format!("{} Proof generation with degree = {}",BENCHMARK_ID, DEGREE);
         let start2 = start_timer!(|| proof_message);
         create_proof::<
             KZGCommitmentScheme<Bn256>,
@@ -84,8 +87,8 @@ mod tests {
         let proof = transcript.finalize();
         end_timer!(start2);
 
-        // Bench verification time
-        let start3 = start_timer!(|| "PI Circuit Proof verification");
+        // Bench verification time      
+        let start3 = start_timer!(|| format!("{} Proof verification", BENCHMARK_ID));
         let mut verifier_transcript = Blake2bRead::<_, G1Affine, Challenge255<_>>::init(&proof[..]);
         let strategy = SingleStrategy::new(&general_params);
 

--- a/circuit-benchmarks/src/pi_circuit.rs
+++ b/circuit-benchmarks/src/pi_circuit.rs
@@ -63,7 +63,7 @@ mod tests {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!("PI_circuit Proof generation with {} rows", DEGREE);
+        let proof_message = format!("PI Circuit Proof generation with {} rows", DEGREE);
         let start2 = start_timer!(|| proof_message);
         create_proof::<
             KZGCommitmentScheme<Bn256>,
@@ -85,7 +85,7 @@ mod tests {
         end_timer!(start2);
 
         // Bench verification time
-        let start3 = start_timer!(|| "PI_circuit Proof verification");
+        let start3 = start_timer!(|| "PI Circuit Proof verification");
         let mut verifier_transcript = Blake2bRead::<_, G1Affine, Challenge255<_>>::init(&proof[..]);
         let strategy = SingleStrategy::new(&general_params);
 

--- a/circuit-benchmarks/src/state_circuit.rs
+++ b/circuit-benchmarks/src/state_circuit.rs
@@ -57,7 +57,7 @@ mod tests {
         let instances: Vec<&[Fr]> = instance.iter().map(|v| v.as_slice()).collect();
 
         // Bench proof generation time
-        let proof_message = format!("{} Proof generation with degree = {}",BENCHMARK_ID,  degree);
+        let proof_message = format!("{} Proof generation with degree = {}", BENCHMARK_ID, degree);
         let start2 = start_timer!(|| proof_message);
         create_proof::<
             KZGCommitmentScheme<Bn256>,
@@ -78,7 +78,7 @@ mod tests {
         let proof = transcript.finalize();
         end_timer!(start2);
 
-        // Bench verification time      
+        // Bench verification time
         let start3 = start_timer!(|| format!("{} Proof verification", BENCHMARK_ID));
         let mut verifier_transcript = Blake2bRead::<_, G1Affine, Challenge255<_>>::init(&proof[..]);
         let strategy = SingleStrategy::new(&general_params);

--- a/circuit-benchmarks/src/state_circuit.rs
+++ b/circuit-benchmarks/src/state_circuit.rs
@@ -24,6 +24,9 @@ mod tests {
     #[cfg_attr(not(feature = "benches"), ignore)]
     #[test]
     fn bench_state_circuit_prover() {
+        //Unique string used by bench results module for parsing the result
+        const BENCHMARK_ID: &str = "State Circuit";
+
         let degree: u32 = var("DEGREE")
             .expect("No DEGREE env var was provided")
             .parse()
@@ -54,7 +57,7 @@ mod tests {
         let instances: Vec<&[Fr]> = instance.iter().map(|v| v.as_slice()).collect();
 
         // Bench proof generation time
-        let proof_message = format!("State Circuit Proof generation with degree = {}", degree);
+        let proof_message = format!("{} Proof generation with degree = {}",BENCHMARK_ID,  degree);
         let start2 = start_timer!(|| proof_message);
         create_proof::<
             KZGCommitmentScheme<Bn256>,
@@ -75,8 +78,8 @@ mod tests {
         let proof = transcript.finalize();
         end_timer!(start2);
 
-        // Bench verification time
-        let start3 = start_timer!(|| "State Circuit Proof verification");
+        // Bench verification time      
+        let start3 = start_timer!(|| format!("{} Proof verification", BENCHMARK_ID));
         let mut verifier_transcript = Blake2bRead::<_, G1Affine, Challenge255<_>>::init(&proof[..]);
         let strategy = SingleStrategy::new(&general_params);
 

--- a/circuit-benchmarks/src/super_circuit.rs
+++ b/circuit-benchmarks/src/super_circuit.rs
@@ -104,7 +104,7 @@ mod tests {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!("{} Proof generation with degree = {}",BENCHMARK_ID, degree);
+        let proof_message = format!("{} Proof generation with degree = {}", BENCHMARK_ID, degree);
         let start2 = start_timer!(|| proof_message);
         create_proof::<
             KZGCommitmentScheme<Bn256>,
@@ -125,7 +125,7 @@ mod tests {
         let proof = transcript.finalize();
         end_timer!(start2);
 
-        // Bench verification time      
+        // Bench verification time
         let start3 = start_timer!(|| format!("{} Proof verification", BENCHMARK_ID));
         let mut verifier_transcript = Blake2bRead::<_, G1Affine, Challenge255<_>>::init(&proof[..]);
         let strategy = SingleStrategy::new(&general_params);

--- a/circuit-benchmarks/src/super_circuit.rs
+++ b/circuit-benchmarks/src/super_circuit.rs
@@ -101,7 +101,7 @@ mod tests {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!("SuperCircuit Proof generation with degree = {}", degree);
+        let proof_message = format!("Super Circuit Proof generation with degree = {}", degree);
         let start2 = start_timer!(|| proof_message);
         create_proof::<
             KZGCommitmentScheme<Bn256>,
@@ -123,7 +123,7 @@ mod tests {
         end_timer!(start2);
 
         // Bench verification time
-        let start3 = start_timer!(|| "SuperCircuit Proof verification");
+        let start3 = start_timer!(|| "Super Circuit Proof verification");
         let mut verifier_transcript = Blake2bRead::<_, G1Affine, Challenge255<_>>::init(&proof[..]);
         let strategy = SingleStrategy::new(&general_params);
 

--- a/circuit-benchmarks/src/super_circuit.rs
+++ b/circuit-benchmarks/src/super_circuit.rs
@@ -29,6 +29,9 @@ mod tests {
     #[cfg_attr(not(feature = "benches"), ignore)]
     #[test]
     fn bench_super_circuit_prover() {
+        //Unique string used by bench results module for parsing the result
+        const BENCHMARK_ID: &str = "Super Circuit";
+
         let degree: u32 = var("DEGREE")
             .expect("No DEGREE env var was provided")
             .parse()
@@ -101,7 +104,7 @@ mod tests {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!("Super Circuit Proof generation with degree = {}", degree);
+        let proof_message = format!("{} Proof generation with degree = {}",BENCHMARK_ID, degree);
         let start2 = start_timer!(|| proof_message);
         create_proof::<
             KZGCommitmentScheme<Bn256>,
@@ -122,8 +125,8 @@ mod tests {
         let proof = transcript.finalize();
         end_timer!(start2);
 
-        // Bench verification time
-        let start3 = start_timer!(|| "Super Circuit Proof verification");
+        // Bench verification time      
+        let start3 = start_timer!(|| format!("{} Proof verification", BENCHMARK_ID));
         let mut verifier_transcript = Blake2bRead::<_, G1Affine, Challenge255<_>>::init(&proof[..]);
         let strategy = SingleStrategy::new(&general_params);
 

--- a/circuit-benchmarks/src/tx_circuit.rs
+++ b/circuit-benchmarks/src/tx_circuit.rs
@@ -54,7 +54,7 @@ mod tests {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!("{} Proof generation with degree = {}",BENCHMARK_ID, DEGREE);
+        let proof_message = format!("{} Proof generation with degree = {}", BENCHMARK_ID, DEGREE);
         let start2 = start_timer!(|| proof_message);
         create_proof::<
             KZGCommitmentScheme<Bn256>,
@@ -75,7 +75,7 @@ mod tests {
         let proof = transcript.finalize();
         end_timer!(start2);
 
-        // Bench verification time      
+        // Bench verification time
         let start3 = start_timer!(|| format!("{} Proof verification", BENCHMARK_ID));
         let mut verifier_transcript = Blake2bRead::<_, G1Affine, Challenge255<_>>::init(&proof[..]);
         let strategy = SingleStrategy::new(&general_params);

--- a/circuit-benchmarks/src/tx_circuit.rs
+++ b/circuit-benchmarks/src/tx_circuit.rs
@@ -26,6 +26,9 @@ mod tests {
     fn bench_tx_circuit_prover() {
         env_logger::Builder::from_env(Env::default().default_filter_or("debug")).init();
 
+        //Unique string used by bench results module for parsing the result
+        const BENCHMARK_ID: &str = "Tx Circuit";
+
         // Approximate value, adjust with changes on the TxCircuit.
         const ROWS_PER_TX: usize = 175_000;
         const MAX_TXS: usize = 2_usize.pow(DEGREE as u32) / ROWS_PER_TX;
@@ -51,7 +54,7 @@ mod tests {
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
 
         // Bench proof generation time
-        let proof_message = format!("Tx Circuit Proof generation with degree = {}", DEGREE);
+        let proof_message = format!("{} Proof generation with degree = {}",BENCHMARK_ID, DEGREE);
         let start2 = start_timer!(|| proof_message);
         create_proof::<
             KZGCommitmentScheme<Bn256>,
@@ -72,8 +75,8 @@ mod tests {
         let proof = transcript.finalize();
         end_timer!(start2);
 
-        // Bench verification time
-        let start3 = start_timer!(|| "Tx Circuit Proof verification");
+        // Bench verification time      
+        let start3 = start_timer!(|| format!("{} Proof verification", BENCHMARK_ID));
         let mut verifier_transcript = Blake2bRead::<_, G1Affine, Challenge255<_>>::init(&proof[..]);
         let strategy = SingleStrategy::new(&general_params);
 


### PR DESCRIPTION
### Description

  Log messages across different prover benchmark tests differ slightly. This PR makes them uniform to make it easier to
  parse and report results

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Files Modified: 
```
circuit-benchmarks/src/bytecode_circuit.rs
circuit-benchmarks/src/copy_circuit.rs
circuit-benchmarks/src/evm_circuit.rs
circuit-benchmarks/src/packed_multi_keccak.rs
circuit-benchmarks/src/pi_circuit.rs
circuit-benchmarks/src/super_circuit.rs
circuit-benchmarks/src/copy_circuit.rs
circuit-benchmarks/src/exp_circuit.rs
circuit-benchmarks/src/tx_circuit.rs
```

