### PR TITLE
feat: cache EVM circuit configuration in unit tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,4 @@ debug-assertions = true
 overflow-checks = true
 rpath = false
 lto = "thin"
-incremental = false
+incremental = true

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -291,6 +291,7 @@ pub(crate) mod cached {
     use halo2_proofs::halo2curves::bn256::Fr;
     use lazy_static::lazy_static;
 
+    /// Cache
     struct Cache {
         cs: ConstraintSystem<Fr>,
         config: (EvmCircuitConfig<Fr>, Challenges),
@@ -300,10 +301,7 @@ pub(crate) mod cached {
         static ref CACHE: Cache = {
             let mut meta = ConstraintSystem::<Fr>::default();
             let config = EvmCircuit::<Fr>::configure(&mut meta);
-            Cache {
-                cs: meta,
-                config: config,
-            }
+            Cache { cs: meta, config }
         };
     }
 

--- a/zkevm-circuits/src/test_util.rs
+++ b/zkevm-circuits/src/test_util.rs
@@ -1,7 +1,7 @@
 //! Testing utilities
 
 use crate::{
-    evm_circuit::EvmCircuit,
+    evm_circuit::{cached::EvmCircuitCached, EvmCircuit},
     state_circuit::StateCircuit,
     util::SubCircuit,
     witness::{Block, Rw},
@@ -211,7 +211,7 @@ impl<const NACC: usize, const NTX: usize> CircuitTestBuilder<NACC, NTX> {
 
             let (active_gate_rows, active_lookup_rows) = EvmCircuit::<Fr>::get_active_rows(&block);
 
-            let circuit = EvmCircuit::<Fr>::get_test_cicuit_from_block(block.clone());
+            let circuit = EvmCircuitCached::get_test_cicuit_from_block(block.clone());
             let prover = MockProver::<Fr>::run(k, &circuit, vec![]).unwrap();
 
             self.evm_checks.as_ref()(prover, &active_gate_rows, &active_lookup_rows)


### PR DESCRIPTION
### Description

This is an experiment to cache the EVM Circuit configuration so that it's reused in all unit tests, to see if github workflow tests time is reduced.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update