### PR TITLE
feat: Add copy circuit stats by exec state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,5 +63,14 @@ exp_bench: ## Run Exp Circuit benchmarks
 
 circuit_benches: evm_bench state_bench ## Run All Circuit benchmarks
 
+stats_state_circuit: # Print a table with State Circuit stats by ExecState/opcode
+	@cargo test -p zkevm-circuits --features=test,warn-unimplemented get_state_states_stats -- --nocapture --ignored
+
+stats_evm_circuit: # Print a table with EVM Circuit stats by ExecState/opcode
+	@cargo test -p zkevm-circuits --features=test,warn-unimplemented get_evm_states_stats -- --nocapture --ignored
+
+stats_copy_circuit: # Print a table with Copy Circuit stats by ExecState/opcode
+	@cargo test -p zkevm-circuits --features=test,warn-unimplemented get_copy_states_stats -- --nocapture --ignored
+
 
 .PHONY: clippy doc fmt test test_benches test-all evm_bench state_bench circuit_benches help

--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -390,6 +390,58 @@ pub struct BuilderClient<P: JsonRpcClient> {
     circuits_params: CircuitsParams,
 }
 
+/// Get State Accesses from TxExecTraces
+pub fn get_state_accesses(
+    eth_block: &EthBlock,
+    geth_traces: &[eth_types::GethExecTrace],
+) -> Result<AccessSet, Error> {
+    let mut block_access_trace = vec![Access::new(
+        None,
+        RW::WRITE,
+        AccessValue::Account {
+            address: eth_block
+                .author
+                .ok_or(Error::EthTypeError(eth_types::Error::IncompleteBlock))?,
+        },
+    )];
+    for (tx_index, tx) in eth_block.transactions.iter().enumerate() {
+        let geth_trace = &geth_traces[tx_index];
+        let tx_access_trace = gen_state_access_trace(eth_block, tx, geth_trace)?;
+        block_access_trace.extend(tx_access_trace);
+    }
+
+    Ok(AccessSet::from(block_access_trace))
+}
+
+/// Build a partial StateDB from step 3
+pub fn build_state_code_db(
+    proofs: Vec<eth_types::EIP1186ProofResponse>,
+    codes: HashMap<Address, Vec<u8>>,
+) -> (StateDB, CodeDB) {
+    let mut sdb = StateDB::new();
+    for proof in proofs {
+        let mut storage = HashMap::new();
+        for storage_proof in proof.storage_proof {
+            storage.insert(storage_proof.key, storage_proof.value);
+        }
+        sdb.set_account(
+            &proof.address,
+            state_db::Account {
+                nonce: proof.nonce,
+                balance: proof.balance,
+                storage,
+                code_hash: proof.code_hash,
+            },
+        )
+    }
+
+    let mut code_db = CodeDB::new();
+    for (_address, code) in codes {
+        code_db.insert(code.clone());
+    }
+    (sdb, code_db)
+}
+
 impl<P: JsonRpcClient> BuilderClient<P> {
     /// Create a new BuilderClient
     pub async fn new(
@@ -451,26 +503,10 @@ impl<P: JsonRpcClient> BuilderClient<P> {
 
     /// Step 2. Get State Accesses from TxExecTraces
     pub fn get_state_accesses(
-        &self,
         eth_block: &EthBlock,
         geth_traces: &[eth_types::GethExecTrace],
     ) -> Result<AccessSet, Error> {
-        let mut block_access_trace = vec![Access::new(
-            None,
-            RW::WRITE,
-            AccessValue::Account {
-                address: eth_block
-                    .author
-                    .ok_or(Error::EthTypeError(eth_types::Error::IncompleteBlock))?,
-            },
-        )];
-        for (tx_index, tx) in eth_block.transactions.iter().enumerate() {
-            let geth_trace = &geth_traces[tx_index];
-            let tx_access_trace = gen_state_access_trace(eth_block, tx, geth_trace)?;
-            block_access_trace.extend(tx_access_trace);
-        }
-
-        Ok(AccessSet::from(block_access_trace))
+        get_state_accesses(eth_block, geth_traces)
     }
 
     /// Step 3. Query geth for all accounts, storage keys, and codes from
@@ -511,32 +547,10 @@ impl<P: JsonRpcClient> BuilderClient<P> {
 
     /// Step 4. Build a partial StateDB from step 3
     pub fn build_state_code_db(
-        &self,
         proofs: Vec<eth_types::EIP1186ProofResponse>,
         codes: HashMap<Address, Vec<u8>>,
     ) -> (StateDB, CodeDB) {
-        let mut sdb = StateDB::new();
-        for proof in proofs {
-            let mut storage = HashMap::new();
-            for storage_proof in proof.storage_proof {
-                storage.insert(storage_proof.key, storage_proof.value);
-            }
-            sdb.set_account(
-                &proof.address,
-                state_db::Account {
-                    nonce: proof.nonce,
-                    balance: proof.balance,
-                    storage,
-                    code_hash: proof.code_hash,
-                },
-            )
-        }
-
-        let mut code_db = CodeDB::new();
-        for (_address, code) in codes {
-            code_db.insert(code.clone());
-        }
-        (sdb, code_db)
+        build_state_code_db(proofs, codes)
     }
 
     /// Step 5. For each step in TxExecTraces, gen the associated ops and state
@@ -575,9 +589,9 @@ impl<P: JsonRpcClient> BuilderClient<P> {
     > {
         let (eth_block, geth_traces, history_hashes, prev_state_root) =
             self.get_block(block_num).await?;
-        let access_set = self.get_state_accesses(&eth_block, &geth_traces)?;
+        let access_set = Self::get_state_accesses(&eth_block, &geth_traces)?;
         let (proofs, codes) = self.get_state(block_num, access_set).await?;
-        let (state_db, code_db) = self.build_state_code_db(proofs, codes);
+        let (state_db, code_db) = Self::build_state_code_db(proofs, codes);
         let builder = self.gen_inputs_from_state(
             state_db,
             code_db,

--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -335,10 +335,9 @@ impl<'a> CircuitInputStateRef<'a> {
         field: AccountField,
         value: Word,
         value_prev: Word,
-    ) -> Result<(), Error> {
+    ) {
         let op = AccountOp::new(address, field, value, value_prev);
         self.push_op(step, RW::READ, op);
-        Ok(())
     }
 
     /// Push a write type [`AccountOp`] into the

--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -467,7 +467,7 @@ pub fn gen_begin_tx_ops(state: &mut CircuitInputStateRef) -> Result<ExecStep, Er
                 AccountField::CodeHash,
                 callee_code_hash_word,
                 callee_code_hash_word,
-            )?;
+            );
 
             // 3. Call to account with empty code.
             if is_empty_code_hash {

--- a/bus-mapping/src/evm/opcodes/balance.rs
+++ b/bus-mapping/src/evm/opcodes/balance.rs
@@ -69,7 +69,7 @@ impl Opcode for Balance {
             AccountField::CodeHash,
             code_hash.to_word(),
             code_hash.to_word(),
-        )?;
+        );
         if exists {
             state.account_read(
                 &mut exec_step,
@@ -77,7 +77,7 @@ impl Opcode for Balance {
                 AccountField::Balance,
                 balance,
                 balance,
-            )?;
+            );
         }
 
         // Write the BALANCE result to stack.

--- a/bus-mapping/src/evm/opcodes/callop.rs
+++ b/bus-mapping/src/evm/opcodes/callop.rs
@@ -106,7 +106,7 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
             AccountField::CodeHash,
             callee_code_hash_word,
             callee_code_hash_word,
-        )?;
+        );
 
         let is_warm = state.sdb.check_account_in_access_list(&callee_address);
         state.push_op_reversible(
@@ -157,7 +157,7 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
             AccountField::Balance,
             caller_balance,
             caller_balance,
-        )?;
+        );
 
         // Transfer value only for CALL opcode, insufficient_balance = false
         // and value > 0.

--- a/bus-mapping/src/evm/opcodes/error_oog_call.rs
+++ b/bus-mapping/src/evm/opcodes/error_oog_call.rs
@@ -76,7 +76,7 @@ impl Opcode for OOGCall {
             AccountField::CodeHash,
             callee_code_hash_word,
             callee_code_hash_word,
-        )?;
+        );
 
         let is_warm = state.sdb.check_account_in_access_list(&call_address);
         state.push_op(

--- a/bus-mapping/src/evm/opcodes/extcodecopy.rs
+++ b/bus-mapping/src/evm/opcodes/extcodecopy.rs
@@ -120,7 +120,7 @@ fn gen_extcodecopy_step(
         AccountField::CodeHash,
         code_hash.to_word(),
         code_hash.to_word(),
-    )?;
+    );
     Ok(exec_step)
 }
 

