### PR TITLE
Fix/bool checks

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -399,6 +399,12 @@ impl<F: Field> ExecutionConfig<F> {
                     1.expr(),
                 )
             });
+            // For every step, is_create and is_root are boolean.
+            cb.require_boolean(
+                "step.is_create is boolean",
+                step_curr.state.is_create.expr(),
+            );
+            cb.require_boolean("step.is_root is boolean", step_curr.state.is_root.expr());
             // q_step needs to be enabled on the last row
             cb.condition(q_step_last, |cb| {
                 cb.require_equal("q_step == 1", q_step.clone(), 1.expr());

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -400,11 +400,13 @@ impl<F: Field> ExecutionConfig<F> {
                 )
             });
             // For every step, is_create and is_root are boolean.
-            cb.require_boolean(
-                "step.is_create is boolean",
-                step_curr.state.is_create.expr(),
-            );
-            cb.require_boolean("step.is_root is boolean", step_curr.state.is_root.expr());
+            cb.condition(q_step.clone(), |cb| {
+                cb.require_boolean(
+                    "step.is_create is boolean",
+                    step_curr.state.is_create.expr(),
+                );
+                cb.require_boolean("step.is_root is boolean", step_curr.state.is_root.expr());
+            });
             // q_step needs to be enabled on the last row
             cb.condition(q_step_last, |cb| {
                 cb.require_equal("q_step == 1", q_step.clone(), 1.expr());


### PR DESCRIPTION
### Description

Boolean checks were missing for a step's `is_create` and `is_root` fields.

### Issue Link

Issue originated from Scroll's fork: https://github.com/scroll-tech/zkevm-circuits/issues/325

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update