### PR TITLE
bus-mapping: more robust access parsing

### DIFF
--- a/bus-mapping/src/circuit_input_builder/access.rs
+++ b/bus-mapping/src/circuit_input_builder/access.rs
@@ -3,6 +3,9 @@ use eth_types::{evm_types::OpcodeId, Address, GethExecStep, GethExecTrace, ToAdd
 use ethers_core::utils::get_contract_address;
 use std::collections::{hash_map::Entry, HashMap, HashSet};
 
+use AccessValue::{Account, Code, Storage};
+use RW::{READ, WRITE};
+
 /// State and Code Access with "keys/index" used in the access operation.
 #[derive(Debug, PartialEq, Eq)]
 pub enum AccessValue {
@@ -116,9 +119,6 @@ pub fn gen_state_access_trace<TX>(
     tx: &eth_types::Transaction,
     geth_trace: &GethExecTrace,
 ) -> Result<Vec<Access>, Error> {
-    use AccessValue::{Account, Code, Storage};
-    use RW::{READ, WRITE};
-
     let mut call_stack: Vec<(Address, CodeSource)> = Vec::new();
     let mut accs = vec![Access::new(None, WRITE, Account { address: tx.from })];
     if let Some(to) = tx.to {
@@ -145,117 +145,124 @@ pub fn gen_state_access_trace<TX>(
             pop_call_stack = step.depth - 1 == next_step.depth;
         }
 
-        match step.op {
-            OpcodeId::SSTORE => {
-                let address = contract_address;
-                let key = step.stack.nth_last(0)?;
-                accs.push(Access::new(i, WRITE, Storage { address, key }));
-            }
-            OpcodeId::SLOAD => {
-                let address = contract_address;
-                let key = step.stack.nth_last(0)?;
-                accs.push(Access::new(i, READ, Storage { address, key }));
-            }
-            OpcodeId::SELFBALANCE => {
-                let address = contract_address;
-                accs.push(Access::new(i, READ, Account { address }));
-            }
-            OpcodeId::CODESIZE => {
-                if let CodeSource::Address(address) = code_source {
+        let result: Result<(), Error> = (|| {
+            match step.op {
+                OpcodeId::SSTORE => {
+                    let address = contract_address;
+                    let key = step.stack.nth_last(0)?;
+                    accs.push(Access::new(i, WRITE, Storage { address, key }));
+                }
+                OpcodeId::SLOAD => {
+                    let address = contract_address;
+                    let key = step.stack.nth_last(0)?;
+                    accs.push(Access::new(i, READ, Storage { address, key }));
+                }
+                OpcodeId::SELFBALANCE => {
+                    let address = contract_address;
+                    accs.push(Access::new(i, READ, Account { address }));
+                }
+                OpcodeId::CODESIZE => {
+                    if let CodeSource::Address(address) = code_source {
+                        accs.push(Access::new(i, READ, Code { address }));
+                    }
+                }
+                OpcodeId::CODECOPY => {
+                    if let CodeSource::Address(address) = code_source {
+                        accs.push(Access::new(i, READ, Code { address }));
+                    }
+                }
+                OpcodeId::BALANCE => {
+                    let address = step.stack.nth_last(0)?.to_address();
+                    accs.push(Access::new(i, READ, Account { address }));
+                }
+                OpcodeId::EXTCODEHASH => {
+                    let address = step.stack.nth_last(0)?.to_address();
+                    accs.push(Access::new(i, READ, Account { address }));
+                }
+                OpcodeId::EXTCODESIZE => {
+                    let address = step.stack.nth_last(0)?.to_address();
                     accs.push(Access::new(i, READ, Code { address }));
                 }
-            }
-            OpcodeId::CODECOPY => {
-                if let CodeSource::Address(address) = code_source {
+                OpcodeId::EXTCODECOPY => {
+                    let address = step.stack.nth_last(0)?.to_address();
                     accs.push(Access::new(i, READ, Code { address }));
                 }
-            }
-            OpcodeId::BALANCE => {
-                let address = step.stack.nth_last(0)?.to_address();
-                accs.push(Access::new(i, READ, Account { address }));
-            }
-            OpcodeId::EXTCODEHASH => {
-                let address = step.stack.nth_last(0)?.to_address();
-                accs.push(Access::new(i, READ, Account { address }));
-            }
-            OpcodeId::EXTCODESIZE => {
-                let address = step.stack.nth_last(0)?.to_address();
-                accs.push(Access::new(i, READ, Code { address }));
-            }
-            OpcodeId::EXTCODECOPY => {
-                let address = step.stack.nth_last(0)?.to_address();
-                accs.push(Access::new(i, READ, Code { address }));
-            }
-            OpcodeId::SELFDESTRUCT => {
-                let address = contract_address;
-                accs.push(Access::new(i, WRITE, Account { address }));
-                let address = step.stack.nth_last(0)?.to_address();
-                accs.push(Access::new(i, WRITE, Account { address }));
-            }
-            OpcodeId::CREATE => {
-                if push_call_stack {
-                    // Find CREATE result
-                    let address = get_call_result(&geth_trace.struct_logs[index..])
-                        .unwrap_or_else(Word::zero)
-                        .to_address();
-                    if !address.is_zero() {
-                        accs.push(Access::new(i, WRITE, Account { address }));
-                        accs.push(Access::new(i, WRITE, Code { address }));
+                OpcodeId::SELFDESTRUCT => {
+                    let address = contract_address;
+                    accs.push(Access::new(i, WRITE, Account { address }));
+                    let address = step.stack.nth_last(0)?.to_address();
+                    accs.push(Access::new(i, WRITE, Account { address }));
+                }
+                OpcodeId::CREATE => {
+                    if push_call_stack {
+                        // Find CREATE result
+                        let address = get_call_result(&geth_trace.struct_logs[index..])
+                            .unwrap_or_else(Word::zero)
+                            .to_address();
+                        if !address.is_zero() {
+                            accs.push(Access::new(i, WRITE, Account { address }));
+                            accs.push(Access::new(i, WRITE, Code { address }));
+                        }
+                        call_stack.push((address, CodeSource::Address(address)));
                     }
-                    call_stack.push((address, CodeSource::Address(address)));
                 }
-            }
-            OpcodeId::CREATE2 => {
-                if push_call_stack {
-                    // Find CREATE2 result
-                    let address = get_call_result(&geth_trace.struct_logs[index..])
-                        .unwrap_or_else(Word::zero)
-                        .to_address();
-                    if !address.is_zero() {
-                        accs.push(Access::new(i, WRITE, Account { address }));
-                        accs.push(Access::new(i, WRITE, Code { address }));
+                OpcodeId::CREATE2 => {
+                    if push_call_stack {
+                        // Find CREATE2 result
+                        let address = get_call_result(&geth_trace.struct_logs[index..])
+                            .unwrap_or_else(Word::zero)
+                            .to_address();
+                        if !address.is_zero() {
+                            accs.push(Access::new(i, WRITE, Account { address }));
+                            accs.push(Access::new(i, WRITE, Code { address }));
+                        }
+                        call_stack.push((address, CodeSource::Address(address)));
                     }
-                    call_stack.push((address, CodeSource::Address(address)));
                 }
-            }
-            OpcodeId::CALL => {
-                let address = contract_address;
-                accs.push(Access::new(i, WRITE, Account { address }));
+                OpcodeId::CALL => {
+                    let address = contract_address;
+                    accs.push(Access::new(i, WRITE, Account { address }));
 
-                let address = step.stack.nth_last(1)?.to_address();
-                accs.push(Access::new(i, WRITE, Account { address }));
-                accs.push(Access::new(i, READ, Code { address }));
-                if push_call_stack {
-                    call_stack.push((address, CodeSource::Address(address)));
+                    let address = step.stack.nth_last(1)?.to_address();
+                    accs.push(Access::new(i, WRITE, Account { address }));
+                    accs.push(Access::new(i, READ, Code { address }));
+                    if push_call_stack {
+                        call_stack.push((address, CodeSource::Address(address)));
+                    }
                 }
-            }
-            OpcodeId::CALLCODE => {
-                let address = contract_address;
-                accs.push(Access::new(i, WRITE, Account { address }));
+                OpcodeId::CALLCODE => {
+                    let address = contract_address;
+                    accs.push(Access::new(i, WRITE, Account { address }));
 
-                let address = step.stack.nth_last(1)?.to_address();
-                accs.push(Access::new(i, WRITE, Account { address }));
-                accs.push(Access::new(i, READ, Code { address }));
-                if push_call_stack {
-                    call_stack.push((address, CodeSource::Address(address)));
+                    let address = step.stack.nth_last(1)?.to_address();
+                    accs.push(Access::new(i, WRITE, Account { address }));
+                    accs.push(Access::new(i, READ, Code { address }));
+                    if push_call_stack {
+                        call_stack.push((address, CodeSource::Address(address)));
+                    }
                 }
-            }
-            OpcodeId::DELEGATECALL => {
-                let address = step.stack.nth_last(1)?.to_address();
-                accs.push(Access::new(i, READ, Code { address }));
-                if push_call_stack {
-                    call_stack.push((contract_address, CodeSource::Address(address)));
+                OpcodeId::DELEGATECALL => {
+                    let address = step.stack.nth_last(1)?.to_address();
+                    accs.push(Access::new(i, READ, Code { address }));
+                    if push_call_stack {
+                        call_stack.push((contract_address, CodeSource::Address(address)));
+                    }
                 }
-            }
-            OpcodeId::STATICCALL => {
-                let address = step.stack.nth_last(1)?.to_address();
-                accs.push(Access::new(i, READ, Code { address }));
-                if push_call_stack {
-                    call_stack.push((address, CodeSource::Address(address)));
+                OpcodeId::STATICCALL => {
+                    let address = step.stack.nth_last(1)?.to_address();
+                    accs.push(Access::new(i, READ, Code { address }));
+                    if push_call_stack {
+                        call_stack.push((address, CodeSource::Address(address)));
+                    }
                 }
+                _ => {}
             }
-            _ => {}
+            Ok(())
+        })();
+        if let Err(e) = result {
+            log::warn!("err when parsing access: {:?}, step {:?}", e, step);
         }
+
         if pop_call_stack {
             if call_stack.len() == 1 {
                 return Err(Error::InvalidGethExecStep(


### PR DESCRIPTION
### Description

When building AccessSet, we read stack input of opcode(eg: read last element of stack when processing  BALANCE opcode). But this method will encounter error when dealing with some ill-formed bytecode(BALANCE when empty stack). So in this PR, when access parsing for a single step encounters errors, the error is printed, the access parsing procedure will continue instead of being interrupted and return.

### Issue Link

[_link issue here_]

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Contents

- [_item_]

### Rationale

[_design decisions and extended information_]

### How Has This Been Tested?

"StackUnderFlowContractCreation_d0_g0_v0" in testool can pass with this PR

<hr>

## How to fill a PR description 

Please give a concise description of your PR.

The target readers could be future developers, reviewers, and auditors. By reading your description, they should easily understand the changes proposed in this pull request.

MUST: Reference the issue to resolve

### Single responsability

Is RECOMMENDED to create single responsibility commits, but not mandatory.

Anyway, you MUST enumerate the changes in a unitary way, e.g.

```
This PR contains:
- Cleanup of xxxx, yyyy
- Changed xxxx to yyyy in order to bla bla
- Added xxxx function to ...
- Refactored ....
```

### Design choices

RECOMMENDED to:
- What types of design choices did you face?
- What decisions you have made?
- Any valuable information that could help reviewers to think critically
