### PR TITLE
subcircuit trait for PiTestCircuit

### DIFF
--- a/zkevm-circuits/src/pi_circuit.rs
+++ b/zkevm-circuits/src/pi_circuit.rs
@@ -1456,12 +1456,39 @@ pub struct PiTestCircuit<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usi
 );
 
 #[cfg(any(feature = "test", test, feature = "test-circuits"))]
-impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize>
-    PiTestCircuit<F, MAX_TXS, MAX_CALLDATA>
+impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize> SubCircuit<F>
+    for PiTestCircuit<F, MAX_TXS, MAX_CALLDATA>
 {
+    type Config = PiCircuitConfig<F>;
+
+    fn new_from_block(block: &witness::Block<F>) -> Self {
+        let mut block = block.clone();
+        block.circuits_params.max_txs = MAX_TXS;
+        block.circuits_params.max_calldata = MAX_CALLDATA;
+
+        Self(PiCircuit::new_from_block(&block))
+    }
+
+    fn min_num_rows_block(block: &witness::Block<F>) -> (usize, usize) {
+        let mut block = block.clone();
+        block.circuits_params.max_txs = MAX_TXS;
+        block.circuits_params.max_calldata = MAX_CALLDATA;
+
+        PiCircuit::min_num_rows_block(&block)
+    }
+
     /// Compute the public inputs for this circuit.
-    pub fn instance(&self) -> Vec<Vec<F>> {
+    fn instance(&self) -> Vec<Vec<F>> {
         self.0.instance()
+    }
+
+    fn synthesize_sub(
+        &self,
+        _config: &Self::Config,
+        _challenges: &Challenges<Value<F>>,
+        _layouter: &mut impl Layouter<F>,
+    ) -> Result<(), Error> {
+        panic!("use PiCircuit for embedding instead");
     }
 }
 

--- a/zkevm-circuits/src/pi_circuit.rs
+++ b/zkevm-circuits/src/pi_circuit.rs
@@ -1465,14 +1465,14 @@ impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize> SubCircuit<F>
         assert_eq!(block.circuits_params.max_txs, MAX_TXS);
         assert_eq!(block.circuits_params.max_calldata, MAX_CALLDATA);
 
-        Self(PiCircuit::new_from_block(&block))
+        Self(PiCircuit::new_from_block(block))
     }
 
     fn min_num_rows_block(block: &witness::Block<F>) -> (usize, usize) {
         assert_eq!(block.circuits_params.max_txs, MAX_TXS);
         assert_eq!(block.circuits_params.max_calldata, MAX_CALLDATA);
 
-        PiCircuit::min_num_rows_block(&block)
+        PiCircuit::min_num_rows_block(block)
     }
 
     /// Compute the public inputs for this circuit.

--- a/zkevm-circuits/src/pi_circuit.rs
+++ b/zkevm-circuits/src/pi_circuit.rs
@@ -1469,9 +1469,8 @@ impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize> SubCircuit<F>
     }
 
     fn min_num_rows_block(block: &witness::Block<F>) -> (usize, usize) {
-        let mut block = block.clone();
-        block.circuits_params.max_txs = MAX_TXS;
-        block.circuits_params.max_calldata = MAX_CALLDATA;
+        assert_eq!(block.circuits_params.max_txs, MAX_TXS);
+        assert_eq!(block.circuits_params.max_calldata, MAX_CALLDATA);
 
         PiCircuit::min_num_rows_block(&block)
     }

--- a/zkevm-circuits/src/pi_circuit.rs
+++ b/zkevm-circuits/src/pi_circuit.rs
@@ -1462,9 +1462,8 @@ impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize> SubCircuit<F>
     type Config = PiCircuitConfig<F>;
 
     fn new_from_block(block: &witness::Block<F>) -> Self {
-        let mut block = block.clone();
-        block.circuits_params.max_txs = MAX_TXS;
-        block.circuits_params.max_calldata = MAX_CALLDATA;
+        assert_eq!(block.circuits_params.max_txs, MAX_TXS);
+        assert_eq!(block.circuits_params.max_calldata, MAX_CALLDATA);
 
         Self(PiCircuit::new_from_block(&block))
     }


### PR DESCRIPTION
### Description

This implements the `SubCircuit` trait for `PiTestCircuit`. PiTestCircuit isn't a subcircuit in technical terms and hence panics when `synthesize_sub` is called with a message to use the `PiCircuit` for embedding instead.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Rationale

After moving some code of macro bodies I had to update the types and zkevm-chain now requires the `SubCircuit` trait being implemented for all circuits used. Technically, PiTestCircuit isn't a Subcircuit. But without creating a new trait it makes downstream usage more streamlined.

### How Has This Been Tested?

In zkevm-chain