--- a/bus-mapping/src/evm/opcodes/extcodehash.rs
+++ b/bus-mapping/src/evm/opcodes/extcodehash.rs
@@ -67,7 +67,7 @@ impl Opcode for Extcodehash {
             AccountField::CodeHash,
             code_hash.to_word(),
             code_hash.to_word(),
-        )?;
+        );
 
         // Stack write of the result of EXTCODEHASH.
         state.stack_write(&mut exec_step, stack_address, steps[1].stack.last()?)?;

--- a/bus-mapping/src/evm/opcodes/extcodesize.rs
+++ b/bus-mapping/src/evm/opcodes/extcodesize.rs
@@ -63,7 +63,7 @@ impl Opcode for Extcodesize {
             AccountField::CodeHash,
             code_hash.to_word(),
             code_hash.to_word(),
-        )?;
+        );
         let code_size = if exists {
             state.code(code_hash)?.len()
         } else {

--- a/bus-mapping/src/evm/opcodes/selfbalance.rs
+++ b/bus-mapping/src/evm/opcodes/selfbalance.rs
@@ -32,7 +32,7 @@ impl Opcode for Selfbalance {
             AccountField::Balance,
             self_balance,
             self_balance,
-        )?;
+        );
 
         // Stack write of self_balance
         state.stack_write(

--- a/integration-tests/tests/circuit_input_builder.rs
+++ b/integration-tests/tests/circuit_input_builder.rs
@@ -1,6 +1,8 @@
 #![cfg(feature = "circuit_input_builder")]
 
-use bus_mapping::circuit_input_builder::{BuilderClient, CircuitsParams};
+use bus_mapping::circuit_input_builder::{
+    build_state_code_db, get_state_accesses, BuilderClient, CircuitsParams,
+};
 use integration_tests::{get_client, log_init, GenDataOutput};
 use lazy_static::lazy_static;
 use log::trace;
@@ -32,14 +34,14 @@ async fn test_circuit_input_builder_block(block_num: u64) {
         cli.get_block(block_num).await.unwrap();
 
     // 2. Get State Accesses from TxExecTraces
-    let access_set = cli.get_state_accesses(&eth_block, &geth_trace).unwrap();
+    let access_set = get_state_accesses(&eth_block, &geth_trace).unwrap();
     trace!("AccessSet: {:#?}", access_set);
 
     // 3. Query geth for all accounts, storage keys, and codes from Accesses
     let (proofs, codes) = cli.get_state(block_num, access_set).await.unwrap();
 
     // 4. Build a partial StateDB from step 3
-    let (state_db, code_db) = cli.build_state_code_db(proofs, codes);
+    let (state_db, code_db) = build_state_code_db(proofs, codes);
     trace!("StateDB: {:#?}", state_db);
 
     // 5. For each step in TxExecTraces, gen the associated ops and state

--- a/zkevm-circuits/Cargo.toml
+++ b/zkevm-circuits/Cargo.toml
@@ -51,3 +51,4 @@ pretty_assertions = "1.0.0"
 default = []
 test = ["ethers-signers", "mock"]
 test-circuits = []
+warn-unimplemented = ["eth-types/warn-unimplemented"]

--- a/zkevm-circuits/src/copy_circuit.rs
+++ b/zkevm-circuits/src/copy_circuit.rs
@@ -1175,3 +1175,44 @@ mod tests {
         }
     }
 }
+
+#[cfg(test)]
+mod copy_circuit_stats {
+    use crate::evm_circuit::step::ExecutionState;
+    use crate::stats::{bytecode_prefix_op_big_rws, print_circuit_stats_by_states};
+
+    /// Prints the stats of Copy circuit per execution state.  See
+    /// `print_circuit_stats_by_states` for more details.
+    ///
+    /// Run with:
+    /// `cargo test -p zkevm-circuits --release --all-features
+    /// get_evm_states_stats -- --nocapture --ignored`
+    #[ignore]
+    #[test]
+    fn get_copy_states_stats() {
+        print_circuit_stats_by_states(
+            |state| {
+                // TODO: Create valid inputs to test all execution states
+                // TODO: Enable CREATE/CREATE2 once they are supported
+                matches!(
+                    state,
+                    ExecutionState::RETURNDATACOPY
+                        | ExecutionState::CODECOPY
+                        | ExecutionState::LOG
+                        | ExecutionState::CALLDATACOPY
+                        | ExecutionState::EXTCODECOPY
+                        | ExecutionState::RETURN_REVERT
+                )
+            },
+            bytecode_prefix_op_big_rws,
+            |block, _, _| {
+                assert!(block.copy_events.len() <= 1);
+                block
+                    .copy_events
+                    .iter()
+                    .map(|c| c.bytes.len() * 2)
+                    .sum::<usize>()
+            },
+        );
+    }
+}

