### PR TITLE
fix: update `ErrorOOGExpGadget` to use `CommonErrorGadget`

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_exp.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_exp.rs
@@ -1,13 +1,11 @@
 use crate::evm_circuit::execution::ExecutionGadget;
 use crate::evm_circuit::param::N_BYTES_GAS;
 use crate::evm_circuit::step::ExecutionState;
-use crate::evm_circuit::util::common_gadget::RestoreContextGadget;
-use crate::evm_circuit::util::constraint_builder::Transition::{Delta, Same};
-use crate::evm_circuit::util::constraint_builder::{ConstraintBuilder, StepStateTransition};
+use crate::evm_circuit::util::common_gadget::CommonErrorGadget;
+use crate::evm_circuit::util::constraint_builder::ConstraintBuilder;
 use crate::evm_circuit::util::math_gadget::{ByteSizeGadget, LtGadget};
 use crate::evm_circuit::util::{CachedRegion, Cell, Word};
 use crate::evm_circuit::witness::{Block, Call, ExecStep, Transaction};
-use crate::table::CallContextFieldTag;
 use crate::util::Expr;
 use eth_types::evm_types::{GasCost, OpcodeId};
 use eth_types::{Field, ToLittleEndian};
@@ -19,12 +17,11 @@ use halo2_proofs::plonk::Error;
 #[derive(Clone, Debug)]
 pub(crate) struct ErrorOOGExpGadget<F> {
     opcode: Cell<F>,
-    rw_counter_end_of_reversion: Cell<F>,
     base: Word<F>,
     exponent: Word<F>,
     exponent_byte_size: ByteSizeGadget<F>,
     insufficient_gas_cost: LtGadget<F, N_BYTES_GAS>,
-    restore_context: RestoreContextGadget<F>,
+    common_error_gadget: CommonErrorGadget<F>,
 }
 
 impl<F: Field> ExecutionGadget<F> for ErrorOOGExpGadget<F> {
@@ -34,7 +31,6 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGExpGadget<F> {
 
     fn configure(cb: &mut ConstraintBuilder<F>) -> Self {
         let opcode = cb.query_cell();
-        cb.opcode_lookup(opcode.expr(), 1.expr());
 
         cb.require_equal(
             "ErrorOutOfGasEXP opcode must be EXP",
@@ -74,66 +70,14 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGExpGadget<F> {
             1.expr(),
         );
 
-        // Current call must fail.
-        cb.call_context_lookup(false.expr(), None, CallContextFieldTag::IsSuccess, 0.expr());
-
-        let rw_counter_end_of_reversion = cb.query_cell();
-        cb.call_context_lookup(
-            false.expr(),
-            None,
-            CallContextFieldTag::RwCounterEndOfReversion,
-            rw_counter_end_of_reversion.expr(),
-        );
-
-        // Go to EndTx only when is_root.
-        let is_to_end_tx = cb.next.execution_state_selector([ExecutionState::EndTx]);
-        cb.require_equal(
-            "Go to EndTx only when is_root",
-            cb.curr.state.is_root.expr(),
-            is_to_end_tx,
-        );
-
-        // When it's a root call.
-        cb.condition(cb.curr.state.is_root.expr(), |cb| {
-            // Do step state transition.
-            cb.require_step_state_transition(StepStateTransition {
-                call_id: Same,
-                rw_counter: Delta(4.expr() + cb.curr.state.reversible_write_counter.expr()),
-                ..StepStateTransition::any()
-            });
-        });
-
-        // When it's an internal call, need to restore caller's state as finishing this
-        // call. Restore caller state to next StepState.
-        let restore_context = cb.condition(1.expr() - cb.curr.state.is_root.expr(), |cb| {
-            RestoreContextGadget::construct(
-                cb,
-                0.expr(),
-                0.expr(),
-                0.expr(),
-                0.expr(),
-                0.expr(),
-                0.expr(),
-            )
-        });
-
-        // Constrain RwCounterEndOfReversion.
-        let rw_counter_end_of_step =
-            cb.curr.state.rw_counter.expr() + cb.rw_counter_offset() - 1.expr();
-        cb.require_equal(
-            "rw_counter_end_of_reversion = rw_counter_end_of_step + reversible_counter",
-            rw_counter_end_of_reversion.expr(),
-            rw_counter_end_of_step + cb.curr.state.reversible_write_counter.expr(),
-        );
-
+        let common_error_gadget = CommonErrorGadget::construct(cb, opcode.expr(), 4.expr());
         Self {
             opcode,
-            rw_counter_end_of_reversion,
             base,
             exponent,
             exponent_byte_size,
             insufficient_gas_cost,
-            restore_context,
+            common_error_gadget,
         }
     }
 
@@ -157,11 +101,6 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGExpGadget<F> {
 
         self.opcode
             .assign(region, offset, Value::known(F::from(opcode.as_u64())))?;
-        self.rw_counter_end_of_reversion.assign(
-            region,
-            offset,
-            Value::known(F::from(call.rw_counter_end_of_reversion as u64)),
-        )?;
         self.base.assign(region, offset, Some(base.to_le_bytes()))?;
         self.exponent
             .assign(region, offset, Some(exponent.to_le_bytes()))?;
@@ -172,8 +111,10 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGExpGadget<F> {
             Value::known(F::from(step.gas_left)),
             Value::known(F::from(step.gas_cost)),
         )?;
-        self.restore_context
-            .assign(region, offset, block, call, step, 4)
+        self.common_error_gadget
+            .assign(region, offset, block, call, step, 4)?;
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
### Description

Update `ErrorOOGExpGadget` according to `CommonErrorGadget` refactor in PR https://github.com/privacy-scaling-explorations/zkevm-circuits/pull/1177.

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Could be tested via ErrorOOGExpGadget unit-test cases.