### PR TITLE
fix tx_accesslist_account_write for warm addresses in BeginTx

### DIFF
--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -383,16 +383,14 @@ pub fn gen_begin_tx_ops(state: &mut CircuitInputStateRef) -> Result<ExecStep, Er
 
     // Add caller and callee into access list
     for address in [call.caller_address, call.address] {
-        let is_cold = state.sdb.add_account_to_access_list(address);
-        if is_cold {
-            state.tx_accesslist_account_write(
-                &mut exec_step,
-                state.tx_ctx.id(),
-                address,
-                true,
-                false,
-            )?;
-        }
+        let is_warm_prev = !state.sdb.add_account_to_access_list(address);
+        state.tx_accesslist_account_write(
+            &mut exec_step,
+            state.tx_ctx.id(),
+            address,
+            true,
+            is_warm_prev,
+        )?;
     }
 
     // Calculate intrinsic gas cost

--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -383,14 +383,16 @@ pub fn gen_begin_tx_ops(state: &mut CircuitInputStateRef) -> Result<ExecStep, Er
 
     // Add caller and callee into access list
     for address in [call.caller_address, call.address] {
-        state.sdb.add_account_to_access_list(address);
-        state.tx_accesslist_account_write(
-            &mut exec_step,
-            state.tx_ctx.id(),
-            address,
-            true,
-            false,
-        )?;
+        let is_cold = state.sdb.add_account_to_access_list(address);
+        if is_cold {
+            state.tx_accesslist_account_write(
+                &mut exec_step,
+                state.tx_ctx.id(),
+                address,
+                true,
+                false,
+            )?;
+        }
     }
 
     // Calculate intrinsic gas cost

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -151,7 +151,8 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             tx_id.expr(),
             tx_callee_address.expr(),
             1.expr(),
-            // Freely choosen by prover, not a soundness issue
+            // No extra constraint being used here.
+            // Correctness will be enforced in build_tx_access_list_account_constraints
             is_caller_callee_equal.expr(),
             None,
         );

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -49,6 +49,7 @@ pub(crate) struct BeginTxGadget<F> {
     is_empty_code_hash: IsEqualGadget<F>,
     caller_nonce_hash_bytes: [Cell<F>; N_BYTES_WORD],
     create: ContractCreateGadget<F, false>,
+    is_caller_callee_equal: Cell<F>,
 }
 
 impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
@@ -145,13 +146,13 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             0.expr(),
             None,
         );
-        let is_warm_prev = not::expr(tx_caller_address.expr() - tx_callee_address.expr());
+        let is_caller_callee_equal = cb.query_bool();
         cb.account_access_list_write(
             tx_id.expr(),
             tx_callee_address.expr(),
             1.expr(),
             // Freely choosen by prover, not a soundness issue
-            is_warm_prev,
+            is_caller_callee_equal.expr(),
             None,
         );
 
@@ -409,6 +410,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             is_empty_code_hash,
             caller_nonce_hash_bytes,
             create,
+            is_caller_callee_equal,
         }
     }
 
@@ -445,19 +447,16 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             .caller_address
             .to_scalar()
             .expect("unexpected Address -> Scalar conversion failure");
+        let callee_address = tx
+            .callee_address
+            .to_scalar()
+            .expect("unexpected Address -> Scalar conversion failure");
         self.tx_caller_address
             .assign(region, offset, Value::known(caller_address))?;
         self.tx_caller_address_is_zero
             .assign(region, offset, caller_address)?;
-        self.tx_callee_address.assign(
-            region,
-            offset,
-            Value::known(
-                tx.callee_address
-                    .to_scalar()
-                    .expect("unexpected Address -> Scalar conversion failure"),
-            ),
-        )?;
+        self.tx_callee_address
+            .assign(region, offset, Value::known(callee_address))?;
         self.call_callee_address.assign(
             region,
             offset,
@@ -470,6 +469,11 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                 .to_scalar()
                 .expect("unexpected Address -> Scalar conversion failure"),
             ),
+        )?;
+        self.is_caller_callee_equal.assign(
+            region,
+            offset,
+            Value::known(F::from(caller_address == callee_address)),
         )?;
         self.tx_is_create
             .assign(region, offset, Value::known(F::from(tx.is_create as u64)))?;

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -49,7 +49,6 @@ pub(crate) struct BeginTxGadget<F> {
     is_empty_code_hash: IsEqualGadget<F>,
     caller_nonce_hash_bytes: [Cell<F>; N_BYTES_WORD],
     create: ContractCreateGadget<F, false>,
-    is_caller_callee_equal: IsEqualGadget<F>,
 }
 
 impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
@@ -146,13 +145,17 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             0.expr(),
             None,
         );
-        let is_caller_callee_equal =
-            IsEqualGadget::construct(cb, tx_caller_address.expr(), tx_callee_address.expr());
+        let is_warm_prev = select::expr(
+            tx_caller_address.expr() - tx_callee_address.expr(),
+            0.expr(),
+            1.expr(),
+        );
         cb.account_access_list_write(
             tx_id.expr(),
             tx_callee_address.expr(),
             1.expr(),
-            is_caller_callee_equal.expr(),
+            // Freely choosen by prover, not a soundness issue
+            is_warm_prev,
             None,
         );
 
@@ -410,7 +413,6 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             is_empty_code_hash,
             caller_nonce_hash_bytes,
             create,
-            is_caller_callee_equal,
         }
     }
 
@@ -447,16 +449,19 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             .caller_address
             .to_scalar()
             .expect("unexpected Address -> Scalar conversion failure");
-        let callee_address = tx
-            .callee_address
-            .to_scalar()
-            .expect("unexpected Address -> Scalar conversion failure");
         self.tx_caller_address
             .assign(region, offset, Value::known(caller_address))?;
         self.tx_caller_address_is_zero
             .assign(region, offset, caller_address)?;
-        self.tx_callee_address
-            .assign(region, offset, Value::known(callee_address))?;
+        self.tx_callee_address.assign(
+            region,
+            offset,
+            Value::known(
+                tx.callee_address
+                    .to_scalar()
+                    .expect("unexpected Address -> Scalar conversion failure"),
+            ),
+        )?;
         self.call_callee_address.assign(
             region,
             offset,
@@ -469,12 +474,6 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                 .to_scalar()
                 .expect("unexpected Address -> Scalar conversion failure"),
             ),
-        )?;
-        self.is_caller_callee_equal.assign_value(
-            region,
-            offset,
-            Value::known(caller_address),
-            Value::known(callee_address),
         )?;
         self.tx_is_create
             .assign(region, offset, Value::known(F::from(tx.is_create as u64)))?;

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -145,11 +145,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             0.expr(),
             None,
         );
-        let is_warm_prev = select::expr(
-            tx_caller_address.expr() - tx_callee_address.expr(),
-            0.expr(),
-            1.expr(),
-        );
+        let is_warm_prev = not::expr(tx_caller_address.expr() - tx_callee_address.expr());
         cb.account_access_list_write(
             tx_id.expr(),
             tx_callee_address.expr(),


### PR DESCRIPTION
### Description

Fixes state.tx_accesslist_account_write for warm addresses.

### Issue Link

Fixes: https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/1233

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

`cargo test -p zkevm-circuits --features test prover_error -- --nocapture --ignored`
with zkevm-chain fixtures

