### PR TITLE
Remove comments as negative test is covered by error_return_data_oo_bound

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution/returndatacopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/returndatacopy.rs
@@ -373,17 +373,4 @@ mod test {
         // rlc value matters only if length > 255, i.e., size.cells.len() > 1
         test_ok_internal(0x200, 0x200, 0x200, 0x00, 0x150);
     }
-
-    // TODO: Add negative cases for out-of-bound and out-of-gas
-    // #[test]
-    // #[should_panic]
-    // fn returndatacopy_gadget_out_of_bound() {
-    //     test_ok_internal(0x00, 0x10, 0x20, 0x10, 0x10);
-    // }
-
-    // #[test]
-    // #[should_panic]
-    // fn returndatacopy_gadget_out_of_gas() {
-    //     test_ok_internal(0x00, 0x10, 0x2000000, 0x00, 0x10);
-    // }
 }


### PR DESCRIPTION
## Description

error_return_data_oo_bound has covered the negative test. We don't need to redo it in returndatacopy

## Issue Link
https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/1189

## Type of change
- Refactor

## Contents
- Remove comments

## How Has This Been Tested?

Run unit tests in error_return_data_oo_bound

Notes (TODO?)
- We should refactor the unit tests in error_return_data_oo_bound, returndatacopy and other files as they use similar test codes to construct contract for testing.

