### PR TITLE
Integration tests with ephemeral runners via GitHub ops

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,11 +25,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  set-instance-type:
+    if: github.event.pull_request.draft == false
+
+    runs-on: ubuntu-latest
+    outputs:
+      output1: ${{ steps.set-instance-type.outputs.type }}
+    steps:
+      - id: set-instance-type
+        name: Select instance type
+        run: |
+          if [ "${{ github.event.inputs.provertype }}" = "mock_prover" ] || [ -z ${{ github.event.inputs.provertype }} ]; then
+            echo "type=c5.9xlarge" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event.inputs.provertype }}" = "real_prover" ]; then
+            echo "type=c5.24xlarge" >> "$GITHUB_OUTPUT"
+          else
+            exit 1
+          fi
+
   integration-tests:
     if: github.event.pull_request.draft == false
 
     name: Integration Tests
-    runs-on: ["${{github.run_id}}", self-hosted, x1e.4xlarge]
+    runs-on: ["${{github.run_id}}", self-hosted, "${{needs.set-instance-type.outputs.output1}}"]
+    needs: set-instance-type
 
     steps:
       - name: Set provertype to mock_prover for push & pull_request_labelled

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,6 +1,7 @@
 name: Integration Tests
 
 on:
+  merge_group:
   schedule:
     - cron: '50 1 * * SUN'
   pull_request:
@@ -19,38 +20,16 @@ on:
         - real_prover
         - mock_prover  
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  consecutiveness:
-    if: github.event_name == 'schedule' ||
-        github.event_name == 'push' ||
-        github.event_name == 'workflow_dispatch' ||
-        contains(github.event.pull_request.labels.*.name, 'trigger-integration-tests')
-
-
-    runs-on: ubuntu-latest
-    steps:
-      - uses: mktcode/consecutive-workflow-action@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-  wakeuprunner:
-    if: github.event.pull_request.draft == false
-
-    needs: [consecutiveness]
-    name: Wake up self-hosted runner
-    runs-on: pse-runner
-
-    steps:
-      - uses: actions/checkout@v2
-      - run: |
-          .github/integrationTestsScripts/wakeUpRunner.sh
-
   integration-tests:
     if: github.event.pull_request.draft == false
 
-    needs: [wakeuprunner]
     name: Integration Tests
-    runs-on: integration-tests-runner
+    runs-on: ["${{github.run_id}}", self-hosted, c5.9xlarge]
 
     defaults:
       run:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -36,12 +36,12 @@ jobs:
       - id: set-outputs
         name: Select instance and prover type
         run: |
-          if [ "${{ github.event.inputs.provertype }}" = "mock_prover" ] || [ -z ${{ github.event.inputs.provertype }} ]; then
-            echo "instancetype=c5.9xlarge" >> "$GITHUB_OUTPUT"
-            echo "provertype=mock_prover" >> "$GITHUB_OUTPUT"
-          elif [ "${{ github.event.inputs.provertype }}" = "real_prover" ]; then
+          if [ "${{ github.event.inputs.provertype }}" = "real_prover" ] || [ "${{ github.event_name }}" = "schedule" ]; then
             echo "instancetype=r6i.32xlarge" >> "$GITHUB_OUTPUT"
             echo "provertype=real_prover" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event.inputs.provertype }}" = "mock_prover" ] || [ -z ${{ github.event.inputs.provertype }} ]; then
+            echo "instancetype=c5.9xlarge" >> "$GITHUB_OUTPUT"
+            echo "provertype=mock_prover" >> "$GITHUB_OUTPUT"
           else
             exit 1
           fi

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,20 +25,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  set-instance-type:
+  set-outputs:
     if: github.event.pull_request.draft == false
 
     runs-on: ubuntu-latest
     outputs:
-      output1: ${{ steps.set-instance-type.outputs.type }}
+      instancetype: ${{ steps.set-outputs.outputs.instancetype }}
+      provertype: ${{ steps.set-outputs.outputs.provertype }}
     steps:
-      - id: set-instance-type
-        name: Select instance type
+      - id: set-outputs
+        name: Select instance and prover type
         run: |
           if [ "${{ github.event.inputs.provertype }}" = "mock_prover" ] || [ -z ${{ github.event.inputs.provertype }} ]; then
-            echo "type=c5.9xlarge" >> "$GITHUB_OUTPUT"
+            echo "instancetype=c5.9xlarge" >> "$GITHUB_OUTPUT"
+            echo "provertype=mock_prover" >> "$GITHUB_OUTPUT"
           elif [ "${{ github.event.inputs.provertype }}" = "real_prover" ]; then
