### PR TITLE
[word lo/hi] pi circuit replace rand/rlc by keccak hash

### DIFF
--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -203,6 +203,8 @@ impl<'a> CircuitInputBuilder {
             let geth_trace = &geth_traces[tx_index];
             self.handle_tx(tx, geth_trace, tx_index + 1 == eth_block.transactions.len())?;
         }
+        // set eth_block
+        self.block.eth_block = eth_block.clone();
         self.set_value_ops_call_context_rwc_eor();
         self.set_end_block();
         Ok(())

--- a/circuit-benchmarks/src/pi_circuit.rs
+++ b/circuit-benchmarks/src/pi_circuit.rs
@@ -4,7 +4,6 @@ mod tests {
     use ark_std::{end_timer, start_timer};
     use eth_types::Word;
     use halo2_proofs::{
-        arithmetic::Field,
         halo2curves::bn256::{Bn256, Fr, G1Affine},
         plonk::{create_proof, keygen_pk, keygen_vk, verify_proof},
         poly::{
@@ -20,13 +19,9 @@ mod tests {
         },
     };
     use rand::SeedableRng;
-    use rand_chacha::ChaCha20Rng;
     use rand_xorshift::XorShiftRng;
     use std::env::var;
-    use zkevm_circuits::{
-        pi_circuit::{PiCircuit, PublicData},
-        util::SubCircuit,
-    };
+    use zkevm_circuits::{instance::PublicData, pi_circuit::PiCircuit, util::SubCircuit};
 
     #[cfg_attr(not(feature = "benches"), ignore)]
     #[test]
@@ -45,12 +40,8 @@ mod tests {
             .parse()
             .expect("Cannot parse DEGREE env var as u32");
 
-        let mut rng = ChaCha20Rng::seed_from_u64(2);
-        let randomness = Fr::random(&mut rng);
-        let rand_rpi = Fr::random(&mut rng);
         let public_data = generate_publicdata(MAX_TXS);
-        let circuit =
-            PiCircuit::<Fr>::new(MAX_TXS, MAX_CALLDATA, randomness, rand_rpi, public_data);
+        let circuit = PiCircuit::<Fr>::new(MAX_TXS, MAX_CALLDATA, public_data);
         let public_inputs = circuit.instance();
         let instance: Vec<&[Fr]> = public_inputs.iter().map(|input| &input[..]).collect();
         let instances = &[&instance[..]];

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
+set -o xtrace
 
 ARG_DEFAULT_SUDO=
 ARG_DEFAULT_STEPS="setup gendata tests cleanup"

--- a/integration-tests/src/integration_test_circuits.rs
+++ b/integration-tests/src/integration_test_circuits.rs
@@ -59,7 +59,7 @@ const MAX_EVM_ROWS: usize = 10000;
 /// MAX_EXP_STEPS
 const MAX_EXP_STEPS: usize = 1000;
 
-const MAX_KECCAK_ROWS: usize = 15000;
+const MAX_KECCAK_ROWS: usize = 38000;
 
 const CIRCUITS_PARAMS: CircuitsParams = CircuitsParams {
     max_rws: MAX_RWS,

--- a/zkevm-circuits/src/evm_circuit/param.rs
+++ b/zkevm-circuits/src/evm_circuit/param.rs
@@ -128,7 +128,9 @@ pub(crate) const N_BYTES_BLOCK: usize = N_BYTES_COINBASE
     + N_BYTES_CHAIN_ID
     + N_BYTES_PREV_HASH;
 
-pub(crate) const N_BYTES_EXTRA_VALUE: usize = N_BYTES_WORD + N_BYTES_WORD;
+pub(crate) const N_BYTES_EXTRA_VALUE: usize = N_BYTES_WORD // block hash
+    + N_BYTES_WORD // state root
+    + N_BYTES_WORD; // prev state root
 
 // Number of bytes that will be used for tx values
 pub(crate) const N_BYTES_TX_NONCE: usize = N_BYTES_U64;

--- a/zkevm-circuits/src/evm_circuit/param.rs
+++ b/zkevm-circuits/src/evm_circuit/param.rs
@@ -109,6 +109,49 @@ pub(crate) const N_BYTES_GAS: usize = N_BYTES_U64;
 // Number of bytes that will be used for call data's size.
 pub(crate) const N_BYTES_CALLDATASIZE: usize = N_BYTES_U64;
 
+// Number of bytes that will be used for block values
+pub(crate) const N_BYTES_COINBASE: usize = N_BYTES_ACCOUNT_ADDRESS;
+pub(crate) const N_BYTES_GAS_LIMIT: usize = N_BYTES_U64;
+pub(crate) const N_BYTES_NUMBER: usize = N_BYTES_U64;
+pub(crate) const N_BYTES_TIMESTAMP: usize = N_BYTES_U64;
+pub(crate) const N_BYTES_DIFFICULTY: usize = N_BYTES_WORD;
+pub(crate) const N_BYTES_BASE_FEE: usize = N_BYTES_WORD;
+pub(crate) const N_BYTES_CHAIN_ID: usize = N_BYTES_U64;
+pub(crate) const N_BYTES_PREV_HASH: usize = 256 * N_BYTES_WORD;
+
+pub(crate) const N_BYTES_BLOCK: usize = N_BYTES_COINBASE
+    + N_BYTES_GAS_LIMIT
+    + N_BYTES_NUMBER
+    + N_BYTES_TIMESTAMP
+    + N_BYTES_DIFFICULTY
+    + N_BYTES_BASE_FEE
+    + N_BYTES_CHAIN_ID
+    + N_BYTES_PREV_HASH;
+
+pub(crate) const N_BYTES_EXTRA_VALUE: usize = N_BYTES_WORD + N_BYTES_WORD;
+
+// Number of bytes that will be used for tx values
+pub(crate) const N_BYTES_TX_NONCE: usize = N_BYTES_U64;
+pub(crate) const N_BYTES_TX_GAS_LIMIT: usize = N_BYTES_U64; // gas limit type is U256, different with gas U64
+pub(crate) const N_BYTES_TX_GASPRICE: usize = N_BYTES_WORD;
+pub(crate) const N_BYTES_TX_FROM: usize = N_BYTES_ACCOUNT_ADDRESS;
+pub(crate) const N_BYTES_TX_TO: usize = N_BYTES_ACCOUNT_ADDRESS;
+pub(crate) const N_BYTES_TX_IS_CREATE: usize = N_BYTES_U64;
+pub(crate) const N_BYTES_TX_VALUE: usize = N_BYTES_WORD;
+pub(crate) const N_BYTES_TX_CALLDATA_LEN: usize = N_BYTES_CALLDATASIZE;
+pub(crate) const N_BYTES_TX_CALLDATA_GASCOST: usize = N_BYTES_U64;
+pub(crate) const N_BYTES_TX_TXSIGNHASH: usize = N_BYTES_WORD;
+pub(crate) const N_BYTES_TX: usize = N_BYTES_TX_NONCE
+    + N_BYTES_TX_GAS_LIMIT
+    + N_BYTES_TX_GASPRICE
+    + N_BYTES_TX_FROM
+    + N_BYTES_TX_TO
+    + N_BYTES_TX_IS_CREATE
+    + N_BYTES_TX_VALUE
+    + N_BYTES_TX_CALLDATA_LEN
+    + N_BYTES_TX_CALLDATA_GASCOST
+    + N_BYTES_TX_TXSIGNHASH;
+
 lazy_static::lazy_static! {
     // Step slot height in evm circuit
     pub(crate) static ref EXECUTION_STATE_HEIGHT_MAP : HashMap<ExecutionState, usize> = get_step_height_map();

--- a/zkevm-circuits/src/instance.rs
+++ b/zkevm-circuits/src/instance.rs
@@ -1,0 +1,288 @@
+//! The instance definition.
+
+use std::iter;
+
+use eth_types::{geth_types::BlockConstants, BigEndianHash, Field, Keccak};
+
+use eth_types::{geth_types::Transaction, Address, ToBigEndian, Word, H256};
+use itertools::Itertools;
+
+use crate::{util::word, witness::Block};
+
+pub(super) const ZERO_BYTE_GAS_COST: u64 = 4;
+pub(super) const NONZERO_BYTE_GAS_COST: u64 = 16;
+
+/// Values of the block table (as in the spec)
+#[derive(Clone, Default, Debug)]
+pub struct BlockValues {
+    /// coinbase
+    pub coinbase: Address,
+    /// gas_limit
+    pub gas_limit: u64,
+    /// number
+    pub number: u64,
+    /// timestamp
+    pub timestamp: u64,
+    /// difficulty
+    pub difficulty: Word,
+    /// base_fee
+    pub base_fee: Word, // NOTE: BaseFee was added by EIP-1559 and is ignored in legacy headers.
+    /// chain_id
+    pub chain_id: u64,
+    /// history_hashes
+    pub history_hashes: Vec<H256>,
+}
+
+/// Values of the tx table (as in the spec)
+#[derive(Default, Debug, Clone)]
+pub struct TxValues {
+    /// nonce
+    pub nonce: u64,
+    /// gas_limit
+    pub gas_limit: u64,
+    /// gas_price
+    pub gas_price: Word,
+    /// from_addr
+    pub from_addr: Address,
+    /// to_addr
+    pub to_addr: Address,
+    /// is_create
+    pub is_create: u64,
+    /// value
+    pub value: Word,
+    /// call_data_len
+    pub call_data_len: u64,
+    /// call_data_gas_cost
+    pub call_data_gas_cost: u64,
+    /// tx_sign_hash
+    pub tx_sign_hash: [u8; 32],
+}
+
+/// Extra values (not contained in block or tx tables)
+#[derive(Default, Debug, Clone)]
+pub struct ExtraValues {
+    // block_hash: H256,
+    /// state_root
+    pub state_root: H256,
+    /// prev_state_root
+    pub prev_state_root: H256,
+}
+
+/// PublicData contains all the values that the PiCircuit recieves as input
+#[derive(Debug, Clone)]
+pub struct PublicData {
+    /// chain id
+    pub chain_id: Word,
+    /// History hashes contains the most recent 256 block hashes in history,
+    /// where the latest one is at history_hashes[history_hashes.len() - 1].
+    pub history_hashes: Vec<Word>,
+    /// Block Transactions
+    pub transactions: Vec<eth_types::Transaction>,
+    /// Block State Root
+    pub state_root: H256,
+    /// Previous block root
+    pub prev_state_root: H256,
+    /// Constants related to Ethereum block
+    pub block_constants: BlockConstants,
+}
+
+impl Default for PublicData {
+    fn default() -> Self {
+        PublicData {
+            chain_id: Word::default(),
+            history_hashes: vec![],
+            transactions: vec![],
+            state_root: H256::zero(),
+            prev_state_root: H256::zero(),
+            block_constants: BlockConstants::default(),
+        }
+    }
+}
+
+impl PublicData {
+    /// Returns struct with values for the block table
+    pub fn get_block_table_values(&self) -> BlockValues {
+        let history_hashes = [
+            vec![H256::zero(); 256 - self.history_hashes.len()],
+            self.history_hashes
+                .iter()
+                .map(|&hash| H256::from(hash.to_be_bytes()))
+                .collect(),
+        ]
+        .concat();
+        BlockValues {
+            coinbase: self.block_constants.coinbase,
+            gas_limit: self.block_constants.gas_limit.as_u64(),
+            number: self.block_constants.number.as_u64(),
+            timestamp: self.block_constants.timestamp.as_u64(),
+            difficulty: self.block_constants.difficulty,
+            base_fee: self.block_constants.base_fee,
+            chain_id: self.chain_id.as_u64(),
+            history_hashes,
+        }
+    }
+
+    /// Returns struct with values for the tx table
+    pub fn get_tx_table_values(&self) -> Vec<TxValues> {
+        let chain_id: u64 = self
+            .chain_id
+            .try_into()
+            .expect("Error converting chain_id to u64");
+        let mut tx_vals = vec![];
+        for tx in &self.txs() {
+            let sign_data_res = tx.sign_data(chain_id);
+            let msg_hash_le =
+                sign_data_res.map_or_else(|_| [0u8; 32], |sign_data| sign_data.msg_hash.to_bytes());
+            tx_vals.push(TxValues {
+                nonce: tx.nonce.low_u64(),
+                gas_price: tx.gas_price,
+                gas_limit: tx.gas_limit.low_u64(),
+                from_addr: tx.from,
+                to_addr: tx.to.unwrap_or_else(Address::zero),
+                is_create: (tx.to.is_none() as u64),
+                value: tx.value,
+                call_data_len: tx.call_data.0.len() as u64,
+                call_data_gas_cost: tx.call_data.0.iter().fold(0, |acc, byte| {
+                    acc + if *byte == 0 {
+                        ZERO_BYTE_GAS_COST
+                    } else {
+                        NONZERO_BYTE_GAS_COST
+                    }
+                }),
+                tx_sign_hash: msg_hash_le,
+            });
+        }
+        tx_vals
+    }
+
+    /// Returns struct with the extra values
+    pub fn get_extra_values(&self) -> ExtraValues {
+        ExtraValues {
+            // block_hash: self.hash.unwrap_or_else(H256::zero),
+            state_root: self.state_root,
+            prev_state_root: self.prev_state_root,
+        }
+    }
+
+    /// Return converted transaction
+    pub fn txs(&self) -> Vec<Transaction> {
+        self.transactions
+            .iter()
+            .map(Transaction::from)
+            .collect_vec()
+    }
+
+    /// get the serialized public data bytes
+    pub fn get_pi_bytes(&self, max_txs: usize, max_calldata: usize) -> Vec<u8> {
+        // Assign block table
+        let block_values = self.get_block_table_values();
+        let result = iter::empty()
+            .chain(0u8.to_be_bytes()) // zero byte
+            .chain(block_values.coinbase.to_fixed_bytes()) // coinbase
+            .chain(block_values.gas_limit.to_be_bytes()) // gas_limit
+            .chain(block_values.number.to_be_bytes()) // number
+            .chain(block_values.timestamp.to_be_bytes()) // timestamp
+            .chain(block_values.difficulty.to_be_bytes()) // difficulty
+            .chain(block_values.base_fee.to_be_bytes()) // base_fee
+            .chain(block_values.chain_id.to_be_bytes()) // chain_id
+            .chain(
+                block_values
+                    .history_hashes
+                    .iter()
+                    .flat_map(|prev_hash| prev_hash.to_fixed_bytes()),
+            ); // history_hashes
+
+        // Assign extra fields
+        let extra_vals = self.get_extra_values();
+        let result = result
+            .chain(extra_vals.state_root.to_fixed_bytes()) // block state root
+            .chain(extra_vals.prev_state_root.to_fixed_bytes()); // previous block state root
+
+        // Assign Tx table
+        let tx_field_byte_fn = |tx_id: u64, index: u64, value_bytes: &[u8]| {
+            iter::empty()
+                .chain(tx_id.to_be_bytes()) // tx_id
+                .chain(index.to_be_bytes()) // index
+                .chain(value_bytes.to_vec()) // value
+        };
+        let tx_bytes_fn = |tx_id: u64, index: u64, tx: &TxValues| {
+            vec![
+                tx.nonce.to_be_bytes().to_vec(),                     // nonce
+                tx.gas_limit.to_be_bytes().to_vec(),                 // gas_limit
+                tx.gas_price.to_be_bytes().to_vec(),                 // gas price
+                tx.from_addr.as_fixed_bytes().to_vec(),              // from_addr
+                tx.to_addr.as_fixed_bytes().to_vec(),                // to_addr
+                tx.is_create.to_be_bytes().to_vec(),                 // is_create
+                tx.value.to_be_bytes().to_vec(),                     // value
+                tx.call_data_len.to_be_bytes().to_vec(),             // call_data_len
+                tx.call_data_gas_cost.to_be_bytes().to_vec(),        // call_data_gas_cost
+                tx.tx_sign_hash.iter().rev().copied().collect_vec(), // tx sign hash
+            ]
+            .iter()
+            .flat_map(move |value_bytes| tx_field_byte_fn(tx_id, index, value_bytes))
+            .collect_vec()
+        };
+
+        let txs_values = self.get_tx_table_values();
+        let tx_values_default = TxValues::default();
+
+        // all tx bytes including tx padding
+        let all_tx_bytes = iter::empty()
+            .chain(&txs_values)
+            .chain((0..(max_txs - txs_values.len())).map(|_| &tx_values_default))
+            .enumerate()
+            .flat_map(|(i, tx)| {
+                let i: u64 = i.try_into().unwrap();
+                tx_bytes_fn(i + 1, 0, tx)
+            });
+
+        // first tx empty row happened here
+        let result = result
+            .chain(tx_field_byte_fn(0, 0, &[0u8; 1])) // empty row
+            .chain(all_tx_bytes);
+
+        // Tx Table CallData
+        let txs = self.txs();
+        let all_calldata = txs
+            .iter()
+            .flat_map(|tx| tx.call_data.0.as_ref().iter().copied())
+            .collect_vec();
+        let calldata_count = all_calldata.len();
+        // concat call data with call data padding
+        let calldata_chain = iter::empty()
+            .chain(all_calldata)
+            .chain((0..max_calldata - calldata_count).map(|_| 0u8));
+        result.chain(calldata_chain).collect_vec()
+    }
+
+    /// generate public data from validator perspective
+    pub fn get_rpi_digest_word<F: Field>(
+        &self,
+        max_txs: usize,
+        max_calldata: usize,
+    ) -> word::Word<F> {
+        let mut keccak = Keccak::default();
+        keccak.update(&self.get_pi_bytes(max_txs, max_calldata));
+        let digest = keccak.digest();
+        word::Word::from(Word::from_big_endian(&digest))
+    }
+}
+
+/// convert witness block to public data
+pub fn public_data_convert<F: Field>(block: &Block<F>) -> PublicData {
+    PublicData {
+        chain_id: block.context.chain_id,
+        history_hashes: block.context.history_hashes.clone(),
+        transactions: block.eth_block.transactions.clone(),
+        state_root: block.eth_block.state_root,
+        prev_state_root: H256::from_uint(&block.prev_state_root),
+        block_constants: BlockConstants {
+            coinbase: block.context.coinbase,
+            timestamp: block.context.timestamp,
+            number: block.context.number.as_u64().into(),
+            difficulty: block.context.difficulty,
+            gas_limit: block.context.gas_limit.into(),
+            base_fee: block.context.base_fee,
+        },
+    }
+}

--- a/zkevm-circuits/src/instance.rs
+++ b/zkevm-circuits/src/instance.rs
@@ -61,7 +61,8 @@ pub struct TxValues {
 /// Extra values (not contained in block or tx tables)
 #[derive(Default, Debug, Clone)]
 pub struct ExtraValues {
-    // block_hash: H256,
+    /// block_hash
+    pub block_hash: H256,
     /// state_root
     pub state_root: H256,
     /// prev_state_root
@@ -84,6 +85,8 @@ pub struct PublicData {
     pub prev_state_root: H256,
     /// Constants related to Ethereum block
     pub block_constants: BlockConstants,
+    /// Block Hash
+    pub block_hash: Option<H256>,
 }
 
 impl Default for PublicData {
@@ -95,6 +98,7 @@ impl Default for PublicData {
             state_root: H256::zero(),
             prev_state_root: H256::zero(),
             block_constants: BlockConstants::default(),
+            block_hash: None,
         }
     }
 }
@@ -158,7 +162,7 @@ impl PublicData {
     /// Returns struct with the extra values
     pub fn get_extra_values(&self) -> ExtraValues {
         ExtraValues {
-            // block_hash: self.hash.unwrap_or_else(H256::zero),
+            block_hash: self.block_hash.unwrap_or_else(H256::zero),
             state_root: self.state_root,
             prev_state_root: self.prev_state_root,
         }
@@ -195,6 +199,7 @@ impl PublicData {
         // Assign extra fields
         let extra_vals = self.get_extra_values();
         let result = result
+            .chain(extra_vals.block_hash.to_fixed_bytes()) // block hash
             .chain(extra_vals.state_root.to_fixed_bytes()) // block state root
             .chain(extra_vals.prev_state_root.to_fixed_bytes()); // previous block state root
 
@@ -276,6 +281,7 @@ pub fn public_data_convert<F: Field>(block: &Block<F>) -> PublicData {
         transactions: block.eth_block.transactions.clone(),
         state_root: block.eth_block.state_root,
         prev_state_root: H256::from_uint(&block.prev_state_root),
+        block_hash: block.eth_block.hash,
         block_constants: BlockConstants {
             coinbase: block.context.coinbase,
             timestamp: block.context.timestamp,

--- a/zkevm-circuits/src/lib.rs
+++ b/zkevm-circuits/src/lib.rs
@@ -33,6 +33,7 @@ pub mod table;
 #[cfg(any(feature = "test", test))]
 pub mod test_util;
 
+pub mod instance;
 pub mod tx_circuit;
 pub mod util;
 pub mod witness;

--- a/zkevm-circuits/src/pi_circuit.rs
+++ b/zkevm-circuits/src/pi_circuit.rs
@@ -1199,15 +1199,21 @@ impl<F: Field> PiCircuitConfig<F> {
         zero_cell: AssignedCell<F, F>,
     ) -> Result<(), Error> {
         // block hash
-        // let block_hash = rlc(extra.block_hash.to_fixed_bytes(), randomness);
-        // region.assign_advice(
-        //     || "block.hash",
-        //     self.raw_public_inputs,
-        //     offset,
-        //     || Ok(block_hash),
-        // )?;
-        // raw_pi_vals[offset] = block_hash;
-        // offset += 1;
+        self.assign_raw_bytes(
+            region,
+            &extra
+                .block_hash
+                .to_fixed_bytes()
+                .iter()
+                .copied()
+                .rev()
+                .collect_vec(),
+            rpi_bytes_keccakrlc,
+            rpi_bytes,
+            current_offset,
+            challenges,
+            zero_cell.clone(),
+        )?;
 
         // block state root
         self.assign_raw_bytes(

--- a/zkevm-circuits/src/pi_circuit/dev.rs
+++ b/zkevm-circuits/src/pi_circuit/dev.rs
@@ -29,6 +29,9 @@ impl<F: Field> Circuit<F> for PiCircuit<F> {
     fn configure_with_params(meta: &mut ConstraintSystem<F>, params: Self::Params) -> Self::Config {
         let block_table = BlockTable::construct(meta);
         let tx_table = TxTable::construct(meta);
+        let keccak_table = KeccakTable::construct(meta);
+        let challenges = Challenges::construct(meta);
+        let challenge_exprs = challenges.exprs(meta);
         (
             PiCircuitConfig::new(
                 meta,
@@ -37,9 +40,11 @@ impl<F: Field> Circuit<F> for PiCircuit<F> {
                     max_calldata: params.max_calldata,
                     block_table,
                     tx_table,
+                    keccak_table,
+                    challenges: challenge_exprs,
                 },
             ),
-            Challenges::construct(meta),
+            challenges,
         )
     }
 
@@ -53,6 +58,14 @@ impl<F: Field> Circuit<F> for PiCircuit<F> {
         mut layouter: impl Layouter<F>,
     ) -> Result<(), Error> {
         let challenges = challenges.values(&mut layouter);
+        // assign keccak table
+        let rpi_bytes = self
+            .public_data
+            .get_pi_bytes(config.max_txs, config.max_calldata);
+        config
+            .keccak_table
+            .dev_load(&mut layouter, vec![&rpi_bytes], &challenges)?;
+
         self.synthesize_sub(&config, &challenges, &mut layouter)
     }
 }

--- a/zkevm-circuits/src/pi_circuit/param.rs
+++ b/zkevm-circuits/src/pi_circuit/param.rs
@@ -1,5 +1,13 @@
+use halo2_proofs::circuit::AssignedCell;
+
+use crate::util::word::Word;
+
 /// Fixed by the spec
 pub(super) const BLOCK_LEN: usize = 7 + 256;
 pub(super) const EXTRA_LEN: usize = 2;
-pub(super) const ZERO_BYTE_GAS_COST: u64 = 4;
-pub(super) const NONZERO_BYTE_GAS_COST: u64 = 16;
+pub(super) const BYTE_POW_BASE: u64 = 256;
+pub(super) const EMPTY_TX_ROW_COUNT: usize = 1;
+pub(super) const EMPTY_BLOCK_ROW_COUNT: usize = 1;
+pub(super) const N_BYTES_ONE: usize = 1;
+
+pub(super) type AssignedByteCells<F> = (AssignedCell<F, F>, Word<AssignedCell<F, F>>);

--- a/zkevm-circuits/src/pi_circuit/test.rs
+++ b/zkevm-circuits/src/pi_circuit/test.rs
@@ -63,11 +63,7 @@ fn test_simple_pi() {
 
     let mut public_data = PublicData::default();
 
-    public_data.block_constants.coinbase = H160(
-        vec![1u8, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
-            .try_into()
-            .unwrap(),
-    );
+    public_data.block_constants.coinbase = H160([1u8; 20]);
     let n_tx = 4;
     for i in 0..n_tx {
         public_data

--- a/zkevm-circuits/src/pi_circuit/test.rs
+++ b/zkevm-circuits/src/pi_circuit/test.rs
@@ -1,13 +1,19 @@
 #![allow(unused_imports)]
-use super::{dev::*, *};
-use crate::util::unusable_rows;
+use std::collections::HashMap;
+
+use crate::{pi_circuit::dev::PiCircuitParams, util::unusable_rows, witness::block_convert};
+
+use super::*;
+use bus_mapping::{circuit_input_builder::CircuitsParams, mock::BlockData};
+use eth_types::{bytecode, geth_types::GethData, Word, H160};
+use ethers_signers::{LocalWallet, Signer};
 use halo2_proofs::{
     dev::{MockProver, VerifyFailure},
     halo2curves::bn256::Fr,
 };
-use mock::{CORRECT_MOCK_TXS, MOCK_CHAIN_ID};
+use mock::{eth, TestContext, CORRECT_MOCK_TXS, MOCK_ACCOUNTS, MOCK_CHAIN_ID};
 use rand::SeedableRng;
-use rand_chacha::ChaCha20Rng;
+use rand_chacha::ChaChaRng;
 
 #[test]
 fn pi_circuit_unusable_rows() {
@@ -26,13 +32,11 @@ fn run<F: Field>(
     max_calldata: usize,
     public_data: PublicData,
 ) -> Result<(), Vec<VerifyFailure>> {
-    let mut rng = ChaCha20Rng::seed_from_u64(2);
-    let randomness = F::random(&mut rng);
-    let rand_rpi = F::random(&mut rng);
     let mut public_data = public_data;
     public_data.chain_id = *MOCK_CHAIN_ID;
 
-    let circuit = PiCircuit::<F>::new(max_txs, max_calldata, randomness, rand_rpi, public_data);
+    let circuit = PiCircuit::<F>::new(max_txs, max_calldata, public_data);
+
     let public_inputs = circuit.instance();
 
     let prover = match MockProver::run(k, &circuit, public_inputs) {
@@ -59,6 +63,11 @@ fn test_simple_pi() {
 
     let mut public_data = PublicData::default();
 
+    public_data.block_constants.coinbase = H160(
+        vec![1u8, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+            .try_into()
+            .unwrap(),
+    );
     let n_tx = 4;
     for i in 0..n_tx {
         public_data
@@ -70,28 +79,78 @@ fn test_simple_pi() {
     assert_eq!(run::<Fr>(k, max_txs, max_calldata, public_data), Ok(()));
 }
 
-fn run_size_check<F: Field>(max_txs: usize, max_calldata: usize, public_data: [PublicData; 2]) {
-    let mut rng = ChaCha20Rng::seed_from_u64(2);
-    let randomness = F::random(&mut rng);
-    let rand_rpi = F::random(&mut rng);
+#[test]
+fn test_1tx_1maxtx() {
+    const MAX_TXS: usize = 1;
+    const MAX_CALLDATA: usize = 32;
+    let mut rng = ChaChaRng::seed_from_u64(2);
+    let wallet_a = LocalWallet::new(&mut rng).with_chain_id(MOCK_CHAIN_ID.as_u64());
 
-    let circuit = PiCircuit::<F>::new(
-        max_txs,
-        max_calldata,
-        randomness,
-        rand_rpi,
-        public_data[0].clone(),
-    );
+    let addr_a = wallet_a.address();
+    let addr_b = MOCK_ACCOUNTS[0];
+
+    let degree = 17;
+    let calldata = vec![];
+    let code = bytecode! {
+        PUSH4(0x1000) // size
+        PUSH2(0x00) // offset
+        RETURN
+    };
+    let test_ctx = TestContext::<2, 1>::new(
+        Some(vec![Word::from("0xdeadbeef")]),
+        |accs| {
+            accs[0].address(addr_b).balance(eth(10)).code(code);
+            accs[1].address(addr_a).balance(eth(10));
+        },
+        |mut txs, accs| {
+            txs[0]
+                .from(accs[1].address)
+                .to(accs[0].address)
+                .input(calldata.into())
+                .gas((1e16 as u64).into());
+        },
+        |block, _txs| block.number(0xcafeu64).chain_id(*MOCK_CHAIN_ID),
+    )
+    .unwrap();
+    let mut wallets = HashMap::new();
+    wallets.insert(wallet_a.address(), wallet_a);
+
+    let mut block: GethData = test_ctx.into();
+    let mut builder = BlockData::new_from_geth_data_with_params(
+        block.clone(),
+        CircuitsParams {
+            max_txs: MAX_TXS,
+            max_calldata: MAX_CALLDATA,
+            max_rws: 1 << (degree - 1),
+            ..Default::default()
+        },
+    )
+    .new_circuit_input_builder();
+
+    block.sign(&wallets);
+
+    builder
+        .handle_block(&block.eth_block, &block.geth_traces)
+        .unwrap();
+
+    let block = block_convert(&builder.block, &builder.code_db).unwrap();
+    // MAX_TXS, MAX_TXS align with `CircuitsParams`
+    let circuit = PiCircuit::<Fr>::new_from_block(&block);
+    let public_inputs = circuit.instance();
+
+    let prover = match MockProver::run(degree, &circuit, public_inputs) {
+        Ok(prover) => prover,
+        Err(e) => panic!("{:#?}", e),
+    };
+    assert_eq!(prover.verify(), Ok(()));
+}
+
+fn run_size_check<F: Field>(max_txs: usize, max_calldata: usize, public_data: [PublicData; 2]) {
+    let circuit = PiCircuit::<F>::new(max_txs, max_calldata, public_data[0].clone());
     let public_inputs = circuit.instance();
     let prover1 = MockProver::run(20, &circuit, public_inputs).unwrap();
 
-    let circuit2 = PiCircuit::new(
-        max_txs,
-        max_calldata,
-        randomness,
-        rand_rpi,
-        public_data[1].clone(),
-    );
+    let circuit2 = PiCircuit::<F>::new(max_txs, max_calldata, public_data[1].clone());
     let public_inputs = circuit2.instance();
     let prover2 = MockProver::run(20, &circuit, public_inputs).unwrap();
 

--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -155,6 +155,8 @@ impl<F: Field> SubCircuitConfig<F> for SuperCircuitConfig<F> {
                 max_calldata,
                 block_table: block_table.clone(),
                 tx_table: tx_table.clone(),
+                keccak_table: keccak_table.clone(),
+                challenges: challenges.clone(),
             },
         );
         let tx_circuit = TxCircuitConfig::new(

--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -192,7 +192,7 @@ impl<F: Field> TxCircuit<F> {
                     Value::known(F::ZERO),
                 )?;
                 offset += 1;
-                // Assign al Tx fields except for call data
+                // Assign all Tx fields except for call data
                 let tx_default = Transaction::default();
                 for (i, assigned_sig_verif) in assigned_sig_verifs.iter().enumerate() {
                     let tx = if i < self.txs.len() {

--- a/zkevm-circuits/src/util/word.rs
+++ b/zkevm-circuits/src/util/word.rs
@@ -295,7 +295,7 @@ impl<F: Field> From<eth_types::Word> for Word<F> {
 }
 
 impl<F: Field> From<H256> for Word<F> {
-    /// Construct the word from u256
+    /// Construct the word from H256
     fn from(h: H256) -> Self {
         let le_bytes = {
             let mut b = h.to_fixed_bytes();


### PR DESCRIPTION
### Description

replace rand/rlc by pure keccak hashing

### Issue Link
- https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/1344
- https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/1383

### Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Contents

- replace rpi rand/rlc logic by pure hashing 
- simplify public input into just 2 fields: digest[0:16] as `hi`, and digest[16:32] as `lo`, while `digest = Keccak(<public data>)`
- adopt word-lo-hi

nitpick
- prefix table column annotation with table name for better debugging


### Rationale

[_design decisions and extended information_]

### How Has This Been Tested?

[_explanation_]
