### PR TITLE
memory and mpt proof synchronization

### DIFF
--- a/zkevm-circuits/src/state_circuit.rs
+++ b/zkevm-circuits/src/state_circuit.rs
@@ -9,7 +9,7 @@ mod test;
 
 use crate::{
     evm_circuit::{param::N_BYTES_WORD, util::rlc},
-    table::{AccountFieldTag, LookupTable, MptTable, MPTProofType, RwTable, RwTableTag},
+    table::{AccountFieldTag, LookupTable, MPTProofType, MptTable, RwTable, RwTableTag},
     util::{Challenges, Expr, SubCircuit, SubCircuitConfig},
     witness::{self, MptUpdates, Rw, RwMap},
 };

--- a/zkevm-circuits/src/state_circuit.rs
+++ b/zkevm-circuits/src/state_circuit.rs
@@ -9,7 +9,7 @@ mod test;
 
 use crate::{
     evm_circuit::{param::N_BYTES_WORD, util::rlc},
-    table::{AccountFieldTag, LookupTable, MptTable, ProofType, RwTable, RwTableTag},
+    table::{AccountFieldTag, LookupTable, MptTable, MPTProofType, RwTable, RwTableTag},
     util::{Challenges, Expr, SubCircuit, SubCircuitConfig},
     witness::{self, MptUpdates, Rw, RwMap},
 };