-            echo "type=c5.24xlarge" >> "$GITHUB_OUTPUT"
+            echo "instancetype=r6i.32xlarge" >> "$GITHUB_OUTPUT"
+            echo "provertype=real_prover" >> "$GITHUB_OUTPUT"
           else
             exit 1
           fi
@@ -47,23 +50,10 @@ jobs:
     if: github.event.pull_request.draft == false
 
     name: Integration Tests
-    runs-on: ["${{github.run_id}}", self-hosted, "${{needs.set-instance-type.outputs.output1}}"]
-    needs: set-instance-type
+    runs-on: ["${{github.run_id}}", self-hosted, "${{needs.set-outputs.outputs.instancetype}}"]
+    needs: set-outputs
 
     steps:
-      - name: Set provertype to mock_prover for push & pull_request_labelled
-        run: |
-          echo "provertype=mock_prover" >> $GITHUB_ENV
-        if: github.event_name == 'push' ||
-            github.event_name == 'pull_request'
-      - name: Set provertype to workflow_dispatch choice
-        run: |
-          echo "provertype=${{ inputs.provertype }}" >> $GITHUB_ENV
-        if: github.event_name == 'workflow_dispatch'
-      - name: Set provertype to real_prover for scheduled runs
-        run: |
-          echo "provertype=real_prover" >> $GITHUB_ENV
-        if: github.event_name == 'schedule'
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
@@ -105,7 +95,7 @@ jobs:
         working-directory: integration-tests
       - run: ./run.sh --steps "tests" --tests "circuit_input_builder"
         working-directory: integration-tests
-      - run: RUST_TEST_THREADS=1 ./run.sh --steps "tests" --tests "circuits::${{ env.provertype }}"
+      - run: RUST_TEST_THREADS=1 ./run.sh --steps "tests" --tests "circuits::${{ needs.set-outputs.outputs.provertype }}"
         working-directory: integration-tests
       - run: ./run.sh --steps "cleanup"
         working-directory: integration-tests

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -31,9 +31,9 @@ jobs:
     name: Integration Tests
     runs-on: ["${{github.run_id}}", self-hosted, c5.9xlarge]
 
-    # defaults:
-    #   run:
-    #     working-directory: ./integration-tests
+    defaults:
+      run:
+        working-directory: integration-tests
     steps:
       - name: Set provertype to mock_prover for push & pull_request_labelled
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -76,17 +76,14 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      # Run an initial build in a separate step to split the build time from execution time
-      - name: Set workdir
-        run: pwd
-        working-directory: ./integration-tests    
+      # Run an initial build in a separate step to split the build time from execution time    
       - name: Build bins
         run: cargo build --bin gen_blockchain_data
       - name: Build tests
         run: for testname in rpc circuit_input_builder circuits; do cargo test --profile release --test $testname --features $testname --no-run; done
-      - run: ./run.sh --steps "setup"
-      - run: ./run.sh --steps "gendata"
-      - run: ./run.sh --steps "tests" --tests "rpc"
-      - run: ./run.sh --steps "tests" --tests "circuit_input_builder"
-      - run: RUST_TEST_THREADS=1 ./run.sh --steps "tests" --tests "circuits::${{ env.provertype }}"
-      - run: ./run.sh --steps "cleanup"
+      - run: ./integration-tests/run.sh --steps "setup"
+      - run: ./integration-tests/run.sh --steps "gendata"
+      - run: ./integration-tests/run.sh --steps "tests" --tests "rpc"
+      - run: ./integration-tests/run.sh --steps "tests" --tests "circuit_input_builder"
+      - run: RUST_TEST_THREADS=1 ./integration-tests/run.sh --steps "tests" --tests "circuits::${{ env.provertype }}"
+      - run: ./integration-tests/run.sh --steps "cleanup"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -31,9 +31,9 @@ jobs:
     name: Integration Tests
     runs-on: ["${{github.run_id}}", self-hosted, c5.9xlarge]
 
-    defaults:
-      run:
-        working-directory: integration-tests
+    # defaults:
+    #   run:
+    #     working-directory: integration-tests
     steps:
       - name: Set provertype to mock_prover for push & pull_request_labelled
         run: |
@@ -77,6 +77,8 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       # Run an initial build in a separate step to split the build time from execution time
+      - name: pause action
+        run: sleep 2000      
       - name: Build bins
         run: cargo build --bin gen_blockchain_data
       - name: Build tests

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -68,6 +68,8 @@ jobs:
             ${{ runner.os }}-go-
       - name: Cargo cache
         uses: actions/cache@v3
