### PR TITLE
fix get_step_error for tx deploy case

### DIFF
--- a/bus-mapping/src/circuit_input_builder/tracer_tests.rs
+++ b/bus-mapping/src/circuit_input_builder/tracer_tests.rs
@@ -101,6 +101,32 @@ fn mock_internal_create() -> Call {
     }
 }
 
+fn mock_root_create() -> Call {
+    Call {
+        call_id: 0,
+        caller_id: 0,
+        last_callee_id: 0,
+        kind: CallKind::Create,
+        is_static: false,
+        is_root: true,
+        is_persistent: false,
+        is_success: false,
+        rw_counter_end_of_reversion: 0,
+        caller_address: *ADDR_A,
+        address: *ADDR_B,
+        code_source: CodeSource::Memory,
+        code_hash: Hash::zero(),
+        depth: 1,
+        value: Word::zero(),
+        call_data_offset: 0,
+        call_data_length: 0,
+        return_data_offset: 0,
+        return_data_length: 0,
+        last_callee_return_data_offset: 0,
+        last_callee_return_data_length: 0,
+    }
+}
+
 //
 // Geth Errors ignored
 //
@@ -563,6 +589,61 @@ fn tracer_err_code_store_out_of_gas() {
     );
 }
 
+#[test]
+fn tracer_err_code_store_out_of_gas_tx_deploy() {
+    // code_creator outputs an empty array of length 0x100, which will
+    // exhaust the gas to store the code.
+    let code_len = 0x100;
+    let code_creator = bytecode! {
+        PUSH1(Word::zero()) // value
+        PUSH32(code_len) // offset
+        MSTORE
+        PUSH32(code_len) // length
+        PUSH1(0x00) // offset
+        RETURN
+    };
+
+    // Get the execution steps from the external tracer
+    let block: GethData = TestContext::<2, 1>::new_with_logger_config(
+        None,
+        |accs| {
+            accs[0].address(address!("0x0000000000000000000000000000000000000000"));
+            accs[1].address(*ADDR_B).balance(Word::from(1u64 << 30));
+        },
+        |mut txs, accs| {
+            txs[0]
+                .from(accs[1].address)
+                .gas(55000u64.into())
+                .nonce(Word::zero())
+                .input(code_creator.into());
+        },
+        |block, _tx| block.number(0x0264),
+        LoggerConfig::enable_memory(),
+    )
+    .unwrap()
+    .into();
+
+    // get last RETURN
+    let (index, step) = block.geth_traces[0]
+        .struct_logs
+        .iter()
+        .enumerate()
+        .rev()
+        .find(|(_, s)| s.op == OpcodeId::RETURN)
+        .unwrap();
+    let next_step = block.geth_traces[0].struct_logs.get(index + 1);
+    assert!(check_err_code_store_out_of_gas(step, next_step));
+
+    let mut builder = CircuitInputBuilderTx::new(&block, step);
+    // Set up call context at CREATE
+    builder.tx_ctx.call_is_success.push(false);
+    builder.state_ref().push_call(mock_root_create());
+    assert_eq!(
+        builder.state_ref().get_step_err(step, next_step).unwrap(),
+        Some(ExecError::CodeStoreOutOfGas)
+    );
+}
+
 fn check_err_invalid_code(step: &GethExecStep, next_step: Option<&GethExecStep>) -> bool {
     let offset = step.stack.nth_last(0).unwrap();
     let length = step.stack.nth_last(1).unwrap();
@@ -770,6 +851,61 @@ fn tracer_err_max_code_size_exceeded() {
     // Set up call context at RETURN
     builder.tx_ctx.call_is_success.push(false);
     builder.state_ref().push_call(mock_internal_create());
+    assert_eq!(
+        builder.state_ref().get_step_err(step, next_step).unwrap(),
+        Some(ExecError::MaxCodeSizeExceeded)
+    );
+}
+
+#[test]
+fn tracer_err_max_code_size_exceeded_tx_deploy() {
+    // code_creator outputs an empty array of length 0x6000 + 1, which will
+    // trigger the max code size limit.
+    let code_len = 0x6000 + 1;
+    let code_creator = bytecode! {
+        PUSH1(Word::zero()) // value
+        PUSH32(code_len) // offset
+        MSTORE
+        PUSH32(code_len) // length
+        PUSH1(0x00) // offset
+        RETURN
+    };
+
+    // Get the execution steps from the external tracer
+    let block: GethData = TestContext::<2, 1>::new_with_logger_config(
+        None,
+        |accs| {
+            accs[0].address(address!("0x0000000000000000000000000000000000000000"));
+            accs[1].address(*ADDR_B).balance(Word::from(1u64 << 30));
+        },
+        |mut txs, accs| {
+            txs[0]
+                .from(accs[1].address)
+                .gas(60000u64.into())
+                .nonce(Word::zero())
+                .input(code_creator.into());
+        },
+        |block, _tx| block.number(0x0264),
+        LoggerConfig::enable_memory(),
+    )
+    .unwrap()
+    .into();
+
+    // get last RETURN
+    let (index, step) = block.geth_traces[0]
+        .struct_logs
+        .iter()
+        .enumerate()
+        .rev()
+        .find(|(_, s)| s.op == OpcodeId::RETURN)
+        .unwrap();
+    let next_step = block.geth_traces[0].struct_logs.get(index + 1);
+    assert!(check_err_max_code_size_exceeded(step, next_step));
+
+    let mut builder = CircuitInputBuilderTx::new(&block, step);
+    // Set up call context at RETURN
+    builder.tx_ctx.call_is_success.push(false);
+    builder.state_ref().push_call(mock_root_create());
     assert_eq!(
         builder.state_ref().get_step_err(step, next_step).unwrap(),
         Some(ExecError::MaxCodeSizeExceeded)


### PR DESCRIPTION
### Description

fix get_step_error for tx deploy case
### Issue Link

try to fix #1267 
### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)




### How Has This Been Tested?
add two tx deploy trace tests

This PR contains:
- fix `get_step_err` to return tx deploy error.
- add two tx deploy trace tests to verify fix
