### PR TITLE
remove create for address collision detect

### DIFF
--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -1261,12 +1261,9 @@ impl<'a> CircuitInputStateRef<'a> {
             }
 
             // Address collision
-            if matches!(step.op, OpcodeId::CREATE | OpcodeId::CREATE2) {
-                let address = match step.op {
-                    OpcodeId::CREATE => self.create_address()?,
-                    OpcodeId::CREATE2 => self.create2_address(step)?,
-                    _ => unreachable!(),
-                };
+            if matches!(step.op, OpcodeId::CREATE2) {
+                let address = self.create2_address(step)?;
+
                 let (found, _) = self.sdb.get_account(&address);
                 if found {
                     return Ok(Some(ExecError::ContractAddressCollision));

--- a/bus-mapping/src/circuit_input_builder/tracer_tests.rs
+++ b/bus-mapping/src/circuit_input_builder/tracer_tests.rs
@@ -482,6 +482,142 @@ fn tracer_err_address_collision() {
     );
 }
 
+#[test]
+fn tracer_create_without_collision() {
+    // We do CREATE twice with the same parameters, with a code_creater
+    // that outputs the same, which will lead to the different new
+    // contract address.
+    let code_creator = bytecode! {
+        PUSH1(0x00) // value
+        PUSH1(0x00) // offset
+        MSTORE
+        PUSH1(0x01) // length
+        PUSH1(0x00) // offset
+        RETURN
+    };
+
+    // code_a calls code_b which executes code_creator in CREATE2
+    let code_a = bytecode! {
+        PUSH1(0x0) // retLength
+        PUSH1(0x0) // retOffset
+        PUSH1(0x0) // argsLength
+        PUSH1(0x0) // argsOffset
+        PUSH1(0x0) // value
+        PUSH32(*WORD_ADDR_B) // addr
+        PUSH32(0x1_0000) // gas
+        CALL
+
+        PUSH2(0xaa)
+    };
+
+    let mut code_b = Bytecode::default();
+    // pad code_creator to multiple of 32 bytes
+    let len = code_creator.to_vec().len();
+    let code_creator: Vec<u8> = code_creator
+        .to_vec()
+        .iter()
+        .cloned()
+        .chain(0u8..((32 - len % 32) as u8))
+        .collect();
+    for (index, word) in code_creator.chunks(32).enumerate() {
+        code_b.push(32, Word::from_big_endian(word));
+        code_b.push(32, Word::from(index * 32));
+        code_b.write_op(OpcodeId::MSTORE);
+    }
+    let code_b_end = bytecode! {
+        PUSH1(len) // length
+        PUSH1(0x00) // offset
+        PUSH1(0x00) // value
+        CREATE
+
+        PUSH1(len) // length
+        PUSH1(0x00) // offset
+        PUSH1(0x00) // value
+        CREATE
+
+        PUSH3(0xbb)
+    };
+    code_b.append(&code_b_end);
+    // Get the execution steps from the external tracer
+    let block: GethData = TestContext::<3, 2>::new_with_logger_config(
+        None,
+        |accs| {
+            accs[0]
+                .address(address!("0x0000000000000000000000000000000000000000"))
+                .code(code_a);
+            accs[1].address(*ADDR_B).code(code_b);
+            accs[2]
+                .address(address!("0x000000000000000000000000000000000cafe002"))
+                .balance(Word::from(1u64 << 30));
+        },
+        |mut txs, accs| {
+            txs[0].to(accs[0].address).from(accs[2].address);
+            txs[1]
+                .to(accs[1].address)
+                .from(accs[2].address)
+                .nonce(Word::one());
+        },
+        |block, _tx| block.number(0xcafeu64),
+        LoggerConfig::enable_memory(),
+    )
+    .unwrap()
+    .into();
+
+    // get last CREATE
+    let (index, step) = block.geth_traces[0]
+        .struct_logs
+        .iter()
+        .enumerate()
+        .rev()
+        .find(|(_, s)| s.op == OpcodeId::CREATE)
+        .unwrap();
+    let next_step = block.geth_traces[0].struct_logs.get(index + 1);
+    let memory = next_step.unwrap().memory.clone();
+
+    let create_address: Address = {
+        // get first RETURN
+        let (index, _) = block.geth_traces[0]
+            .struct_logs
+            .iter()
+            .enumerate()
+            .find(|(_, s)| s.op == OpcodeId::RETURN)
+            .unwrap();
+        let next_step = block.geth_traces[0].struct_logs.get(index + 1);
+        let addr_word = next_step.unwrap().stack.last().unwrap();
+        addr_word.to_address()
+    };
+
+    let mut builder = CircuitInputBuilderTx::new(&block, step);
+    // Set up call context at CREATE
+    builder.tx_ctx.call_is_success.push(false);
+    builder.state_ref().push_call(mock_internal_create());
+    builder.state_ref().call_ctx_mut().unwrap().memory = memory;
+    // Set up account and contract that exist during the second CREATE2
+    builder.builder.sdb.set_account(
+        &ADDR_B,
+        Account {
+            nonce: Word::zero(),
+            balance: Word::from(555u64), /* same value as in
+                                          * `mock::new_tracer_account` */
+            storage: HashMap::new(),
+            code_hash: Hash::zero(),
+        },
+    );
+    builder.builder.sdb.set_account(
+        &create_address,
+        Account {
+            nonce: Word::zero(),
+            balance: Word::zero(),
+            storage: HashMap::new(),
+            code_hash: Hash::zero(),
+        },
+    );
+
+    let error = builder.state_ref().get_step_err(step, next_step);
+    // expects no errors detected
+    assert_eq!(error.unwrap(), None);
+}
+
 fn check_err_code_store_out_of_gas(step: &GethExecStep, next_step: Option<&GethExecStep>) -> bool {
     let length = step.stack.nth_last(1).unwrap();
     step.op == OpcodeId::RETURN


### PR DESCRIPTION
### Description
remove create for address collision detect
### Issue Link
todo

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Rationale

for create op code and tx deploy case(eventually use `create` method), creating contract address is derived from kecakk(caller_address, caller_nonce), when call `create`, the caller_once increase by 1 so never meet address collision issue.



This PR contains:
-  Added trace test to show `create` won't get  address collision error
- remove `create` when detecting address collision error
