### PR TITLE
Updated Chiquito lookup table grammar for bytecode circuit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "chiquito"
 version = "0.1.0"
-source = "git+https://github.com/privacy-scaling-explorations/chiquito?tag=v2023_04_24#975d09576b1a27cc2171701e169720c9a76ec04f"
+source = "git+https://github.com/privacy-scaling-explorations/chiquito?tag=v2023_04_24_2#c5097d09d012c89664914ff74475a3385002e203"
 dependencies = [
  "halo2_proofs 0.2.0",
 ]

--- a/zkevm-circuits/Cargo.toml
+++ b/zkevm-circuits/Cargo.toml
@@ -39,7 +39,7 @@ snark-verifier = { git = "https://github.com/privacy-scaling-explorations/snark-
     "loader_halo2",
     "system_halo2",
 ] }
-chiquito = { git = "https://github.com/privacy-scaling-explorations/chiquito", tag = "v2023_04_24" }
+chiquito = { git = "https://github.com/privacy-scaling-explorations/chiquito", tag = "v2023_04_24_2" }
 
 [dev-dependencies]
 bus-mapping = { path = "../bus-mapping", features = ["test"] }

--- a/zkevm-circuits/src/bytecode_circuit/bytecode_chiquito.rs
+++ b/zkevm-circuits/src/bytecode_circuit/bytecode_chiquito.rs
@@ -108,9 +108,11 @@ pub fn bytecode_circuit<F: Field + From<u64>>(
                     eq(is_code, push_data_left_is_zero.is_zero()),
                 );
 
-                ctx.lookup(
-                    "lookup((value, push_data_size_table.value)(push_data_size, push_data_size_table.push_data_size))",
-                    vec![(value.expr(), push_data_table_value.expr()), (push_data_size.expr(), push_data_table_size.expr())]);
+                ctx.add_lookup(
+                    lookup()
+                    .add(value, push_data_table_value)
+                    .add(push_data_size, push_data_table_size)
+                );
 
                 ctx.transition(
                     if_next_step(byte_step,
@@ -149,14 +151,13 @@ pub fn bytecode_circuit<F: Field + From<u64>>(
 
                 ctx.transition(select(index_length_diff_is_zero.is_zero(), next_step_must_be(header), 0)); // zero is the valid constraint
 
-                ctx.lookup(
-                    "if header.next() then keccak256_table_lookup(cur.value_rlc, cur.length, cur.hash)",
-                    vec![
-                        (header.next().expr(), keccak_is_enabled.expr()),
-                        (header.next() * value_rlc, keccak_value_rlc.expr()),
-                        (header.next() * length, keccak_length.expr()),
-                        (header.next() * hash, keccak_hash.expr()),
-                    ],
+                ctx.add_lookup(
+                    lookup()
+                    .add(1, keccak_is_enabled)
+                    .add(value_rlc, keccak_value_rlc)
+                    .add(length, keccak_length)
+                    .add(hash, keccak_hash)
+                    .enable(header.next())
                 );
 
                 ctx.wg(move |ctx, wit| {

--- a/zkevm-circuits/src/bytecode_circuit/bytecode_chiquito.rs
+++ b/zkevm-circuits/src/bytecode_circuit/bytecode_chiquito.rs
@@ -113,7 +113,7 @@ pub fn bytecode_circuit<F: Field + From<u64>>(
                     .add(value, push_data_table_value)
                     .add(push_data_size, push_data_table_size)
                 );
-
+                
                 ctx.transition(
                     if_next_step(byte_step,
                         eq(length, length.next())

--- a/zkevm-circuits/src/bytecode_circuit/bytecode_chiquito.rs
+++ b/zkevm-circuits/src/bytecode_circuit/bytecode_chiquito.rs
@@ -110,8 +110,8 @@ pub fn bytecode_circuit<F: Field + From<u64>>(
 
                 ctx.add_lookup(
                     lookup()
-                    .add(value, push_data_table_value)
-                    .add(push_data_size, push_data_table_size)
+                        .add(value, push_data_table_value)
+                        .add(push_data_size, push_data_table_size)
                 );
                 
                 ctx.transition(
@@ -153,11 +153,11 @@ pub fn bytecode_circuit<F: Field + From<u64>>(
 
                 ctx.add_lookup(
                     lookup()
-                    .add(1, keccak_is_enabled)
-                    .add(value_rlc, keccak_value_rlc)
-                    .add(length, keccak_length)
-                    .add(hash, keccak_hash)
-                    .enable(header.next())
+                        .add(1, keccak_is_enabled)
+                        .add(value_rlc, keccak_value_rlc)
+                        .add(length, keccak_length)
+                        .add(hash, keccak_hash)
+                        .enable(header.next())
                 );
 
                 ctx.wg(move |ctx, wit| {

--- a/zkevm-circuits/src/bytecode_circuit/test.rs
+++ b/zkevm-circuits/src/bytecode_circuit/test.rs
@@ -298,7 +298,7 @@ fn bytecode_soundness_bug_1() {
     let minimum_rows = 8;
 
     let overwrite_len = unrolled.bytes.len();
-    let mut overwrite = unrolled.clone();
+    let mut overwrite = unrolled;
     for i in 0..size - minimum_rows + 3 {
         if i >= unrolled_len {
             overwrite.rows.push(BytecodeRow {


### PR DESCRIPTION
## Description
- Use Chiquito tag version "v2023_04_24", which updated PLONKish lookup table syntax with auto annotation features
- Updated the bytecode circuit according to the new syntax

## Contents
This is an update to Leo's original pull request here: https://github.com/privacy-scaling-explorations/zkevm-circuits/pull/1348