--- a/zkevm-circuits/src/copy_circuit.rs
+++ b/zkevm-circuits/src/copy_circuit.rs
@@ -1192,7 +1192,6 @@ mod copy_circuit_stats {
     fn get_copy_states_stats() {
         print_circuit_stats_by_states(
             |state| {
-                // TODO: Create valid inputs to test all execution states
                 // TODO: Enable CREATE/CREATE2 once they are supported
                 matches!(
                     state,

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -406,12 +406,11 @@ pub mod test {
 #[cfg(test)]
 mod evm_circuit_stats {
     use crate::evm_circuit::step::ExecutionState;
+    use crate::stats::print_circuit_stats_by_states;
     use crate::test_util::CircuitTestBuilder;
-
-    use eth_types::{bytecode, evm_types::OpcodeId, geth_types::GethData};
-
-    use mock::test_ctx::{helpers::*, TestContext};
-    use strum::IntoEnumIterator;
+    use eth_types::{bytecode, evm_types::OpcodeId, ToWord};
+    use mock::test_ctx::TestContext;
+    use mock::MOCK_ACCOUNTS;
 
     #[test]
     pub fn empty_evm_circuit_no_padding() {
@@ -432,67 +431,52 @@ mod evm_circuit_stats {
         .run();
     }
 
-    /// This function prints to stdout a table with all the implemented states
-    /// and their responsible opcodes with the following stats:
-    /// - height: number of rows in the EVM circuit used by the execution state
-    /// - gas: gas value used for the opcode execution
-    /// - height/gas: ratio between circuit cost and gas cost
+    /// Prints the stats of EVM circuit per execution state.  See
+    /// `print_circuit_stats_by_states` for more details.
     ///
     /// Run with:
-    /// `cargo test -p zkevm-circuits --release get_evm_states_stats --
-    /// --nocapture --ignored`
+    /// `cargo test -p zkevm-circuits --release --all-features
+    /// get_evm_states_stats -- --nocapture --ignored`
     #[ignore]
     #[test]
-    pub fn get_evm_states_stats() {
-        let mut implemented_states = Vec::new();
-        for state in ExecutionState::iter() {
-            let height = state.get_step_height_option();
-            if let Some(h) = height {
-                implemented_states.push((state, h));
-            }
-        }
-
-        let mut stats = Vec::new();
-        for (state, h) in implemented_states {
-            for opcode in state.responsible_opcodes() {
-                let mut code = bytecode! {
-                    PUSH2(0x8000)
-                    PUSH2(0x00)
-                    PUSH2(0x10)
-                    PUSH2(0x20)
-                    PUSH2(0x30)
+    fn get_evm_states_stats() {
+        print_circuit_stats_by_states(
+            |state| {
+                // TODO: Create valid inputs to test all execution states
+                // TODO: Enable CREATE/CREATE2 once they are supported
+                !matches!(
+                    state,
+                    ExecutionState::ErrorInvalidOpcode
+                        | ExecutionState::JUMP
+                        | ExecutionState::JUMPI
+                        | ExecutionState::CREATE
+                        | ExecutionState::CREATE2
+                        | ExecutionState::CALL_OP
+                        | ExecutionState::SELFDESTRUCT
+                )
+            },
+            |opcode| match opcode {
+                OpcodeId::RETURNDATACOPY => {
+                    bytecode! {
+                    PUSH1(0x00) // retLength
+                    PUSH1(0x00) // retOffset
+                    PUSH1(0x00) // argsLength
+                    PUSH1(0x00) // argsOffset
+                    PUSH1(0x00) // value
+                    PUSH32(MOCK_ACCOUNTS[3].to_word())
+                    PUSH32(0x1_0000) // gas
+                    CALL
+                    PUSH2(0x01) // size
+                    PUSH2(0x00) // offset
+                    PUSH2(0x00) // destOffset
+                    }
+                }
+                _ => bytecode! {
                     PUSH2(0x40)
                     PUSH2(0x50)
-                };
-                code.write_op(opcode);
-                code.write_op(OpcodeId::STOP);
-                let block: GethData = TestContext::<2, 1>::new(
-                    None,
-                    account_0_code_account_1_no_code(code),
-                    tx_from_1_to_0,
-                    |block, _tx| block.number(0xcafeu64),
-                )
-                .unwrap()
-                .into();
-                let gas_cost = block.geth_traces[0].struct_logs[7].gas_cost.0;
-                stats.push((state, opcode, h, gas_cost));
-            }
-        }
-
-        println!(
-            "| {: <14} | {: <14} | {: <2} | {: >6} | {: <5} |",
-            "state", "opcode", "h", "g", "h/g"
+                },
+            },
+            |_, state, _| state.get_step_height_option().unwrap(),
         );
-        println!("| ---            | ---            | ---|    --- | ---   |");
-        for (state, opcode, height, gas_cost) in stats {
-            println!(
-                "| {: <14?} | {: <14?} | {: >2} | {: >6} | {: >1.3} |",
-                state,
-                opcode,
-                height,
-                gas_cost,
-                height as f64 / gas_cost as f64
-            );
-        }
     }
 }

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -442,16 +442,12 @@ mod evm_circuit_stats {
     fn get_evm_states_stats() {
         print_circuit_stats_by_states(
             |state| {
-                // TODO: Create valid inputs to test all execution states
                 // TODO: Enable CREATE/CREATE2 once they are supported
                 !matches!(
                     state,
                     ExecutionState::ErrorInvalidOpcode
-                        | ExecutionState::JUMP
-                        | ExecutionState::JUMPI
                         | ExecutionState::CREATE
                         | ExecutionState::CREATE2
-                        | ExecutionState::CALL_OP
                         | ExecutionState::SELFDESTRUCT
                 )
             },

--- a/zkevm-circuits/src/lib.rs
+++ b/zkevm-circuits/src/lib.rs
@@ -31,6 +31,9 @@ pub mod table;
 #[cfg(any(feature = "test", test))]
 pub mod test_util;
 
+#[cfg(any(feature = "test", test))]
+mod stats;
+
 pub mod tx_circuit;
 pub mod util;
 pub mod witness;

--- a/zkevm-circuits/src/state_circuit.rs
+++ b/zkevm-circuits/src/state_circuit.rs
@@ -619,16 +619,12 @@ mod state_circuit_stats {
     pub fn get_state_states_stats() {
         print_circuit_stats_by_states(
             |state| {
-                // TODO: Create valid inputs to test all execution states
                 // TODO: Enable CREATE/CREATE2 once they are supported
                 !matches!(
                     state,
                     ExecutionState::ErrorInvalidOpcode
-                        | ExecutionState::JUMP
-                        | ExecutionState::JUMPI
                         | ExecutionState::CREATE
                         | ExecutionState::CREATE2
-                        | ExecutionState::CALL_OP
                         | ExecutionState::SELFDESTRUCT
                 )
             },

--- a/zkevm-circuits/src/state_circuit.rs
+++ b/zkevm-circuits/src/state_circuit.rs
@@ -606,125 +606,38 @@ fn queries<F: Field>(meta: &mut VirtualCells<'_, F>, c: &StateCircuitConfig<F>) 
 #[cfg(test)]
 mod state_circuit_stats {
     use crate::evm_circuit::step::ExecutionState;
-    use bus_mapping::{circuit_input_builder::ExecState, mock::BlockData};
-    use eth_types::{bytecode, evm_types::OpcodeId, geth_types::GethData, Address};
-    use mock::{eth, test_ctx::TestContext, MOCK_ACCOUNTS};
-    use strum::IntoEnumIterator;
+    use crate::stats::{bytecode_prefix_op_big_rws, print_circuit_stats_by_states};
 
-    /// This function prints to stdout a table with all the implemented states
-    /// and their responsible opcodes with the following stats:
-    /// - height: number of rows in the State circuit used by the execution
-    ///   state
-    /// - gas: gas value used for the opcode execution
-    /// - height/gas: ratio between circuit cost and gas cost
+    /// Prints the stats of State circuit per execution state.  See
+    /// `print_circuit_stats_by_states` for more details.
     ///
     /// Run with:
-    /// `cargo test -p zkevm-circuits --release get_state_states_stats --
-    /// --nocapture --ignored`
+    /// `cargo test -p zkevm-circuits --release --all-features
+    /// get_state_states_stats -- --nocapture --ignored`
     #[ignore]
     #[test]
     pub fn get_state_states_stats() {
-        // Get the list of implemented execution states by configuring the EVM Circuit
-        // and querying the step height for each possible execution state (only those
-        // implemented will return a Some value).
-
-        let mut implemented_states = Vec::new();
-        for state in ExecutionState::iter() {
-            let height = state.get_step_height_option();
-            if height.is_some() {
-                implemented_states.push(state);
-            }
-        }
-
-        let mut stats = Vec::new();
-        for state in implemented_states {
-            for opcode in state.responsible_opcodes() {
-                let mut code = bytecode! {
-                    PUSH2(0x100)
-                    MLOAD // Expand memory a bit
-                    PUSH2(0x00)
-                    EXTCODESIZE // Warm up 0x0 address
-                    PUSH2(0x8000)
-                    PUSH2(0x00)
-                    PUSH2(0x10)
-                    PUSH2(0x20)
-                    PUSH2(0x30)
-                };
-                // Make sure that opcodes that take an address as argument use addres 0x0, which
-                // will exist in the test.
-                match opcode {
-                    OpcodeId::BALANCE
-                    | OpcodeId::EXTCODESIZE
-                    | OpcodeId::EXTCODECOPY
-                    | OpcodeId::SELFDESTRUCT
-                    | OpcodeId::EXTCODEHASH => code.append(&bytecode! {
-                        PUSH2(0x40)
-                        PUSH2(0x00)
-                    }),
-                    OpcodeId::CALL
-                    | OpcodeId::CALLCODE
-                    | OpcodeId::DELEGATECALL
-                    | OpcodeId::STATICCALL => code.append(&bytecode! {
-                        PUSH2(0x00)
-                        PUSH2(0x50)
-                    }),
-                    _ => code.append(&bytecode! {
-                        PUSH2(0x40)
-                        PUSH2(0x50)
-                    }),
-                };
-                code.write_op(opcode);
-                code.write_op(OpcodeId::STOP);
-                let block: GethData = TestContext::<3, 1>::new(
-                    None,
-                    |accs| {
-                        accs[0]
-                            .address(MOCK_ACCOUNTS[0])
-                            .balance(eth(10))
-                            .code(code.clone());
-                        accs[1].address(MOCK_ACCOUNTS[1]).balance(eth(10));
-                        accs[2].address(Address::zero()).balance(eth(10)).code(code);
-                    },
-                    |mut txs, accs| {
-                        txs[0]
-                            .from(accs[1].address)
-                            .to(accs[0].address)
-                            .input(vec![1, 2, 3, 4, 5, 6, 7].into());
-                    },
-                    |block, _tx| block.number(0xcafeu64),
+        print_circuit_stats_by_states(
+            |state| {
+                // TODO: Create valid inputs to test all execution states
+                // TODO: Enable CREATE/CREATE2 once they are supported
+                !matches!(
+                    state,
+                    ExecutionState::ErrorInvalidOpcode
+                        | ExecutionState::JUMP
+                        | ExecutionState::JUMPI
+                        | ExecutionState::CREATE
+                        | ExecutionState::CREATE2
+                        | ExecutionState::CALL_OP
+                        | ExecutionState::SELFDESTRUCT
                 )
-                .unwrap()
-                .into();
-                let mut builder =
-                    BlockData::new_from_geth_data(block.clone()).new_circuit_input_builder();
-                builder
-                    .handle_block(&block.eth_block, &block.geth_traces)
-                    .unwrap();
-                let step_index = 1 + 11; // 1 is for the BeginTx, 11 for the bytecode opcodes.
-                let step = &builder.block.txs[0].steps()[step_index];
-                let step_next = &builder.block.txs[0].steps()[step_index + 1];
-                assert_eq!(ExecState::Op(opcode), step.exec_state);
-                let h = step_next.rwc.0 - step.rwc.0;
-
-                let gas_cost = block.geth_traces[0].struct_logs[11].gas_cost.0;
-                stats.push((state, opcode, h, gas_cost));
-            }
-        }
-
-        println!(
-            "| {: <14} | {: <14} | {: <2} | {: >6} | {: <5} |",
-            "state", "opcode", "h", "g", "h/g"
+            },
+            bytecode_prefix_op_big_rws,
+            |block, _, step_index| {
+                let step = &block.txs[0].steps()[step_index];
+                let step_next = &block.txs[0].steps()[step_index + 1];
+                step_next.rwc.0 - step.rwc.0
+            },
         );
-        println!("| ---            | ---            | ---|    --- | ---   |");
-        for (state, opcode, height, gas_cost) in stats {
-            println!(
-                "| {: <14?} | {: <14?} | {: >2} | {: >6} | {: >1.3} |",
-                state,
-                opcode,
-                height,
-                gas_cost,
-                height as f64 / gas_cost as f64
-            );
-        }
     }
 }

--- a/zkevm-circuits/src/stats.rs
+++ b/zkevm-circuits/src/stats.rs
@@ -1,0 +1,243 @@
+use crate::evm_circuit::step::ExecutionState;
+use bus_mapping::{
+    circuit_input_builder::{self, CircuitsParams, ExecState},
+    mock::BlockData,
+};
+use eth_types::{bytecode, evm_types::OpcodeId, geth_types::GethData, Address, Bytecode, ToWord};
+use mock::{eth, test_ctx::TestContext, MOCK_ACCOUNTS};
+use strum::IntoEnumIterator;
+
+/// Helper type to print formatted tables in MarkDown
+pub(crate) struct DisplayTable<const N: usize> {
+    header: [String; N],
+    rows: Vec<[String; N]>,
+}
+
+impl<const N: usize> DisplayTable<N> {
+    pub(crate) fn new(header: [String; N]) -> Self {
+        Self {
+            header,
+            rows: Vec::new(),
+        }
+    }
+    fn push_row(&mut self, row: [String; N]) {
+        self.rows.push(row)
+    }
+    fn print_row(row: &[String; N], rows_width: &[usize; N]) {
+        for (i, h) in row.iter().enumerate() {
+            if i == 0 {
+                print!("|");
+            }
+            print!(" {:width$} |", h, width = rows_width[i]);
+        }
+        println!();
+    }
+    pub(crate) fn print(&self) {
+        let mut rows_width = [0; N];
+        for row in std::iter::once(&self.header).chain(self.rows.iter()) {
+            for (i, s) in row.iter().enumerate() {
+                if s.len() > rows_width[i] {
+                    rows_width[i] = s.len();
+                }
+            }
+        }
+        Self::print_row(&self.header, &rows_width);
+        for (i, width) in rows_width.iter().enumerate() {
+            if i == 0 {
+                print!("|");
+            }
+            print!(" {:-<width$} |", "", width = width);
+        }
+        println!();
+        for row in &self.rows {
+            Self::print_row(row, &rows_width);
+        }
+    }
+}
+
+/// Generate the prefix bytecode to trigger a big amount of rw operations
+pub(crate) fn bytecode_prefix_op_big_rws(opcode: OpcodeId) -> Bytecode {
+    match opcode {
+        OpcodeId::CODECOPY | OpcodeId::CALLDATACOPY => {
+            bytecode! {
+                PUSH4(0x1000) // size
+                PUSH2(0x00) // offset
+                PUSH2(0x00) // destOffset
+            }
+        }
+        OpcodeId::RETURNDATACOPY => {
+            bytecode! {
+                PUSH1(0x00) // retLength
+                PUSH1(0x00) // retOffset
+                PUSH1(0x00) // argsLength
+                PUSH1(0x00) // argsOffset
+                PUSH1(0x00) // value
+                PUSH32(MOCK_ACCOUNTS[3].to_word())
+                PUSH32(0x1_0000) // gas
+                CALL
+                PUSH4(0x1000) // size
+                PUSH2(0x00) // offset
+                PUSH2(0x00) // destOffset
+            }
+        }
+        OpcodeId::LOG0
+        | OpcodeId::LOG1
+        | OpcodeId::LOG2
+        | OpcodeId::LOG3
+        | OpcodeId::LOG4
+        | OpcodeId::SHA3
+        | OpcodeId::RETURN
+        | OpcodeId::REVERT => bytecode! {
+            PUSH4(0x1000) // size
+            PUSH2(0x00) // offset
+        },
+        OpcodeId::EXTCODECOPY => bytecode! {
+            PUSH4(0x1000) // size
+            PUSH2(0x00) // offset
+            PUSH2(0x00) // destOffset
+            PUSH2(0x00) // address
+        },
+        _ => bytecode! {
+            PUSH2(0x40)
+            PUSH2(0x50)
+        },
+    }
+}
+
+/// This function prints to stdout a table with all the implemented states
+/// and their responsible opcodes with the following stats:
+/// - height: number of rows in a circuit used by the execution state
+/// - gas: gas value used for the opcode execution
+/// - height/gas: ratio between circuit cost and gas cost
+///
+/// The TestContext is as follows:
+/// - `MOCK_ACCOUNTS[0]` calls `MOCK_ACCOUNTS[1]` which has a proxy code that
+///   calls `MOCK_ACCOUNT[2]` which has the main code
+/// - `0x0` account has a copy of the main code
+/// - `MOCK_ACCOUNTS[3]` has a small code that returns a 0-memory chunk
+pub(crate) fn print_circuit_stats_by_states(
+    // Function to select which opcodes to analyze.  When this returns false,
+    // the opcode is skipped.
+    fn_filter: impl Fn(ExecutionState) -> bool,
+    // Function to generate bytecode that will be prefixed to the opcode,
+    // useful to set up arguments that cause worst height/gas case.
+    fn_bytecode_prefix_op: impl Fn(OpcodeId) -> Bytecode,
+    // Function that calculates the circuit height used by an opcode.  This function takes the
+    // circuit input builder Block, the current execution state, and the step index in circuit
+    // input builder tx.
+    fn_height: impl Fn(&circuit_input_builder::Block, ExecutionState, usize) -> usize,
+) {
+    let mut implemented_states = Vec::new();
+    for state in ExecutionState::iter() {
+        let height = state.get_step_height_option();
+        if height.is_some() {
+            implemented_states.push(state);
+        }
+    }
+
+    let mut table = DisplayTable::new(["state", "opcode", "h", "g", "h/g"].map(|s| s.into()));
+    for state in implemented_states {
+        if !fn_filter(state) {
+            continue;
+        }
+        for opcode in state.responsible_opcodes() {
+            let mut code = bytecode! {
+                PUSH2(0x00)
+                EXTCODESIZE // Warm up 0x0 address
+                PUSH1(0x00)
+                PUSH1(0x00)
+                PUSH1(0x00)
+                PUSH1(0x00)
+                PUSH1(0x00)
+                PUSH1(0x00)
+                PUSH1(0x00)
+                PUSH1(0x00)
+                PUSH1(0x00)
+                PUSH1(0x00)
+                PUSH2(0x00)
+                PUSH2(0x10)
+                PUSH2(0x20)
+                PUSH2(0x30)
+            };
+            let bytecode_prefix_op = fn_bytecode_prefix_op(opcode);
+            code.append(&bytecode_prefix_op);
+            code.write_op(opcode);
+            code.write_op(OpcodeId::STOP);
+            let smallcode = bytecode! {
+                PUSH4(0x1000) // size
+                PUSH2(0x00) // offset
+                RETURN
+            };
+            let proxy_code = bytecode! {
+                PUSH2(0x1000) // retLength
+                PUSH1(0x00) // retOffset
+                PUSH1(0x00) // argsLength
+                PUSH1(0x00) // argsOffset
+                PUSH1(0x00) // value
+                PUSH32(MOCK_ACCOUNTS[2].to_word())
+                PUSH32(800_000) // gas
+                CALL
+                STOP
+            };
+            let block: GethData = TestContext::<10, 1>::new(
+                None,
+                |accs| {
+                    accs[0].address(MOCK_ACCOUNTS[0]).balance(eth(10));
+                    accs[1]
+                        .address(MOCK_ACCOUNTS[1])
+                        .balance(eth(10))
+                        .code(proxy_code);
+                    accs[2]
+                        .address(MOCK_ACCOUNTS[2])
+                        .balance(eth(10))
+                        .code(code.clone());
+                    accs[3].address(MOCK_ACCOUNTS[3]).code(smallcode.clone());
+                    accs[4].address(Address::zero()).balance(eth(10)).code(code);
+                },
+                |mut txs, accs| {
+                    txs[0]
+                        .from(accs[0].address)
+                        .to(accs[1].address)
+                        .input(vec![1, 2, 3, 4, 5, 6, 7].into());
+                },
+                |block, _tx| block.number(0xcafeu64),
+            )
+            .unwrap()
+            .into();
+            let mut builder = BlockData::new_from_geth_data_with_params(
+                block.clone(),
+                CircuitsParams {
+                    max_rws: 16_000,
+                    max_copy_rows: 8_000,
+                    ..CircuitsParams::default()
+                },
+            )
+            .new_circuit_input_builder();
+            builder
+                .handle_block(&block.eth_block, &block.geth_traces)
+                .unwrap();
+            // The steps end with [... `opcode`, STOP, STOP, EndTx] when opcode doesn't
+            // halt, [... `opcode`, STOP, EndTx] otherwise
+            let step_index =
+                (builder.block.txs[0].steps().len() - 1) - 3 + if state.halts() { 1 } else { 0 };
+            let step = &builder.block.txs[0].steps()[step_index];
+            assert_eq!(ExecState::Op(opcode), step.exec_state);
+            let h = fn_height(&builder.block, state, step_index);
+
+            let geth_step_index = (block.geth_traces[0].struct_logs.len() - 1) - 2
+                + if state.halts() { 1 } else { 0 };
+            let geth_step = &block.geth_traces[0].struct_logs[geth_step_index];
+            assert_eq!(opcode, geth_step.op);
+            let gas_cost = geth_step.gas_cost.0;
+            table.push_row([
+                format!("{:?}", state),
+                format!("{:?}", opcode),
+                format!("{}", h),
+                format!("{}", gas_cost),
+                format!("{:1.3}", h as f64 / gas_cost as f64),
+            ]);
+        }
+    }
+
+    table.print();
+}


### PR DESCRIPTION
### Description

feat: Add copy circuit stats by exec state like the ones we had for evm circuit and state circuit.

refactor: move duplicate code used to get circuit stats by exec state into a new module, which also contains a helper struct to draw formatted tables

feat: add the `warn-unimplemented` fature in `zkevm-circuits` so that it can be enabled/disabled when using the zkevm-circuits crate.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Contents

Here are the stats for the Copy Circuit

| state          | opcode         | h    | g     | h/g    |
| -------------- | -------------- | ---- | ----- | ------ |
| CALLDATACOPY   | CALLDATACOPY   | 8192 | 803   | 10.202 |
| CODECOPY       | CODECOPY       | 8192 | 803   | 10.202 |
| EXTCODECOPY    | EXTCODECOPY    | 8192 | 900   | 9.102  |
| RETURNDATACOPY | RETURNDATACOPY | 8192 | 803   | 10.202 |
| LOG            | LOG0           | 8192 | 33559 | 0.244  |
| LOG            | LOG1           | 8192 | 33934 | 0.241  |
| LOG            | LOG2           | 8192 | 34309 | 0.239  |
| LOG            | LOG3           | 8192 | 34684 | 0.236  |
| LOG            | LOG4           | 8192 | 35059 | 0.234  |
| RETURN_REVERT  | RETURN         | 8192 | 416   | 19.692 |
| RETURN_REVERT  | REVERT         | 8192 | 416   | 19.692 |

<details><summary>Updated stats for EVM Circuit</summary>

| state          | opcode         | h  | g     | h/g   |
| -------------- | -------------- | -- | ----- | ----- |
| STOP           | STOP           | 2  | 0     | inf   |
| ADD_SUB        | ADD            | 5  | 3     | 1.667 |
| ADD_SUB        | SUB            | 5  | 3     | 1.667 |
| MUL_DIV_MOD    | MUL            | 8  | 5     | 1.600 |
| MUL_DIV_MOD    | DIV            | 8  | 5     | 1.600 |
| MUL_DIV_MOD    | MOD            | 8  | 5     | 1.600 |
| SDIV_SMOD      | SDIV           | 19 | 5     | 3.800 |
| SDIV_SMOD      | SMOD           | 19 | 5     | 3.800 |
| SHL_SHR        | SHL            | 10 | 3     | 3.333 |
| SHL_SHR        | SHR            | 10 | 3     | 3.333 |
| ADDMOD         | ADDMOD         | 17 | 8     | 2.125 |
| MULMOD         | MULMOD         | 20 | 8     | 2.500 |
| EXP            | EXP            | 7  | 60    | 0.117 |
| SIGNEXTEND     | SIGNEXTEND     | 3  | 5     | 0.600 |
| CMP            | LT             | 5  | 3     | 1.667 |
| CMP            | GT             | 5  | 3     | 1.667 |
| CMP            | EQ             | 5  | 3     | 1.667 |
| SCMP           | SLT            | 5  | 3     | 1.667 |
| SCMP           | SGT            | 5  | 3     | 1.667 |
| ISZERO         | ISZERO         | 2  | 3     | 0.667 |
| BITWISE        | AND            | 5  | 3     | 1.667 |
| BITWISE        | OR             | 5  | 3     | 1.667 |
| BITWISE        | XOR            | 5  | 3     | 1.667 |
| NOT            | NOT            | 5  | 3     | 1.667 |
| BYTE           | BYTE           | 3  | 3     | 1.000 |
| SAR            | SAR            | 10 | 3     | 3.333 |
| SHA3           | SHA3           | 4  | 57    | 0.070 |
| ADDRESS        | ADDRESS        | 2  | 2     | 1.000 |
| BALANCE        | BALANCE        | 2  | 2600  | 0.001 |
| ORIGIN         | ORIGIN         | 2  | 2     | 1.000 |
| CALLER         | CALLER         | 2  | 2     | 1.000 |
| CALLVALUE      | CALLVALUE      | 1  | 2     | 0.500 |
| CALLDATALOAD   | CALLDATALOAD   | 8  | 3     | 2.667 |
| CALLDATASIZE   | CALLDATASIZE   | 1  | 2     | 0.500 |
| CALLDATACOPY   | CALLDATACOPY   | 3  | 21    | 0.143 |
| CODESIZE       | CODESIZE       | 1  | 2     | 0.500 |
| CODECOPY       | CODECOPY       | 3  | 21    | 0.143 |
| GASPRICE       | GASPRICE       | 1  | 2     | 0.500 |
| EXTCODESIZE    | EXTCODESIZE    | 2  | 2600  | 0.001 |
| EXTCODECOPY    | EXTCODECOPY    | 4  | 2612  | 0.002 |
| RETURNDATASIZE | RETURNDATASIZE | 1  | 2     | 0.500 |
| RETURNDATACOPY | RETURNDATACOPY | 3  | 9     | 0.333 |
| EXTCODEHASH    | EXTCODEHASH    | 2  | 2600  | 0.001 |
| BLOCKHASH      | BLOCKHASH      | 3  | 20    | 0.150 |
| BLOCKCTXU64    | TIMESTAMP      | 1  | 2     | 0.500 |
| BLOCKCTXU64    | NUMBER         | 1  | 2     | 0.500 |
| BLOCKCTXU64    | GASLIMIT       | 1  | 2     | 0.500 |
| BLOCKCTXU160   | COINBASE       | 2  | 2     | 1.000 |
| BLOCKCTXU256   | DIFFICULTY     | 2  | 2     | 1.000 |
| BLOCKCTXU256   | BASEFEE        | 2  | 2     | 1.000 |
| CHAINID        | CHAINID        | 1  | 2     | 0.500 |
| SELFBALANCE    | SELFBALANCE    | 1  | 5     | 0.200 |
| POP            | POP            | 1  | 2     | 0.500 |
| MEMORY         | MLOAD          | 5  | 15    | 0.333 |
| MEMORY         | MSTORE         | 5  | 15    | 0.333 |
| MEMORY         | MSTORE8        | 5  | 12    | 0.417 |
| SLOAD          | SLOAD          | 2  | 2100  | 0.001 |
| SSTORE         | SSTORE         | 12 | 22100 | 0.001 |
| JUMP           | JUMP           | 1  | 8     | 0.125 |
| JUMPI          | JUMPI          | 3  | 10    | 0.300 |
| PC             | PC             | 1  | 2     | 0.500 |
| MSIZE          | MSIZE          | 1  | 2     | 0.500 |
| GAS            | GAS            | 1  | 2     | 0.500 |
| JUMPDEST       | JUMPDEST       | 1  | 1     | 1.000 |
| PUSH           | PUSH1          | 9  | 3     | 3.000 |
| PUSH           | PUSH2          | 9  | 3     | 3.000 |
| PUSH           | PUSH3          | 9  | 3     | 3.000 |
| PUSH           | PUSH4          | 9  | 3     | 3.000 |
| PUSH           | PUSH5          | 9  | 3     | 3.000 |
| PUSH           | PUSH6          | 9  | 3     | 3.000 |
| PUSH           | PUSH7          | 9  | 3     | 3.000 |
| PUSH           | PUSH8          | 9  | 3     | 3.000 |
| PUSH           | PUSH9          | 9  | 3     | 3.000 |
| PUSH           | PUSH10         | 9  | 3     | 3.000 |
| PUSH           | PUSH11         | 9  | 3     | 3.000 |
| PUSH           | PUSH12         | 9  | 3     | 3.000 |
| PUSH           | PUSH13         | 9  | 3     | 3.000 |
| PUSH           | PUSH14         | 9  | 3     | 3.000 |
| PUSH           | PUSH15         | 9  | 3     | 3.000 |
| PUSH           | PUSH16         | 9  | 3     | 3.000 |
| PUSH           | PUSH17         | 9  | 3     | 3.000 |
| PUSH           | PUSH18         | 9  | 3     | 3.000 |
| PUSH           | PUSH19         | 9  | 3     | 3.000 |
| PUSH           | PUSH20         | 9  | 3     | 3.000 |
| PUSH           | PUSH21         | 9  | 3     | 3.000 |
| PUSH           | PUSH22         | 9  | 3     | 3.000 |
| PUSH           | PUSH23         | 9  | 3     | 3.000 |
| PUSH           | PUSH24         | 9  | 3     | 3.000 |
| PUSH           | PUSH25         | 9  | 3     | 3.000 |
| PUSH           | PUSH26         | 9  | 3     | 3.000 |
| PUSH           | PUSH27         | 9  | 3     | 3.000 |
| PUSH           | PUSH28         | 9  | 3     | 3.000 |
| PUSH           | PUSH29         | 9  | 3     | 3.000 |
| PUSH           | PUSH30         | 9  | 3     | 3.000 |
| PUSH           | PUSH31         | 9  | 3     | 3.000 |
| PUSH           | PUSH32         | 9  | 3     | 3.000 |
| DUP            | DUP1           | 1  | 3     | 0.333 |
| DUP            | DUP2           | 1  | 3     | 0.333 |
| DUP            | DUP3           | 1  | 3     | 0.333 |
| DUP            | DUP4           | 1  | 3     | 0.333 |
| DUP            | DUP5           | 1  | 3     | 0.333 |
| DUP            | DUP6           | 1  | 3     | 0.333 |
| DUP            | DUP7           | 1  | 3     | 0.333 |
| DUP            | DUP8           | 1  | 3     | 0.333 |
| DUP            | DUP9           | 1  | 3     | 0.333 |
| DUP            | DUP10          | 1  | 3     | 0.333 |
| DUP            | DUP11          | 1  | 3     | 0.333 |
| DUP            | DUP12          | 1  | 3     | 0.333 |
| DUP            | DUP13          | 1  | 3     | 0.333 |
| DUP            | DUP14          | 1  | 3     | 0.333 |
| DUP            | DUP15          | 1  | 3     | 0.333 |
| DUP            | DUP16          | 1  | 3     | 0.333 |
| SWAP           | SWAP1          | 1  | 3     | 0.333 |
| SWAP           | SWAP2          | 1  | 3     | 0.333 |
| SWAP           | SWAP3          | 1  | 3     | 0.333 |
| SWAP           | SWAP4          | 1  | 3     | 0.333 |
| SWAP           | SWAP5          | 1  | 3     | 0.333 |
| SWAP           | SWAP6          | 1  | 3     | 0.333 |
| SWAP           | SWAP7          | 1  | 3     | 0.333 |
| SWAP           | SWAP8          | 1  | 3     | 0.333 |
| SWAP           | SWAP9          | 1  | 3     | 0.333 |
| SWAP           | SWAP10         | 1  | 3     | 0.333 |
| SWAP           | SWAP11         | 1  | 3     | 0.333 |
| SWAP           | SWAP12         | 1  | 3     | 0.333 |
| SWAP           | SWAP13         | 1  | 3     | 0.333 |
| SWAP           | SWAP14         | 1  | 3     | 0.333 |
| SWAP           | SWAP15         | 1  | 3     | 0.333 |
| SWAP           | SWAP16         | 1  | 3     | 0.333 |
| LOG            | LOG0           | 2  | 902   | 0.002 |
| LOG            | LOG1           | 2  | 1277  | 0.002 |
| LOG            | LOG2           | 2  | 1652  | 0.001 |
| LOG            | LOG3           | 2  | 2027  | 0.001 |
| LOG            | LOG4           | 2  | 2402  | 0.001 |
| CALL_OP        | CALL           | 21 | 36686 | 0.001 |
| CALL_OP        | CALLCODE       | 21 | 11686 | 0.002 |
| CALL_OP        | DELEGATECALL   | 21 | 2689  | 0.008 |
| CALL_OP        | STATICCALL     | 21 | 2689  | 0.008 |
| RETURN_REVERT  | RETURN         | 3  | 15    | 0.200 |
| RETURN_REVERT  | REVERT         | 3  | 15    | 0.200 |

</details>

<details><summary>Updated stats for State Circuit</summary>

| state          | opcode         | h    | g     | h/g    |
| -------------- | -------------- | ---- | ----- | ------ |
| STOP           | STOP           | 13   | 0     | inf    |
| ADD_SUB        | ADD            | 3    | 3     | 1.000  |
| ADD_SUB        | SUB            | 3    | 3     | 1.000  |
| MUL_DIV_MOD    | MUL            | 3    | 5     | 0.600  |
| MUL_DIV_MOD    | DIV            | 3    | 5     | 0.600  |
| MUL_DIV_MOD    | MOD            | 3    | 5     | 0.600  |
| SDIV_SMOD      | SDIV           | 3    | 5     | 0.600  |
| SDIV_SMOD      | SMOD           | 3    | 5     | 0.600  |
| SHL_SHR        | SHL            | 3    | 3     | 1.000  |
| SHL_SHR        | SHR            | 3    | 3     | 1.000  |
| ADDMOD         | ADDMOD         | 4    | 8     | 0.500  |
| MULMOD         | MULMOD         | 4    | 8     | 0.500  |
| EXP            | EXP            | 3    | 60    | 0.050  |
| SIGNEXTEND     | SIGNEXTEND     | 3    | 5     | 0.600  |
| CMP            | LT             | 3    | 3     | 1.000  |
| CMP            | GT             | 3    | 3     | 1.000  |
| CMP            | EQ             | 3    | 3     | 1.000  |
| SCMP           | SLT            | 3    | 3     | 1.000  |
| SCMP           | SGT            | 3    | 3     | 1.000  |
| ISZERO         | ISZERO         | 2    | 3     | 0.667  |
| BITWISE        | AND            | 3    | 3     | 1.000  |
| BITWISE        | OR             | 3    | 3     | 1.000  |
| BITWISE        | XOR            | 3    | 3     | 1.000  |
| NOT            | NOT            | 2    | 3     | 0.667  |
| BYTE           | BYTE           | 3    | 3     | 1.000  |
| SAR            | SAR            | 3    | 3     | 1.000  |
| SHA3           | SHA3           | 4099 | 1214  | 3.376  |
| ADDRESS        | ADDRESS        | 2    | 2     | 1.000  |
| BALANCE        | BALANCE        | 7    | 2600  | 0.003  |
| ORIGIN         | ORIGIN         | 2    | 2     | 1.000  |
| CALLER         | CALLER         | 2    | 2     | 1.000  |
| CALLVALUE      | CALLVALUE      | 2    | 2     | 1.000  |
| CALLDATALOAD   | CALLDATALOAD   | 5    | 3     | 1.667  |
| CALLDATASIZE   | CALLDATASIZE   | 2    | 2     | 1.000  |
| CALLDATACOPY   | CALLDATACOPY   | 4102 | 803   | 5.108  |
| CODESIZE       | CODESIZE       | 1    | 2     | 0.500  |
| CODECOPY       | CODECOPY       | 4099 | 803   | 5.105  |
| GASPRICE       | GASPRICE       | 2    | 2     | 1.000  |
| EXTCODESIZE    | EXTCODESIZE    | 7    | 2600  | 0.003  |
| EXTCODECOPY    | EXTCODECOPY    | 4105 | 900   | 4.561  |
| RETURNDATASIZE | RETURNDATASIZE | 2    | 2     | 1.000  |
| RETURNDATACOPY | RETURNDATACOPY | 8198 | 803   | 10.209 |
| EXTCODEHASH    | EXTCODEHASH    | 7    | 2600  | 0.003  |
| BLOCKHASH      | BLOCKHASH      | 2    | 20    | 0.100  |
| BLOCKCTXU64    | TIMESTAMP      | 1    | 2     | 0.500  |
| BLOCKCTXU64    | NUMBER         | 1    | 2     | 0.500  |
| BLOCKCTXU64    | GASLIMIT       | 1    | 2     | 0.500  |
| BLOCKCTXU160   | COINBASE       | 1    | 2     | 0.500  |
| BLOCKCTXU256   | DIFFICULTY     | 1    | 2     | 0.500  |
| BLOCKCTXU256   | BASEFEE        | 1    | 2     | 0.500  |
| CHAINID        | CHAINID        | 1    | 2     | 0.500  |
| SELFBALANCE    | SELFBALANCE    | 3    | 5     | 0.600  |
| POP            | POP            | 1    | 2     | 0.500  |
| MEMORY         | MLOAD          | 34   | 15    | 2.267  |
| MEMORY         | MSTORE         | 34   | 15    | 2.267  |
| MEMORY         | MSTORE8        | 3    | 12    | 0.250  |
| SLOAD          | SLOAD          | 8    | 2100  | 0.004  |
| SSTORE         | SSTORE         | 10   | 22100 | 0.000  |
| JUMP           | JUMP           | 16   | 8     | 2.000  |
| JUMPI          | JUMPI          | 17   | 10    | 1.700  |
| PC             | PC             | 1    | 2     | 0.500  |
| MSIZE          | MSIZE          | 1    | 2     | 0.500  |
| GAS            | GAS            | 1    | 2     | 0.500  |
| JUMPDEST       | JUMPDEST       | 0    | 1     | 0.000  |
| PUSH           | PUSH1          | 1    | 3     | 0.333  |
| PUSH           | PUSH2          | 1    | 3     | 0.333  |
| PUSH           | PUSH3          | 1    | 3     | 0.333  |
| PUSH           | PUSH4          | 1    | 3     | 0.333  |
| PUSH           | PUSH5          | 1    | 3     | 0.333  |
| PUSH           | PUSH6          | 1    | 3     | 0.333  |
| PUSH           | PUSH7          | 1    | 3     | 0.333  |
| PUSH           | PUSH8          | 1    | 3     | 0.333  |
| PUSH           | PUSH9          | 1    | 3     | 0.333  |
| PUSH           | PUSH10         | 1    | 3     | 0.333  |
| PUSH           | PUSH11         | 1    | 3     | 0.333  |
| PUSH           | PUSH12         | 1    | 3     | 0.333  |
| PUSH           | PUSH13         | 1    | 3     | 0.333  |
| PUSH           | PUSH14         | 1    | 3     | 0.333  |
| PUSH           | PUSH15         | 1    | 3     | 0.333  |
| PUSH           | PUSH16         | 1    | 3     | 0.333  |
| PUSH           | PUSH17         | 1    | 3     | 0.333  |
| PUSH           | PUSH18         | 1    | 3     | 0.333  |
| PUSH           | PUSH19         | 1    | 3     | 0.333  |
| PUSH           | PUSH20         | 1    | 3     | 0.333  |
| PUSH           | PUSH21         | 1    | 3     | 0.333  |
| PUSH           | PUSH22         | 1    | 3     | 0.333  |
| PUSH           | PUSH23         | 1    | 3     | 0.333  |
| PUSH           | PUSH24         | 1    | 3     | 0.333  |
| PUSH           | PUSH25         | 1    | 3     | 0.333  |
| PUSH           | PUSH26         | 1    | 3     | 0.333  |
| PUSH           | PUSH27         | 1    | 3     | 0.333  |
| PUSH           | PUSH28         | 1    | 3     | 0.333  |
| PUSH           | PUSH29         | 1    | 3     | 0.333  |
| PUSH           | PUSH30         | 1    | 3     | 0.333  |
| PUSH           | PUSH31         | 1    | 3     | 0.333  |
| PUSH           | PUSH32         | 1    | 3     | 0.333  |
| DUP            | DUP1           | 2    | 3     | 0.667  |
| DUP            | DUP2           | 2    | 3     | 0.667  |
| DUP            | DUP3           | 2    | 3     | 0.667  |
| DUP            | DUP4           | 2    | 3     | 0.667  |
| DUP            | DUP5           | 2    | 3     | 0.667  |
| DUP            | DUP6           | 2    | 3     | 0.667  |
| DUP            | DUP7           | 2    | 3     | 0.667  |
| DUP            | DUP8           | 2    | 3     | 0.667  |
| DUP            | DUP9           | 2    | 3     | 0.667  |
| DUP            | DUP10          | 2    | 3     | 0.667  |
| DUP            | DUP11          | 2    | 3     | 0.667  |
| DUP            | DUP12          | 2    | 3     | 0.667  |
| DUP            | DUP13          | 2    | 3     | 0.667  |
| DUP            | DUP14          | 2    | 3     | 0.667  |
| DUP            | DUP15          | 2    | 3     | 0.667  |
| DUP            | DUP16          | 2    | 3     | 0.667  |
| SWAP           | SWAP1          | 4    | 3     | 1.333  |
| SWAP           | SWAP2          | 4    | 3     | 1.333  |
| SWAP           | SWAP3          | 4    | 3     | 1.333  |
| SWAP           | SWAP4          | 4    | 3     | 1.333  |
| SWAP           | SWAP5          | 4    | 3     | 1.333  |
| SWAP           | SWAP6          | 4    | 3     | 1.333  |
| SWAP           | SWAP7          | 4    | 3     | 1.333  |
| SWAP           | SWAP8          | 4    | 3     | 1.333  |
| SWAP           | SWAP9          | 4    | 3     | 1.333  |
| SWAP           | SWAP10         | 4    | 3     | 1.333  |
| SWAP           | SWAP11         | 4    | 3     | 1.333  |
| SWAP           | SWAP12         | 4    | 3     | 1.333  |
| SWAP           | SWAP13         | 4    | 3     | 1.333  |
| SWAP           | SWAP14         | 4    | 3     | 1.333  |
| SWAP           | SWAP15         | 4    | 3     | 1.333  |
| SWAP           | SWAP16         | 4    | 3     | 1.333  |
| LOG            | LOG0           | 8199 | 33559 | 0.244  |
| LOG            | LOG1           | 8201 | 33934 | 0.242  |
| LOG            | LOG2           | 8203 | 34309 | 0.239  |
| LOG            | LOG3           | 8205 | 34684 | 0.237  |
| LOG            | LOG4           | 8207 | 35059 | 0.234  |
| CALL_OP        | CALL           | 24   | 36686 | 0.001  |
| CALL_OP        | CALLCODE       | 22   | 11686 | 0.002  |
| CALL_OP        | DELEGATECALL   | 23   | 2689  | 0.009  |
| CALL_OP        | STATICCALL     | 21   | 2689  | 0.008  |
| RETURN_REVERT  | RETURN         | 8212 | 416   | 19.740 |
| RETURN_REVERT  | REVERT         | 8213 | 416   | 19.743 |

</details>
