### PR TITLE
Bug: fix to handle `destination` overflow in `ErrorInvalidJumpGadget`

### DIFF
--- a/bus-mapping/src/evm/opcodes/error_invalid_jump.rs
+++ b/bus-mapping/src/evm/opcodes/error_invalid_jump.rs
@@ -1,7 +1,7 @@
 use crate::circuit_input_builder::{CircuitInputStateRef, ExecStep};
 use crate::evm::{Opcode, OpcodeId};
 use crate::Error;
-use eth_types::{GethExecStep, ToAddress, ToWord, Word};
+use eth_types::{GethExecStep, Word};
 
 #[derive(Debug, Copy, Clone)]
 pub(crate) struct InvalidJump;
@@ -22,7 +22,6 @@ impl Opcode for InvalidJump {
         // assert op code can only be JUMP or JUMPI
         assert!(geth_step.op == OpcodeId::JUMP || geth_step.op == OpcodeId::JUMPI);
         let is_jumpi = geth_step.op == OpcodeId::JUMPI;
-        let dest = geth_steps[0].stack.last()?.to_address();
         let mut condition: Word = Word::zero();
         if is_jumpi {
             condition = geth_step.stack.nth_last(1)?;
@@ -30,7 +29,7 @@ impl Opcode for InvalidJump {
         state.stack_read(
             &mut exec_step,
             geth_step.stack.last_filled(),
-            dest.to_word(),
+            geth_step.stack.last()?,
         )?;
         if is_jumpi {
             state.stack_read(


### PR DESCRIPTION
### Description

Reference go-ethereum function [opJump](https://github.com/ethereum/go-ethereum/blob/master/core/vm/instructions.go#L538
) and [validJumpdest](https://github.com/ethereum/go-ethereum/blob/master/core/vm/contract.go#L86), try to handle `destination` overflow in `ErrorInvalidJumpGadget`.

### Issue Link

Close https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/1257

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Add a new test case `invalid_jump_dest_overflow`.