+        run:
+          working-directory: ./integration-tests        
         with:
           path: |
             ~/.cargo/bin/

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -81,9 +81,15 @@ jobs:
         run: cargo build --bin gen_blockchain_data
       - name: Build tests
         run: for testname in rpc circuit_input_builder circuits; do cargo test --profile release --test $testname --features $testname --no-run; done
-      - run: ./integration-tests/run.sh --steps "setup"
-      - run: ./integration-tests/run.sh --steps "gendata"
-      - run: ./integration-tests/run.sh --steps "tests" --tests "rpc"
-      - run: ./integration-tests/run.sh --steps "tests" --tests "circuit_input_builder"
-      - run: RUST_TEST_THREADS=1 ./integration-tests/run.sh --steps "tests" --tests "circuits::${{ env.provertype }}"
-      - run: ./integration-tests/run.sh --steps "cleanup"
+      - run: ./run.sh --steps "setup"
+        working-directory: integration-tests
+      - run: ./run.sh --steps "gendata"
+        working-directory: integration-tests
+      - run: ./run.sh --steps "tests" --tests "rpc"
+        working-directory: integration-tests
+      - run: ./run.sh --steps "tests" --tests "circuit_input_builder"
+        working-directory: integration-tests
+      - run: RUST_TEST_THREADS=1 ./run.sh --steps "tests" --tests "circuits::${{ env.provertype }}"
+        working-directory: integration-tests
+      - run: ./run.sh --steps "cleanup"
+        working-directory: integration-tests

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -77,8 +77,8 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       # Run an initial build in a separate step to split the build time from execution time
-      - name: pause action
-        run: sleep 2000      
+      - name: Set workdir
+        working-directory: ./integration-tests    
       - name: Build bins
         run: cargo build --bin gen_blockchain_data
       - name: Build tests

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -31,9 +31,9 @@ jobs:
     name: Integration Tests
     runs-on: ["${{github.run_id}}", self-hosted, c5.9xlarge]
 
-    defaults:
-      run:
-        working-directory: ./integration-tests
+    # defaults:
+    #   run:
+    #     working-directory: ./integration-tests
     steps:
       - name: Set provertype to mock_prover for push & pull_request_labelled
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -78,6 +78,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       # Run an initial build in a separate step to split the build time from execution time
       - name: Set workdir
+        run: pwd
         working-directory: ./integration-tests    
       - name: Build bins
         run: cargo build --bin gen_blockchain_data

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,27 +25,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  prepare-checkout:
-    if: github.event.pull_request.draft == false
-    
-    name: Integration Tests (prepare-checkout)
-    runs-on: ["${{github.run_id}}", self-hosted, c5.9xlarge]
-
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          clean: false
-
   integration-tests:
     if: github.event.pull_request.draft == false
 
     name: Integration Tests
-    needs: prepare-checkout
     runs-on: ["${{github.run_id}}", self-hosted, c5.9xlarge]
 
-    defaults:
-      run:
-        working-directory: integration-tests
+    # defaults:
+    #   run:
+    #     working-directory: integration-tests
     steps:
       - name: Set provertype to mock_prover for push & pull_request_labelled
         run: |
@@ -60,6 +48,7 @@ jobs:
         run: |
           echo "provertype=real_prover" >> $GITHUB_ENV
         if: github.event_name == 'schedule'
+      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           override: false
@@ -93,8 +82,14 @@ jobs:
       - name: Build tests
         run: for testname in rpc circuit_input_builder circuits; do cargo test --profile release --test $testname --features $testname --no-run; done
       - run: ./run.sh --steps "setup"
+        working-directory: integration-tests
       - run: ./run.sh --steps "gendata"
+        working-directory: integration-tests
       - run: ./run.sh --steps "tests" --tests "rpc"
+        working-directory: integration-tests
       - run: ./run.sh --steps "tests" --tests "circuit_input_builder"
+        working-directory: integration-tests
       - run: RUST_TEST_THREADS=1 ./run.sh --steps "tests" --tests "circuits::${{ env.provertype }}"
+        working-directory: integration-tests
       - run: ./run.sh --steps "cleanup"
+        working-directory: integration-tests

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,15 +25,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  prepare-checkout:
+    if: github.event.pull_request.draft == false
+    
+    name: Integration Tests (prepare-checkout)
+    runs-on: ["${{github.run_id}}", self-hosted, c5.9xlarge]
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          clean: false
+
   integration-tests:
     if: github.event.pull_request.draft == false
 
     name: Integration Tests
+    needs: prepare-checkout
     runs-on: ["${{github.run_id}}", self-hosted, c5.9xlarge]
 
