### PR TITLE
bus-mapping: fix clippy errors

### DIFF
--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -937,9 +937,11 @@ impl<'a> CircuitInputStateRef<'a> {
 
         let call = self.call()?.clone();
         let call_ctx = self.call_ctx()?;
+        let call_success_create: bool =
+            call.is_create() && call.is_success && step.op == OpcodeId::RETURN;
 
         // Store deployed code if it's a successful create
-        if call.is_create() && call.is_success && step.op == OpcodeId::RETURN {
+        if call_success_create {
             let offset = step.stack.nth_last(0)?;
             let length = step.stack.nth_last(1)?;
             let code = call_ctx
@@ -962,7 +964,7 @@ impl<'a> CircuitInputStateRef<'a> {
         if let Ok(caller) = self.caller_mut() {
             caller.last_callee_id = call.call_id;
             // EIP-211 CREATE/CREATE2 call successful case should set RETURNDATASIZE = 0
-            if step.op == OpcodeId::RETURN && call.is_create() && call.is_success {
+            if call_success_create {
                 caller.last_callee_return_data_length = 0u64;
                 caller.last_callee_return_data_offset = 0u64;
             } else {
@@ -972,13 +974,11 @@ impl<'a> CircuitInputStateRef<'a> {
         }
 
         // If current call has caller_ctx (has caller)
-        // EIP-211 CREATE/CREATE2 call successful case should set RETURNDATASIZE = 0
-        if let Ok(caller_ctx) = self.caller_ctx_mut() && (
-           step.op == OpcodeId::RETURN &&
-           call.is_create() &&
-           call.is_success
-        ) {
-            caller_ctx.return_data.truncate(0);
+        if let Ok(caller_ctx) = self.caller_ctx_mut() {
+            // EIP-211 CREATE/CREATE2 call successful case should set RETURNDATASIZE = 0
+            if call_success_create {
+                caller_ctx.return_data.truncate(0);
+            }
         }
 
         self.tx_ctx.pop_call_ctx();


### PR DESCRIPTION
### Description

Fixes the following error that can not be silenced from zkevm-chain
```
    Checking bus-mapping v0.1.0 (/app/deps/zkevm-circuits/bus-mapping)
error[E0658]: `let` expressions in this position are unstable
   --> deps/zkevm-circuits/bus-mapping/src/circuit_input_builder/input_state_ref.rs:976:12
    |
976 |         if let Ok(caller_ctx) = self.caller_ctx_mut() && (
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable

For more information about this error, try `rustc --explain E0658`.
error: could not compile `bus-mapping` due to previous error
```
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
