### PR TITLE
improve debuggability: better check of rw lookup and rw value

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -1307,10 +1307,10 @@ impl<F: Field> ExecutionConfig<F> {
             }
         }
 
-        let rlc_assignments: BTreeSet<_> = block
-            .rws
-            .table_assignments()
+        let rlc_assignments: BTreeSet<_> = step
+            .rw_indices
             .iter()
+            .map(|rw_idx| block.rws[*rw_idx])
             .map(|rw| {
                 rw.table_assignment_aux(evm_randomness)
                     .rlc(lookup_randomness)

--- a/zkevm-circuits/src/witness/block.rs
+++ b/zkevm-circuits/src/witness/block.rs
@@ -237,11 +237,13 @@ pub fn block_convert<F: Field>(
     block: &circuit_input_builder::Block,
     code_db: &bus_mapping::state_db::CodeDB,
 ) -> Result<Block<F>, Error> {
+    let rws = RwMap::from(&block.container);
+    rws.check_value();
     Ok(Block {
         // randomness: F::from(0x100), // Special value to reveal elements after RLC
         randomness: F::from(0xcafeu64),
         context: block.into(),
-        rws: RwMap::from(&block.container),
+        rws,
         txs: block
             .txs()
             .iter()

--- a/zkevm-circuits/src/witness/rw.rs
+++ b/zkevm-circuits/src/witness/rw.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use bus_mapping::operation::{self, AccountField, CallContextField, TxLogField, TxReceiptField};
 use eth_types::{Address, Field, ToAddress, ToLittleEndian, ToScalar, Word, U256};
 use halo2_proofs::circuit::Value;
+use halo2_proofs::halo2curves::bn256::Fr;
 use itertools::Itertools;
 
 use crate::evm_circuit::util::rlc;
@@ -11,6 +12,8 @@ use crate::table::{
     AccountFieldTag, CallContextFieldTag, RwTableTag, TxLogFieldTag, TxReceiptFieldTag,
 };
 use crate::util::build_tx_log_address;
+
+use super::MptUpdates;
 
 /// Rw constainer for a witness block
 #[derive(Debug, Default, Clone)]
@@ -36,6 +39,61 @@ impl RwMap {
             .enumerate()
         {
             debug_assert_eq!(idx, rw_counter - 1);
+        }
+    }
+    /// Check value in the same way like StateCircuit
+    pub fn check_value(&self) {
+        let mock_rand = Fr::from(0x1000u64);
+        let err_msg_first = "first access reads don't change value";
+        let err_msg_non_first = "non-first access reads don't change value";
+        let rows = self.table_assignments();
+        let updates = MptUpdates::mock_from(&rows);
+        let mut errs = Vec::new();
+        for idx in 1..rows.len() {
+            let row = &rows[idx];
+            let prev_row = &rows[idx - 1];
+            let is_first = {
+                let key = |row: &Rw| {
+                    (
+                        row.tag() as u64,
+                        row.id().unwrap_or_default(),
+                        row.address().unwrap_or_default(),
+                        row.field_tag().unwrap_or_default(),
+                        row.storage_key().unwrap_or_default(),
+                    )
+                };
+                key(prev_row) != key(row)
+            };
+            if !row.is_write() {
+                let value = row.value_assignment::<Fr>(mock_rand);
+                if is_first {
+                    // value == init_value
+                    let init_value = updates
+                        .get(row)
+                        .map(|u| u.value_assignments(mock_rand).1)
+                        .unwrap_or_default();
+                    if value != init_value {
+                        errs.push((idx, err_msg_first, *row, *prev_row));
+                    }
+                } else {
+                    // value == prev_value
+                    let prev_value = prev_row.value_assignment::<Fr>(mock_rand);
+
+                    if value != prev_value {
+                        errs.push((idx, err_msg_non_first, *row, *prev_row));
+                    }
+                }
+            }
+        }
+        log::debug!("after rw value check, err num: {}", errs.len());
+        for (idx, err_msg, row, prev_row) in errs {
+            log::debug!(
+                "err: rw idx: {}, reason: \"{}\", row: {:?}, prev_row: {:?}",
+                idx,
+                err_msg,
+                row,
+                prev_row
+            );
         }
     }
     /// Calculates the number of Rw::Start rows needed.

--- a/zkevm-circuits/src/witness/rw.rs
+++ b/zkevm-circuits/src/witness/rw.rs
@@ -85,15 +85,17 @@ impl RwMap {
                 }
             }
         }
-        log::debug!("after rw value check, err num: {}", errs.len());
-        for (idx, err_msg, row, prev_row) in errs {
-            log::debug!(
-                "err: rw idx: {}, reason: \"{}\", row: {:?}, prev_row: {:?}",
-                idx,
-                err_msg,
-                row,
-                prev_row
-            );
+        if !errs.is_empty() {
+            log::error!("after rw value check, err num: {}", errs.len());
+            for (idx, err_msg, row, prev_row) in errs {
+                log::error!(
+                    "err: rw idx: {}, reason: \"{}\", row: {:?}, prev_row: {:?}",
+                    idx,
+                    err_msg,
+                    row,
+                    prev_row
+                );
+            }
         }
     }
     /// Calculates the number of Rw::Start rows needed.


### PR DESCRIPTION


### Description

1. in evm circuit, check_rw_lookup only checks rw inside step instead of whole block. Improve running speedup greatly.
2. add a `check_value` method for RwMap. Without running StateCircuit we can quickly find almost problems related to rw::value.

### Issue Link

[_link issue here_]

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Contents

- [_item_]

### Rationale

[_design decisions and extended information_]

### How Has This Been Tested?

[_explanation_]

<hr>

## How to fill a PR description 

Please give a concise description of your PR.

The target readers could be future developers, reviewers, and auditors. By reading your description, they should easily understand the changes proposed in this pull request.

MUST: Reference the issue to resolve

### Single responsability

Is RECOMMENDED to create single responsibility commits, but not mandatory.

Anyway, you MUST enumerate the changes in a unitary way, e.g.

```
This PR contains:
- Cleanup of xxxx, yyyy
- Changed xxxx to yyyy in order to bla bla
- Added xxxx function to ...
- Refactored ....
```

### Design choices

RECOMMENDED to:
- What types of design choices did you face?
- What decisions you have made?
- Any valuable information that could help reviewers to think critically