-    # defaults:
-    #   run:
-    #     working-directory: integration-tests
+    defaults:
+      run:
+        working-directory: integration-tests
     steps:
       - name: Set provertype to mock_prover for push & pull_request_labelled
         run: |
@@ -48,7 +60,6 @@ jobs:
         run: |
           echo "provertype=real_prover" >> $GITHUB_ENV
         if: github.event_name == 'schedule'
-      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           override: false
@@ -82,14 +93,8 @@ jobs:
       - name: Build tests
         run: for testname in rpc circuit_input_builder circuits; do cargo test --profile release --test $testname --features $testname --no-run; done
       - run: ./run.sh --steps "setup"
-        working-directory: integration-tests
       - run: ./run.sh --steps "gendata"
-        working-directory: integration-tests
       - run: ./run.sh --steps "tests" --tests "rpc"
-        working-directory: integration-tests
       - run: ./run.sh --steps "tests" --tests "circuit_input_builder"
-        working-directory: integration-tests
       - run: RUST_TEST_THREADS=1 ./run.sh --steps "tests" --tests "circuits::${{ env.provertype }}"
-        working-directory: integration-tests
       - run: ./run.sh --steps "cleanup"
-        working-directory: integration-tests

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -67,9 +67,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Cargo cache
-        uses: actions/cache@v3
-        run:
-          working-directory: ./integration-tests        
+        uses: actions/cache@v3  
         with:
           path: |
             ~/.cargo/bin/

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -29,11 +29,8 @@ jobs:
     if: github.event.pull_request.draft == false
 
     name: Integration Tests
-    runs-on: ["${{github.run_id}}", self-hosted, c5.9xlarge]
+    runs-on: ["${{github.run_id}}", self-hosted, x1e.4xlarge]
 
-    # defaults:
-    #   run:
-    #     working-directory: integration-tests
     steps:
       - name: Set provertype to mock_prover for push & pull_request_labelled
         run: |

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -11,7 +11,7 @@ is used like this:
 $ ./run.sh --help                
         Usage: ./run.sh [OPTIONS]
         Options:
-          --sudo         Use sudo for docker-compose commands.
+          --sudo         Use sudo for docker compose commands.
           --steps ARG    Space separated list of steps to do.
                          Default: "setup gendata tests cleanup".
           --tests ARG    Space separated list of tests to run.
@@ -21,7 +21,7 @@ $ ./run.sh --help
 
 ## Steps
 1. Setup: Start the docker container that runs a fresh geth in dev mode, via
-   docker-compose.
+   docker compose.
 2. Gendata: Run the `gen_blockchain_data` binary found in
    `src/bin/gen_blockchain_data.rs` which compiles the contracts, deploys them,
    and executes transactions; in order to generate blocks with a variety of
@@ -45,6 +45,6 @@ themselves are defined in `lib.rs`.
 ## Requirements
 
 The following software needs to be installed to run the integration tests script:
-- docker-compose
+- docker compose
 - Rust toolchain
 - `solc` version 0.7.x or 0.8.x

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -9,7 +9,7 @@ usage() {
     cat >&2 << EOF
         Usage: $0 [OPTIONS]
         Options:
-          --sudo         Use sudo for docker-compoes commands.
+          --sudo         Use sudo for docker compose commands.
           --steps ARG    Space separated list of steps to do.
                          Default: "${ARG_DEFAULT_STEPS}".
           --tests ARG    Space separated list of tests to run.
@@ -76,9 +76,9 @@ done
 
 docker_compose_cmd() {
     if [ -n "$ARG_SUDO" ]; then
-        sudo docker-compose $@
+        sudo docker compose $@
     else
-        docker-compose $@
+        docker compose $@
     fi
 }
 


### PR DESCRIPTION
### Description

This PR introduces github-ops functionality to zkevm-circuits/integration-tests, allowing execution on ephemeral AWS hosted runners. Execution mode is parameterized based on event trigger type and prover type selection.    

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Contents

- .github/workflows/integration.yml
- integration-tests/run.sh
- integration-tests/README.md

```
This PR contains:
- A new job that initializes prover and instance type workflow variables 
- run.sh updated to Compose V2
- Updated README.md file to reflect the updated docker compose commands
```

### Design choices
As per new integration tests execution mode, we run the tests manually, on schedule or on specific GitHub events (PR, push to main). Depending on workflow setup, test is executed either with real or mock prover, thus different AWS instance is selected to accommodate increased resource requirements for real prover. For this reason, we introduced a new job that initializes instance type and prover type variables as job outputs to be used for subsequent jobs (integration-tests).   