### PR TITLE
zkevm_circuits: add zkevm chain fixture test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5027,6 +5027,8 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_xorshift",
+ "serde",
+ "serde_json",
  "sha3 0.10.6",
  "snark-verifier",
  "strum",

--- a/mock/src/test_ctx.rs
+++ b/mock/src/test_ctx.rs
@@ -88,7 +88,7 @@ pub struct TestContext<const NACC: usize, const NTX: usize> {
     /// Block from geth
     pub eth_block: eth_types::Block<eth_types::Transaction>,
     /// Execution Trace from geth
-    pub geth_traces: [eth_types::GethExecTrace; NTX],
+    pub geth_traces: Vec<eth_types::GethExecTrace>,
 }
 
 impl<const NACC: usize, const NTX: usize> From<TestContext<NACC, NTX>> for GethData {
@@ -171,7 +171,7 @@ impl<const NACC: usize, const NTX: usize> TestContext<NACC, NTX> {
         let geth_traces = gen_geth_traces(
             chain_id,
             block.clone(),
-            accounts.clone(),
+            accounts.to_vec(),
             history_hashes.clone(),
             logger_config,
         )?;
@@ -228,13 +228,13 @@ impl<const NACC: usize, const NTX: usize> TestContext<NACC, NTX> {
 
 /// Generates execution traces for the transactions included in the provided
 /// Block
-fn gen_geth_traces<const NACC: usize, const NTX: usize>(
+pub fn gen_geth_traces(
     chain_id: Word,
     block: Block<Transaction>,
-    accounts: [Account; NACC],
+    accounts: Vec<Account>,
     history_hashes: Option<Vec<Word>>,
     logger_config: LoggerConfig,
-) -> Result<[GethExecTrace; NTX], Error> {
+) -> Result<Vec<GethExecTrace>, Error> {
     let trace_config = TraceConfig {
         chain_id,
         history_hashes: history_hashes.unwrap_or_default(),
@@ -251,8 +251,7 @@ fn gen_geth_traces<const NACC: usize, const NTX: usize>(
         logger_config,
     };
     let traces = trace(&trace_config)?;
-    let result: [GethExecTrace; NTX] = traces.try_into().expect("Unexpected len mismatch");
-    Ok(result)
+    Ok(traces)
 }
 
 /// Collection of helper functions which contribute to specific rutines on the

--- a/zkevm-circuits/Cargo.toml
+++ b/zkevm-circuits/Cargo.toml
@@ -47,6 +47,8 @@ itertools = "0.10.1"
 mock = { path = "../mock" }
 pretty_assertions = "1.0.0"
 cli-table = "0.4"
+serde = { version = "1.0.130", features = ["derive"] }
+serde_json = "1.0.78"
 
 [features]
 default = []

--- a/zkevm-circuits/tests/prover_error.rs
+++ b/zkevm-circuits/tests/prover_error.rs
@@ -1,9 +1,11 @@
 // This file is intended to be used with fixtures generated from zkevm-chain.
-// Copy the `errors/<block number>` directory into the zkevm-circuits git root as `block` and
-// run via `cargo test -p zkevm-circuits --features test prover_error -- --nocapture --ignored`.
-// Change any constant variables like `MAX_TXS` to suit your needs.
+// Copy the `errors/<block number>` directory into the zkevm-circuits git root
+// as `block` and run via `cargo test -p zkevm-circuits --features test
+// prover_error -- --nocapture --ignored`. Change any constant variables like
+// `MAX_TXS` to suit your needs.
 use bus_mapping::circuit_input_builder::CircuitsParams;
 use bus_mapping::mock::BlockData;
+use env_logger::Env;
 use eth_types::geth_types::{Account, GethData};
 use eth_types::{Block, Bytes, Error, Transaction, Word, H160, U256};
 use halo2_proofs::dev::MockProver;
@@ -49,6 +51,7 @@ fn prover_error() {
         ..Default::default()
     };
 
+    env_logger::Builder::from_env(Env::default().default_filter_or("trace")).init();
     let eth_block = load_json("../block/block.json");
     let mut eth_block: Block<Transaction> = from_value(eth_block).unwrap();
     eth_block.base_fee_per_gas = Some(U256::zero());

--- a/zkevm-circuits/tests/prover_error.rs
+++ b/zkevm-circuits/tests/prover_error.rs
@@ -113,4 +113,5 @@ fn prover_error() {
         .expect("MockProver::run")
         .verify_par();
     println!("MockProver: {res:#?}");
+    res.expect("verify_par");
 }

--- a/zkevm-circuits/tests/prover_error.rs
+++ b/zkevm-circuits/tests/prover_error.rs
@@ -1,0 +1,113 @@
+// This file is intended to be used with fixtures generated from zkevm-chain.
+// Copy the `errors/<block number>` directory into the zkevm-circuits git root as `block` and
+// run via `cargo test -p zkevm-circuits --features test prover_error -- --nocapture --ignored`.
+// Change any constant variables like `MAX_TXS` to suit your needs.
+use bus_mapping::circuit_input_builder::CircuitsParams;
+use bus_mapping::mock::BlockData;
+use eth_types::geth_types::{Account, GethData};
+use eth_types::{Block, Bytes, Error, Transaction, Word, H160, U256};
+use halo2_proofs::dev::MockProver;
+use halo2_proofs::halo2curves::bn256::Fr;
+use mock::test_ctx::{gen_geth_traces, LoggerConfig};
+use serde_json::{from_value, Value};
+use std::io::BufReader;
+use std::{collections::HashMap, fs::File};
+use zkevm_circuits::super_circuit::SuperCircuit;
+use zkevm_circuits::util::SubCircuit;
+use zkevm_circuits::witness::block_convert;
+
+#[derive(serde::Deserialize)]
+struct MyAccount {
+    pub nonce: u64,
+    pub balance: Word,
+    pub code: Bytes,
+    pub storage: HashMap<Word, Word>,
+}
+
+fn load_json(path: &str) -> Value {
+    let file = File::open(path).expect(path);
+    let reader = BufReader::new(file);
+    let output: Value = serde_json::from_reader(reader)
+        .map_err(Error::SerdeError)
+        .unwrap();
+    output
+}
+
+#[test]
+#[ignore]
+fn prover_error() {
+    // change any of these values to your needs
+    const MAX_TXS: usize = 1;
+    const MAX_CALLDATA: usize = 256;
+    const MOCK_RANDOMNESS: u64 = 0x100;
+    let k = 19;
+    let chain_id = Word::from(99);
+    let circuit_params = CircuitsParams {
+        max_txs: MAX_TXS,
+        max_calldata: MAX_CALLDATA,
+        max_rws: 16388,
+        ..Default::default()
+    };
+
+    let eth_block = load_json("../block/block.json");
+    let mut eth_block: Block<Transaction> = from_value(eth_block).unwrap();
+    eth_block.base_fee_per_gas = Some(U256::zero());
+    println!("block {:#?}", eth_block);
+    let history_hashes: Vec<U256> = {
+        let hashes = load_json("../block/block_hashes.json");
+        let mut hashes: Vec<U256> = from_value(hashes).unwrap();
+        let block_num: usize = eth_block.number.unwrap().as_usize();
+
+        if block_num < hashes.len() {
+            hashes.drain((hashes.len() - block_num)..).collect()
+        } else {
+            hashes
+        }
+    };
+    let mut accounts: Vec<Account> = vec![];
+    {
+        let state = load_json("../block/prestate.json");
+        let state: HashMap<H160, MyAccount> = from_value(state[0]["result"].clone()).unwrap();
+        for (address, acc) in state {
+            let account = Account {
+                address,
+                nonce: acc.nonce.into(),
+                balance: acc.balance,
+                code: acc.code,
+                storage: acc.storage,
+            };
+            accounts.push(account);
+        }
+    }
+    let geth_traces = gen_geth_traces(
+        chain_id,
+        eth_block.clone(),
+        accounts.clone(),
+        Some(history_hashes.clone()),
+        LoggerConfig::default(),
+    )
+    .expect("gen_geth_traces");
+    let geth_data = GethData {
+        chain_id,
+        history_hashes,
+        eth_block,
+        geth_traces,
+        accounts,
+    };
+    let mut builder = BlockData::new_from_geth_data_with_params(geth_data.clone(), circuit_params)
+        .new_circuit_input_builder();
+    builder
+        .handle_block(&geth_data.eth_block, &geth_data.geth_traces)
+        .expect("handle_block");
+    let block_witness = {
+        let mut block = block_convert(&builder.block, &builder.code_db).expect("block_convert");
+        block.randomness = Fr::from(MOCK_RANDOMNESS);
+        block
+    };
+    let circuit =
+        SuperCircuit::<_, MAX_TXS, MAX_CALLDATA, MOCK_RANDOMNESS>::new_from_block(&block_witness);
+    let res = MockProver::run(k, &circuit, circuit.instance())
+        .expect("MockProver::run")
+        .verify_par();
+    println!("MockProver: {res:#?}");
+}


### PR DESCRIPTION
### Description

Introduces a new `prover_error` test that allows testing the SuperCircuit with the generated fixtures from zkevm-chain errors.

Instructions:
Copy the `errors/<block number>` directory into the zkevm-circuits git root as `block` and run via `cargo test -p zkevm-circuits --features test prover_error -- --nocapture --ignored`. Change any constant variables like `MAX_TXS` to suit your needs.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update