### PR TITLE
zellic-fix-1: fix typo in multiplied terms

### DIFF
--- a/gadgets/src/mul_add.rs
+++ b/gadgets/src/mul_add.rs
@@ -158,8 +158,8 @@ impl<F: Field> MulAddChip<F> {
             overflow = carry_hi_expr.clone()
                 + a_limbs[1].clone() * b_limbs[3].clone()
                 + a_limbs[2].clone() * b_limbs[2].clone()
-                + a_limbs[3].clone() * b_limbs[2].clone()
                 + a_limbs[2].clone() * b_limbs[3].clone()
+                + a_limbs[3].clone() * b_limbs[1].clone()
                 + a_limbs[3].clone() * b_limbs[2].clone()
                 + a_limbs[3].clone() * b_limbs[3].clone();
 


### PR DESCRIPTION
### Description

An important typo.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Contents

- Add term `a[3] * b[1]` (was written as `b[2]`).
