### PR TITLE
Sort state circuit stats by descending order of h/g

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,12 +37,6 @@ evm_bench: ## Run Evm Circuit benchmarks
 state_bench: ## Run State Circuit benchmarks
 	@cargo test --profile bench bench_state_circuit_prover -p circuit-benchmarks --features benches  -- --nocapture
 
-bit_keccak_bench: ## Run Bit Keccak Circuit benchmarks
-	@cargo test --profile bench bench_bit_keccak_circuit_prover -p circuit-benchmarks --features benches  -- --nocapture
-
-packed_keccak_bench: ## Run Packed Keccak Circuit benchmarks
-	@cargo test --profile bench bench_packed_keccak_circuit_prover -p circuit-benchmarks --features benches  -- --nocapture
-
 packed_multi_keccak_bench: ## Run Packed Multi Keccak Circuit benchmarks
 	@cargo test --profile bench bench_packed_multi_keccak_circuit_prover -p circuit-benchmarks --features benches  -- --nocapture
 


### PR DESCRIPTION
### Description

Descending the order of h/g tells us what operations should be optimized first.

### Issue Link

slightly related to #1328

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Contents
Before 
```
| state          | opcode         | h    | g     | h/g    |
| -------------- | -------------- | ---- | ----- | ------ |
| STOP           | STOP           | 13   | 0     | inf    |
| ADD_SUB        | ADD            | 3    | 3     | 1.000  |
| ADD_SUB        | SUB            | 3    | 3     | 1.000  |
| MUL_DIV_MOD    | MUL            | 3    | 5     | 0.600  |
| MUL_DIV_MOD    | DIV            | 3    | 5     | 0.600  |
| MUL_DIV_MOD    | MOD            | 3    | 5     | 0.600  |
| SDIV_SMOD      | SDIV           | 3    | 5     | 0.600  |
| SDIV_SMOD      | SMOD           | 3    | 5     | 0.600  |
| SHL_SHR        | SHL            | 3    | 3     | 1.000  |
| SHL_SHR        | SHR            | 3    | 3     | 1.000  |
| ADDMOD         | ADDMOD         | 4    | 8     | 0.500  |
```
After

```
| state          | opcode         | h    | g     | h/g    |
| -------------- | -------------- | ---- | ----- | ------ |
| STOP           | STOP           | 13   | 0     | inf    |
| RETURN_REVERT  | REVERT         | 8210 | 416   | 19.736 |
| ErrorStack     | REVERT         | 8210 | 416   | 19.736 |
| ErrorStack     | REVERT         | 8210 | 416   | 19.736 |
| RETURN_REVERT  | RETURN         | 8209 | 416   | 19.733 |
| ErrorStack     | RETURN         | 8209 | 416   | 19.733 |
| ErrorStack     | RETURN         | 8209 | 416   | 19.733 |
| RETURNDATACOPY | RETURNDATACOPY | 8198 | 803   | 10.209 |
| ErrorStack     | RETURNDATACOPY | 8198 | 803   | 10.209 |
| ErrorStack     | RETURNDATACOPY | 8198 | 803   | 10.209 |
| ErrorStack     | RETURNDATACOPY | 8198 | 803   | 10.209 |
| CALLDATACOPY   | CALLDATACOPY   | 4102 | 803   | 5.108  |
| ErrorStack     | CALLDATACOPY   | 4102 | 803   | 5.108  |
```

### How Has This Been Tested?

Run `make stats_state_circuit` to make sure it works

### Design choices

- Added a struct so that the rows are sortable easily.
- This PR also removed unused `make` commands
