### PR TITLE
Simplify bytecode circuit assignment

### DIFF
--- a/gadgets/src/is_zero.rs
+++ b/gadgets/src/is_zero.rs
@@ -51,11 +51,11 @@ impl<F: Field> IsZeroConfig<F> {
     }
 }
 
+#[derive(Debug, Clone)]
 /// Wrapper arround [`IsZeroConfig`] for which [`Chip`] is implemented.
 pub struct IsZeroChip<F> {
     config: IsZeroConfig<F>,
 }
-
 #[rustfmt::skip]
 impl<F: Field> IsZeroChip<F> {
     /// Sets up the configuration of the chip by creating the required columns
@@ -104,6 +104,11 @@ impl<F: Field> IsZeroChip<F> {
     /// Given an `IsZeroConfig`, construct the chip.
     pub fn construct(config: IsZeroConfig<F>) -> Self {
         IsZeroChip { config }
+    }
+
+    /// Annotates columns of this gadget embedded within a circuit region.
+    pub fn annotate_columns_in_region(&self, region: &mut Region<F>, prefix: &str) {
+      self.config.annotate_columns_in_region(region, prefix)
     }
 }
 

--- a/zkevm-circuits/src/bytecode_circuit/circuit.rs
+++ b/zkevm-circuits/src/bytecode_circuit/circuit.rs
@@ -665,6 +665,7 @@ impl<F: Field> BytecodeCircuitConfig<F> {
                 last_row_offset,
                 code_hash: empty_hash,
                 tag: F::from(BytecodeFieldTag::Header as u64),
+                value_rlc: Value::known(F::ZERO),
                 ..Default::default()
             },
         )

--- a/zkevm-circuits/src/bytecode_circuit/circuit.rs
+++ b/zkevm-circuits/src/bytecode_circuit/circuit.rs
@@ -756,6 +756,7 @@ impl<F: Field> BytecodeCircuitConfig<F> {
         region.name_column(|| "BYTECODE_q_first", self.q_first);
         region.name_column(|| "BYTECODE_q_last", self.q_last);
         region.name_column(|| "BYTECODE_length", self.length);
+        region.name_column(|| "BYTECODE_push_data_left", self.push_data_left);
         region.name_column(|| "BYTECODE_push_data_size", self.push_data_size);
         region.name_column(|| "BYTECODE_value_rlc", self.value_rlc);
     }

--- a/zkevm-circuits/src/bytecode_circuit/circuit.rs
+++ b/zkevm-circuits/src/bytecode_circuit/circuit.rs
@@ -71,6 +71,7 @@ pub struct BytecodeCircuitConfig<F> {
     q_first: Column<Fixed>,
     q_last: Column<Fixed>,
     bytecode_table: BytecodeTable,
+    push_data_left: Column<Advice>,
     value_rlc: Column<Advice>,
     length: Column<Advice>,
     push_data_size: Column<Advice>,
@@ -461,6 +462,7 @@ impl<F: Field> SubCircuitConfig<F> for BytecodeCircuitConfig<F> {
             q_first,
             q_last,
             bytecode_table,
+            push_data_left,
             value_rlc,
             length,
             push_data_size,
@@ -703,6 +705,11 @@ impl<F: Field> BytecodeCircuitConfig<F> {
             ("index", self.bytecode_table.index, row.index),
             ("is_code", self.bytecode_table.is_code, row.is_code),
             ("value", self.bytecode_table.value, row.value),
+            (
+                "push_data_left",
+                self.push_data_left,
+                F::from(row.push_data_left),
+            ),
             ("length", self.length, row.length),
             ("push_data_size", self.push_data_size, row.push_data_size),
         ] {


### PR DESCRIPTION
### Description

We simplify the assignment logic in the bytecode circuit by reducing the number of function arguments. The reduction is achieved by

1. Construct IsZero Chips early and make them a part of the circuit struct so that they don't stay with the function arguments.
2. Create a new row struct that carries all the relevant data.

### Issue Link

This would be part of #1391. 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Rationale

- I avoid using `BytecodeRow` in the `bytecode_unroller` since they are part of the future simplification plan.


### How Has This Been Tested?

Sent to the CI and pray.
