### PR TITLE
Introduce support for PUSH0

### DIFF
--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -43,6 +43,7 @@ mod mload;
 mod mstore;
 mod number;
 mod origin;
+mod push0;
 mod return_revert;
 mod returndatacopy;
 mod returndatasize;
@@ -208,6 +209,7 @@ fn fn_gen_associated_ops(opcode_id: &OpcodeId) -> FnGenAssociatedOps {
         OpcodeId::MSIZE => StackOnlyOpcode::<0, 1>::gen_associated_ops,
         OpcodeId::GAS => StackOnlyOpcode::<0, 1>::gen_associated_ops,
         OpcodeId::JUMPDEST => Dummy::gen_associated_ops,
+        OpcodeId::PUSH0 => StackOnlyOpcode::<0, 1>::gen_associated_ops,
         OpcodeId::DUP1 => Dup::<1>::gen_associated_ops,
         OpcodeId::DUP2 => Dup::<2>::gen_associated_ops,
         OpcodeId::DUP3 => Dup::<3>::gen_associated_ops,

--- a/bus-mapping/src/evm/opcodes/push0.rs
+++ b/bus-mapping/src/evm/opcodes/push0.rs
@@ -1,0 +1,60 @@
+#[cfg(test)]
+mod push0_tests {
+    use crate::{
+        circuit_input_builder::ExecState,
+        mock::BlockData,
+        operation::{StackOp, RW},
+    };
+    use eth_types::{
+        bytecode,
+        evm_types::{OpcodeId, StackAddress},
+        geth_types::GethData,
+        U256,
+    };
+
+    use mock::{
+        test_ctx::{helpers::*, TestContext},
+    };
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn push0_opcode_impl() {
+        let code = bytecode! {
+            PUSH0
+            STOP
+        };
+
+        // Get the execution steps from the external tracer
+        let block: GethData = TestContext::<2, 1>::new(
+            None,
+            account_0_code_account_1_no_code(code),
+            tx_from_1_to_0,
+            |block, _tx| block,
+        )
+        .unwrap()
+        .into();
+
+        let mut builder = BlockData::new_from_geth_data(block.clone()).new_circuit_input_builder();
+        builder
+            .handle_block(&block.eth_block, &block.geth_traces)
+            .unwrap();
+
+        let step = builder.block.txs()[0]
+            .steps()
+            .iter()
+            .find(|step| step.exec_state == ExecState::Op(OpcodeId::PUSH0))
+            .unwrap();
+
+        assert_eq!(
+            {
+                let operation =
+                    &builder.block.container.stack[step.bus_mapping_instance[0].as_usize()];
+                (operation.rw(), operation.op())
+            },
+            (
+                RW::WRITE,
+                &StackOp::new(1, StackAddress::from(1023), U256::zero())
+            )
+        );
+    }
+}

--- a/eth-types/src/evm_types/opcode_ids.rs
+++ b/eth-types/src/evm_types/opcode_ids.rs
@@ -94,6 +94,9 @@ pub enum OpcodeId {
     /// `JUMPDEST`
     JUMPDEST,
 
+    /// `PUSH0`
+    PUSH0,
+
     // PUSHn
     /// `PUSH1`
     PUSH1,
@@ -402,6 +405,7 @@ impl OpcodeId {
             OpcodeId::PC => 0x58u8,
             OpcodeId::MSIZE => 0x59u8,
             OpcodeId::JUMPDEST => 0x5bu8,
+            OpcodeId::PUSH0 => 0x5fu8,
             OpcodeId::PUSH1 => 0x60u8,
             OpcodeId::PUSH2 => 0x61u8,
             OpcodeId::PUSH3 => 0x62u8,
@@ -580,6 +584,7 @@ impl OpcodeId {
             OpcodeId::MSIZE => GasCost::QUICK,
             OpcodeId::GAS => GasCost::QUICK,
             OpcodeId::JUMPDEST => GasCost::ONE,
+            OpcodeId::PUSH0 => GasCost::QUICK,
             OpcodeId::PUSH1 => GasCost::FASTEST,
             OpcodeId::PUSH2 => GasCost::FASTEST,
             OpcodeId::PUSH3 => GasCost::FASTEST,
@@ -734,6 +739,7 @@ impl OpcodeId {
             OpcodeId::MSIZE => (1, 1024),
             OpcodeId::GAS => (1, 1024),
             OpcodeId::JUMPDEST => (0, 1024),
+            OpcodeId::PUSH0 => (1, 1024),
             OpcodeId::PUSH1 => (1, 1024),
             OpcodeId::PUSH2 => (1, 1024),
             OpcodeId::PUSH3 => (1, 1024),
@@ -936,6 +942,7 @@ impl From<u8> for OpcodeId {
             0x58u8 => OpcodeId::PC,
             0x59u8 => OpcodeId::MSIZE,
             0x5bu8 => OpcodeId::JUMPDEST,
+            0x5fu8 => OpcodeId::PUSH0,
             0x60u8 => OpcodeId::PUSH1,
             0x61u8 => OpcodeId::PUSH2,
             0x62u8 => OpcodeId::PUSH3,
@@ -1089,6 +1096,7 @@ impl FromStr for OpcodeId {
             "PC" => OpcodeId::PC,
             "MSIZE" => OpcodeId::MSIZE,
             "JUMPDEST" => OpcodeId::JUMPDEST,
+            "PUSH0" => OpcodeId::PUSH0,
             "PUSH1" => OpcodeId::PUSH1,
             "PUSH2" => OpcodeId::PUSH2,
             "PUSH3" => OpcodeId::PUSH3,
@@ -1156,7 +1164,6 @@ impl FromStr for OpcodeId {
             "RETURN" => OpcodeId::RETURN,
             "REVERT" => OpcodeId::REVERT,
             "INVALID" => OpcodeId::INVALID(0xfe),
-            "PUSH0" => OpcodeId::INVALID(0x5f),
             "SHA3" | "KECCAK256" => OpcodeId::SHA3,
             "ADDRESS" => OpcodeId::ADDRESS,
             "BALANCE" => OpcodeId::BALANCE,

--- a/geth-utils/gethutil/asm.go
+++ b/geth-utils/gethutil/asm.go
@@ -119,6 +119,7 @@ func (a *Asm) JumpI(label ...string) *Asm    { return a.jump(vm.JUMPI, label...)
 func (a *Asm) PC() *Asm                      { return a.appendByte(vm.PC) }
 func (a *Asm) MSize() *Asm                   { return a.appendByte(vm.MSIZE) }
 func (a *Asm) Gas() *Asm                     { return a.appendByte(vm.GAS) }
+func (a *Asm) Push0() *Asm                   { return a.appendByte(vm.PUSH0) }
 func (a *Asm) JumpDest(label ...string) *Asm { return a.jumpDest(label...) }
 
 // 0x60 range

--- a/geth-utils/gethutil/trace.go
+++ b/geth-utils/gethutil/trace.go
@@ -143,6 +143,9 @@ func Trace(config TraceConfig) ([]*ExecutionResult, error) {
 		MuirGlacierBlock:    big.NewInt(0),
 		BerlinBlock:         big.NewInt(0),
 		LondonBlock:         big.NewInt(0),
+		TerminalTotalDifficulty:       big.NewInt(0),
+		TerminalTotalDifficultyPassed: true,
+		ShanghaiTime:                  newUint64(0),
 	}
 
 	var txsGasLimit uint64
@@ -180,6 +183,8 @@ func Trace(config TraceConfig) ([]*ExecutionResult, error) {
 		return nil, fmt.Errorf("txs total gas: %d Exceeds block gas limit: %d", txsGasLimit, blockGasLimit)
 	}
 
+	randao := common.BigToHash(toBigInt(config.Block.Difficulty)) // TODO: fix
+
 	blockCtx := vm.BlockContext{
 		CanTransfer: core.CanTransfer,
 		Transfer:    core.Transfer,
@@ -195,6 +200,7 @@ func Trace(config TraceConfig) ([]*ExecutionResult, error) {
 		BlockNumber: toBigInt(config.Block.Number),
 		Time:        toBigInt(config.Block.Timestamp).Uint64(),
 		Difficulty:  toBigInt(config.Block.Difficulty),
+		Random:      &randao,
 		BaseFee:     toBigInt(config.Block.BaseFee),
 		GasLimit:    blockGasLimit,
 	}

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -91,6 +91,7 @@ mod opcode_not;
 mod origin;
 mod pc;
 mod pop;
+mod push0;
 mod push;
 mod return_revert;
 mod returndatacopy;
@@ -161,6 +162,7 @@ use origin::OriginGadget;
 use pc::PcGadget;
 use pop::PopGadget;
 use push::PushGadget;
+use push0::Push0Gadget;
 use return_revert::ReturnRevertGadget;
 use returndatacopy::ReturnDataCopyGadget;
 use returndatasize::ReturnDataSizeGadget;
@@ -257,6 +259,7 @@ pub(crate) struct ExecutionConfig<F> {
     pc_gadget: Box<PcGadget<F>>,
     pop_gadget: Box<PopGadget<F>>,
     push_gadget: Box<PushGadget<F>>,
+    push0_gadget: Box<Push0Gadget<F>>,
     return_revert_gadget: Box<ReturnRevertGadget<F>>,
     sar_gadget: Box<SarGadget<F>>,
     sdiv_smod_gadget: Box<SignedDivModGadget<F>>,
@@ -520,6 +523,7 @@ impl<F: Field> ExecutionConfig<F> {
             pc_gadget: configure_gadget!(),
             pop_gadget: configure_gadget!(),
             push_gadget: configure_gadget!(),
+            push0_gadget: configure_gadget!(),
             return_revert_gadget: configure_gadget!(),
             sdiv_smod_gadget: configure_gadget!(),
             selfbalance_gadget: configure_gadget!(),
@@ -1204,6 +1208,7 @@ impl<F: Field> ExecutionConfig<F> {
             ExecutionState::PC => assign_exec_step!(self.pc_gadget),
             ExecutionState::POP => assign_exec_step!(self.pop_gadget),
             ExecutionState::PUSH => assign_exec_step!(self.push_gadget),
+            ExecutionState::PUSH0 => assign_exec_step!(self.push0_gadget),
             ExecutionState::RETURN_REVERT => assign_exec_step!(self.return_revert_gadget),
             ExecutionState::RETURNDATASIZE => assign_exec_step!(self.returndatasize_gadget),
             ExecutionState::RETURNDATACOPY => assign_exec_step!(self.returndatacopy_gadget),

--- a/zkevm-circuits/src/evm_circuit/execution/push0.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/push0.rs
@@ -1,0 +1,87 @@
+use crate::{
+    evm_circuit::{
+        execution::ExecutionGadget,
+        step::ExecutionState,
+        util::{
+            common_gadget::SameContextGadget,
+            constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
+            CachedRegion, Cell,
+        },
+        witness::{Block, Call, ExecStep, Transaction},
+    },
+    table::BlockContextFieldTag,
+    util::Expr,
+};
+use bus_mapping::evm::OpcodeId;
+use eth_types::Field;
+use halo2_proofs::{
+    plonk::{
+        Error,
+        Expression::Constant,
+    },
+};
+
+#[derive(Clone, Debug)]
+pub(crate) struct Push0Gadget<F> {
+    same_context: SameContextGadget<F>,
+}
+
+impl<F: Field> ExecutionGadget<F> for Push0Gadget<F> {
+    const NAME: &'static str = "PUSH0";
+
+    const EXECUTION_STATE: ExecutionState = ExecutionState::PUSH0;
+
+    fn configure(cb: &mut ConstraintBuilder<F>) -> Self {
+        // Push the value to the stack
+        cb.stack_push(Constant(F::from(0u64)));
+
+        // State transition
+        let opcode = cb.query_cell();
+        let step_state_transition = StepStateTransition {
+            rw_counter: Delta(1.expr()),
+            program_counter: Delta(1.expr()),
+            stack_pointer: Delta((-1).expr()),
+            gas_left: Delta(-OpcodeId::PUSH0.constant_gas_cost().expr()),
+            ..Default::default()
+        };
+        let same_context = SameContextGadget::construct(cb, opcode, step_state_transition);
+
+        Self {
+            same_context,
+        }
+    }
+
+    fn assign_exec_step(
+        &self,
+        region: &mut CachedRegion<'_, '_, F>,
+        offset: usize,
+        _: &Block<F>,
+        _: &Transaction,
+        _: &Call,
+        step: &ExecStep,
+    ) -> Result<(), Error> {
+        self.same_context.assign_exec_step(region, offset, step)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::test_util::CircuitTestBuilder;
+    use eth_types::bytecode;
+    use mock::test_ctx::TestContext;
+
+    #[test]
+    fn push0_gadget_test() {
+        let bytecode = bytecode! {
+            #[start]
+            PUSH0
+            STOP
+        };
+
+        CircuitTestBuilder::new_from_test_ctx(
+            TestContext::<2, 1>::simple_ctx_with_bytecode(bytecode).unwrap(),
+        )
+        .run();
+    }
+}

--- a/zkevm-circuits/src/evm_circuit/step.rs
+++ b/zkevm-circuits/src/evm_circuit/step.rs
@@ -74,6 +74,7 @@ pub enum ExecutionState {
     MSIZE,
     GAS,
     JUMPDEST,
+    PUSH0,
     PUSH, // PUSH1, PUSH2, ..., PUSH32
     DUP,  // DUP1, DUP2, ..., DUP16
     SWAP, // SWAP1, SWAP2, ..., SWAP16
@@ -227,6 +228,7 @@ impl ExecutionState {
             Self::MSIZE => vec![OpcodeId::MSIZE],
             Self::GAS => vec![OpcodeId::GAS],
             Self::JUMPDEST => vec![OpcodeId::JUMPDEST],
+            Self::PUSH0 => vec![OpcodeId::PUSH0],
             Self::PUSH => vec![
                 OpcodeId::PUSH1,
                 OpcodeId::PUSH2,

--- a/zkevm-circuits/src/witness/step.rs
+++ b/zkevm-circuits/src/witness/step.rs
@@ -184,6 +184,7 @@ impl From<&circuit_input_builder::ExecStep> for ExecutionState {
                     OpcodeId::RETURN | OpcodeId::REVERT => ExecutionState::RETURN_REVERT,
                     OpcodeId::RETURNDATASIZE => ExecutionState::RETURNDATASIZE,
                     OpcodeId::RETURNDATACOPY => ExecutionState::RETURNDATACOPY,
+                    OpcodeId::PUSH0 => ExecutionState::PUSH0,
                     // dummy ops
                     OpcodeId::EXTCODECOPY => dummy!(ExecutionState::EXTCODECOPY),
                     OpcodeId::CREATE => dummy!(ExecutionState::CREATE),


### PR DESCRIPTION
### Description

Introduction of support of the PUSH0 instruction, together with bumping geth integration to a newer version supporting it.

This is a PR for discussion and not meant to be merged, given the amount of changes and potential regressions.

### Issue Link

#1362

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Contents

The PR consists of 3 parts:
- Introduction of PUSH0 (both in the circuits and testing). This is simple enough given the instruction is very basic.
- ~~Updating geth from v1.10.18 to v1.11.5. The previous version is rather old (and it of course does not support Shanghai). This I think could be pulled out and merged on its own.~~
- Changing geth to run in Shanghai mode. This change is risky and likely causes failures.

### Rationale

N/A

### How Has This Been Tested?

Unit test in `bus-mapping`.