@@ -59,8 +59,8 @@ pub struct StateCircuitConfig<F> {
     // others, it is 0.
     initial_value: Column<Advice>,
     // For Rw::AccountStorage, identify non-existing if both committed value and
-    // new value are zero. Will do lookup for ProofType::StorageDoesNotExist if
-    // non-existing, otherwise do lookup for ProofType::StorageChanged.
+    // new value are zero. Will do lookup for MPTProofType::NonExistingStorageProof if
+    // non-existing, otherwise do lookup for MPTProofType::StorageMod.
     is_non_exist: BatchedIsZeroConfig,
     // Intermediary witness used to reduce mpt lookup expression degree
     mpt_proof_type: Column<Advice>,
@@ -320,9 +320,9 @@ impl<F: Field> StateCircuitConfig<F> {
                 F::from(match row {
                     Rw::AccountStorage { .. } => {
                         if pair[0].is_zero_vartime() && pair[1].is_zero_vartime() {
-                            ProofType::StorageDoesNotExist as u64
+                            MPTProofType::NonExistingStorageProof as u64
                         } else {
-                            ProofType::StorageChanged as u64
+                            MPTProofType::StorageMod as u64
                         }
                     }
                     Rw::Account { field_tag, .. } => {
@@ -330,7 +330,7 @@ impl<F: Field> StateCircuitConfig<F> {
                             && pair[1].is_zero_vartime()
                             && matches!(field_tag, AccountFieldTag::CodeHash)
                         {
-                            ProofType::AccountDoesNotExist as u64
+                            MPTProofType::NonExistingAccountProof as u64
                         } else {
                             *field_tag as u64
                         }

--- a/zkevm-circuits/src/state_circuit/constraint_builder.rs
+++ b/zkevm-circuits/src/state_circuit/constraint_builder.rs
@@ -9,7 +9,7 @@ use crate::{
         param::N_BYTES_WORD,
         util::{math_gadget::generate_lagrange_base_polynomial, not},
     },
-    table::{AccountFieldTag, ProofType, RwTableTag},
+    table::{AccountFieldTag, MPTProofType, RwTableTag},
 };
 use eth_types::Field;
 use gadgets::binary_number::BinaryNumberConfig;
@@ -268,10 +268,10 @@ impl<F: Field> ConstraintBuilder<F> {
         // non-existing proof.
         let is_non_exist = q.is_non_exist();
         self.require_equal(
-            "mpt_proof_type is field_tag or StorageDoesNotExist",
+            "mpt_proof_type is field_tag or NonExistingStorageProof",
             q.mpt_proof_type(),
-            is_non_exist.expr() * ProofType::StorageDoesNotExist.expr()
-                + (1.expr() - is_non_exist) * ProofType::StorageChanged.expr(),
+            is_non_exist.expr() * MPTProofType::NonExistingStorageProof.expr()
+                + (1.expr() - is_non_exist) * MPTProofType::StorageMod.expr(),
         );
 
         // ref. spec 4.1. MPT lookup for last access to (address, storage_key)
@@ -420,10 +420,10 @@ impl<F: Field> ConstraintBuilder<F> {
                 .map(|t| *t as usize),
             );
         self.require_equal(
-            "mpt_proof_type is field_tag or AccountDoesNotExists",
+            "mpt_proof_type is field_tag or NonExistingAccountProofs",
             q.mpt_proof_type(),
             // degree = max(4, 4 + 1) = 5
-            is_non_exist.expr() * ProofType::AccountDoesNotExist.expr()
+            is_non_exist.expr() * MPTProofType::NonExistingAccountProof.expr()
                 + (1.expr() - is_non_exist) * q.field_tag(),
         );
 

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -557,29 +557,29 @@ impl RwTable {
 
 /// The types of proofs in the MPT table
 #[derive(Clone, Copy, Debug)]
-pub enum ProofType {
+pub enum MPTProofType {
     /// Nonce updated
-    NonceChanged = AccountFieldTag::Nonce as isize,
+    NonceMod = AccountFieldTag::Nonce as isize,
     /// Balance updated
-    BalanceChanged = AccountFieldTag::Balance as isize,
+    BalanceMod = AccountFieldTag::Balance as isize,
     /// Code hash exists
-    CodeHashExists = AccountFieldTag::CodeHash as isize,
+    CodeHashMod = AccountFieldTag::CodeHash as isize,
     /// Account does not exist
-    AccountDoesNotExist = AccountFieldTag::NonExisting as isize,
+    NonExistingAccountProof = AccountFieldTag::NonExisting as isize,
     /// Storage updated
-    StorageChanged,
+    StorageMod,
     /// Storage does not exist
-    StorageDoesNotExist,
+    NonExistingStorageProof,
 }
-impl_expr!(ProofType);
+impl_expr!(MPTProofType);
 
-impl From<AccountFieldTag> for ProofType {
+impl From<AccountFieldTag> for MPTProofType {
     fn from(tag: AccountFieldTag) -> Self {
         match tag {
-            AccountFieldTag::Nonce => Self::NonceChanged,
-            AccountFieldTag::Balance => Self::BalanceChanged,
-            AccountFieldTag::CodeHash => Self::CodeHashExists,
-            AccountFieldTag::NonExisting => Self::AccountDoesNotExist,
+            AccountFieldTag::Nonce => Self::NonceMod,
+            AccountFieldTag::Balance => Self::BalanceMod,
+            AccountFieldTag::CodeHash => Self::CodeHashMod,
+            AccountFieldTag::NonExisting => Self::NonExistingAccountProof,
         }
     }
 }

--- a/zkevm-circuits/src/witness/mpt.rs
+++ b/zkevm-circuits/src/witness/mpt.rs
@@ -1,6 +1,6 @@
 use crate::evm_circuit::util::rlc;
 use crate::evm_circuit::witness::Rw;
-use crate::table::{AccountFieldTag, ProofType};
+use crate::table::{AccountFieldTag, MPTProofType};
 use eth_types::{Address, Field, ToLittleEndian, ToScalar, Word};
 use halo2_proofs::circuit::Value;
 use itertools::Itertools;
@@ -21,9 +21,9 @@ impl MptUpdate {
         let proof_type = match self.key {
             Key::AccountStorage { .. } => {
                 if self.old_value.is_zero() && self.new_value.is_zero() {
-                    ProofType::StorageDoesNotExist
+                    MPTProofType::NonExistingStorageProof
                 } else {
-                    ProofType::StorageChanged
+                    MPTProofType::StorageMod
                 }
             }
             Key::Account { field_tag, .. } => field_tag.into(),


### PR DESCRIPTION
I synchronized memory and mpt proof according to spec synchronization.
https://github.com/privacy-scaling-explorations/zkevm-specs/pull/385

I did following things.

- add [2.1 constraint](https://github.com/privacy-scaling-explorations/zkevm-specs/blob/master/specs/state-proof.md#memory)
- update ProofType

I would appreciate it if you could confirm.
Thank you!