### PR TITLE
add scheduler, add conditional parameter provertype, add workflow_dis…

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,16 +1,30 @@
 name: Integration Tests
 
 on:
+  schedule:
+    - cron: '50 1 * * SUN'
   pull_request:
     types: [synchronize, labeled]
   push:
     branches:
       - main
-  workflow_dispatch:      
+  workflow_dispatch:    
+    inputs:
+      provertype:
+        description: 'invoke real vs mock prover'
+        required: true
+        default: 'mock_prover'
+        type: choice
+        options:
+        - real_prover
+        - mock_prover  
 
 jobs:
   consecutiveness:
-    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'trigger-integration-tests')
+    if: github.event_name == 'push' ||
+        github.event_name == 'workflow_dispatch' ||
+        contains(github.event.pull_request.labels.*.name, 'trigger-integration-tests')
+
 
     runs-on: ubuntu-latest
     steps:
@@ -41,6 +55,19 @@ jobs:
       run:
         working-directory: ./integration-tests
     steps:
+      - name: Set provertype to mock_prover for push & pull_request_labelled
+        run: |
+          echo "provertype=mock_prover" >> $GITHUB_ENV
+        if: github.event_name == 'push' ||
+            github.event_name == 'pull_request'
+      - name: Set provertype to workflow_dispatch choice
+        run: |
+          echo "provertype=${{ inputs.provertype }}" >> $GITHUB_ENV
+        if: github.event_name == 'workflow_dispatch'
+      - name: Set provertype to real_prover for scheduled runs
+        run: |
+          echo "provertype=real_prover" >> $GITHUB_ENV
+        if: github.event_name == 'schedule'
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
@@ -78,5 +105,5 @@ jobs:
       - run: ./run.sh --steps "gendata"
       - run: ./run.sh --steps "tests" --tests "rpc"
       - run: ./run.sh --steps "tests" --tests "circuit_input_builder"
-      - run: RUST_TEST_THREADS=1 ./run.sh --steps "tests" --tests "circuits::mock_prover"
+      - run: RUST_TEST_THREADS=1 ./run.sh --steps "tests" --tests "circuits::${{ env.provertype }}"
       - run: ./run.sh --steps "cleanup"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -21,7 +21,8 @@ on:
 
 jobs:
   consecutiveness:
-    if: github.event_name == 'push' ||
+    if: github.event_name == 'schedule' ||
+        github.event_name == 'push' ||
         github.event_name == 'workflow_dispatch' ||
         contains(github.event.pull_request.labels.*.name, 'trigger-integration-tests')
 


### PR DESCRIPTION
### Description
As a follow up to #1290, we add required input choices for manual trigger (workflow_dispatch), as a means to define whether we want to invoke mock or real prover and select target branch.
We introduce environment variable [provertype] 
We also add a scheduler to trigger integration tests every Sunday at 01:50AM. Scheduled job will default to real_prover.
Consecutiveness job is also now enforced on scheduled events and workflow_dispatch

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Contents

- Changed File: .github/workflows/integration.yml

### Rationale
Overall, we want integration tests to be invoked on 4 distinct occasions:
1. Ready for Review PRs, labelled as 'trigger-integration-tests'
2. On branch push to main
3. On a predefined interval (once a week on offline hours for now)
4. On demand

1 and 2 are always executed with mock object to save time and cloud resources
3 is always executed with real_prover
4 allows selection of both prover type and branch to execute integration tests against. 

### Design choices

Due to gh actions not supporting ternary operations on environment variables
for example:
    if github.event == pull_request:
        env.provertype="mock_prover"
    elif github.event == schedule:
        env.provertype="real_prover"

we introduce new job steps to conditionally inject ${{ env.provertype }} to $GITHUB_ENV, for example:
    - name: Set provertype to workflow_dispatch choice
        run: |
          echo "provertype=${{ inputs.provertype }}" >> $GITHUB_ENV
        if: github.event_name == 'workflow_dispatch'


