### PR TITLE
follow EIP-211: create/create2 successful case must set empty returndatasize

### DIFF
--- a/bus-mapping/src/evm/opcodes/return_revert.rs
+++ b/bus-mapping/src/evm/opcodes/return_revert.rs
@@ -49,21 +49,6 @@ impl Opcode for ReturnRevert {
 
         // Case A in the spec.
         if call.is_create() && call.is_success && length > 0 {
-            // EIP-211 RETURNDATASIZE should be 0 for CREATE/CREATE(2)
-            state.call_context_write(
-                &mut exec_step,
-                state.call()?.call_id,
-                CallContextField::LastCalleeReturnDataOffset,
-                0.into(),
-            );
-
-            state.call_context_write(
-                &mut exec_step,
-                state.call()?.call_id,
-                CallContextField::LastCalleeReturnDataLength,
-                0.into(),
-            );
-
             // Note: handle_return updates state.code_db. All we need to do here is push the
             // copy event.
             let code_hash = handle_create(

--- a/bus-mapping/src/evm/opcodes/return_revert.rs
+++ b/bus-mapping/src/evm/opcodes/return_revert.rs
@@ -49,6 +49,21 @@ impl Opcode for ReturnRevert {
 
         // Case A in the spec.
         if call.is_create() && call.is_success && length > 0 {
+            // EIP-211 RETURNDATASIZE should be 0 for CREATE/CREATE(2)
+            state.call_context_write(
+                &mut exec_step,
+                state.call()?.call_id,
+                CallContextField::LastCalleeReturnDataOffset,
+                0.into(),
+            );
+
+            state.call_context_write(
+                &mut exec_step,
+                state.call()?.call_id,
+                CallContextField::LastCalleeReturnDataLength,
+                0.into(),
+            );
+
             // Note: handle_return updates state.code_db. All we need to do here is push the
             // copy event.
             let code_hash = handle_create(

--- a/zkevm-circuits/src/evm_circuit/execution/return_revert.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/return_revert.rs
@@ -97,6 +97,14 @@ impl<F: Field> ExecutionGadget<F> for ReturnRevertGadget<F> {
             is_create.clone() * is_success.expr() * not::expr(copy_rw_increase_is_zero.expr());
         let (caller_id, address, reversion_info, code_hash) =
             cb.condition(is_contract_deployment.clone(), |cb| {
+                // EIP-211 RETURNDATASIZE should be 0 for CREATE/CREATE(2)
+                for (field_tag, value) in [
+                    (CallContextFieldTag::LastCalleeReturnDataOffset, 0.expr()),
+                    (CallContextFieldTag::LastCalleeReturnDataLength, 0.expr()),
+                ] {
+                    cb.call_context_lookup(true.expr(), None, field_tag, value);
+                }
+
                 // We don't need to place any additional constraints on code_hash because the
                 // copy circuit enforces that it is the hash of the bytes in the copy lookup.
                 let code_hash = cb.query_cell_phase2();
@@ -243,6 +251,10 @@ impl<F: Field> ExecutionGadget<F> for ReturnRevertGadget<F> {
         call: &Call,
         step: &ExecStep,
     ) -> Result<(), Error> {
+        // XXX: please pay attention to few hardcode number below for index to accessing
+        // `block.rws` Magic number follows rw_context lookup order in
+        // `configure` function
+
         self.opcode.assign(
             region,
             offset,
@@ -274,7 +286,7 @@ impl<F: Field> ExecutionGadget<F> for ReturnRevertGadget<F> {
         }
 
         if call.is_create && call.is_success {
-            let values: Vec<_> = (3..3 + length.as_usize())
+            let values: Vec<_> = (5..5 + length.as_usize())
                 .map(|i| block.rws[step.rw_indices[i]].memory_value())
                 .collect();
             let mut code_hash = keccak256(&values);
@@ -301,7 +313,7 @@ impl<F: Field> ExecutionGadget<F> for ReturnRevertGadget<F> {
         let is_contract_deployment = call.is_create && call.is_success && !length.is_zero();
         if !call.is_root {
             let rw_counter_offset = 3 + if is_contract_deployment {
-                5 + length.as_u64()
+                7 + length.as_u64()
             } else {
                 0
             };

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -142,7 +142,7 @@ impl<F: Field> RestoreContextGadget<F> {
                 select::expr(
                     is_call_create_and_success_expr.clone(),
                     0.expr(),
-                    return_data_offset.clone(),
+                    return_data_offset,
                 ),
             ),
             (


### PR DESCRIPTION
### Description

Align specs in EIP-211: returndatasize should be 0 after create/create2 success call

### Issue Link

Closed https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/1250

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Contents

- revamp `handle_restore_context` and `handle_return` to be able to handle create/create2 returndatasize 0 case
- add unittest to assure 1. create/create2 contract created successfully 2. bytecode with returndatasize/returndatacopy satisfy constraints
- add few comments for existing hardcode magic number

### Rationale

use magic number to access rws indices during assignment is inevitable. We might need a better design to address this issue.
One possible way is refactor, by bumping and returning index when every time calling rw_lookup, and exposing index value into XXXXXGadget like other `Cell` fields

### How Has This Been Tested?

`cargo test --package zkevm-circuits --lib --features test --features warn-unimplemented -- evm_circuit::execution::return_revert::test --nocapture`

<hr>