### PR TITLE
Use halo2 circuit-params feature

### DIFF
--- a/circuit-benchmarks/src/pi_circuit.rs
+++ b/circuit-benchmarks/src/pi_circuit.rs
@@ -24,7 +24,7 @@ mod tests {
     use rand_xorshift::XorShiftRng;
     use std::env::var;
     use zkevm_circuits::{
-        pi_circuit::{PiCircuit, PiTestCircuit, PublicData},
+        pi_circuit::{PiCircuit, PublicData},
         util::SubCircuit,
     };
 
@@ -48,15 +48,10 @@ mod tests {
         let mut rng = ChaCha20Rng::seed_from_u64(2);
         let randomness = Fr::random(&mut rng);
         let rand_rpi = Fr::random(&mut rng);
-        let public_data = generate_publicdata::<MAX_TXS, MAX_CALLDATA>();
-        let circuit = PiTestCircuit::<Fr, MAX_TXS, MAX_CALLDATA>(PiCircuit::<Fr>::new(
-            MAX_TXS,
-            MAX_CALLDATA,
-            randomness,
-            rand_rpi,
-            public_data,
-        ));
-        let public_inputs = circuit.0.instance();
+        let public_data = generate_publicdata(MAX_TXS);
+        let circuit =
+            PiCircuit::<Fr>::new(MAX_TXS, MAX_CALLDATA, randomness, rand_rpi, public_data);
+        let public_inputs = circuit.instance();
         let instance: Vec<&[Fr]> = public_inputs.iter().map(|input| &input[..]).collect();
         let instances = &[&instance[..]];
 
@@ -90,7 +85,7 @@ mod tests {
             Challenge255<G1Affine>,
             XorShiftRng,
             Blake2bWrite<Vec<u8>, G1Affine, Challenge255<G1Affine>>,
-            PiTestCircuit<Fr, MAX_TXS, MAX_CALLDATA>,
+            PiCircuit<Fr>,
         >(
             &general_params,
             &pk,
@@ -125,12 +120,12 @@ mod tests {
         end_timer!(start3);
     }
 
-    fn generate_publicdata<const MAX_TXS: usize, const MAX_CALLDATA: usize>() -> PublicData {
+    fn generate_publicdata(max_txs: usize) -> PublicData {
         let mut public_data = PublicData::default();
         let chain_id = 1337u64;
         public_data.chain_id = Word::from(chain_id);
 
-        let n_tx = MAX_TXS;
+        let n_tx = max_txs;
         for _ in 0..n_tx {
             let eth_tx = eth_types::Transaction::from(mock::CORRECT_MOCK_TXS[0].clone());
             public_data.transactions.push(eth_tx);

--- a/circuit-benchmarks/src/super_circuit.rs
+++ b/circuit-benchmarks/src/super_circuit.rs
@@ -79,11 +79,9 @@ mod tests {
 
         block.sign(&wallets);
 
-        const MAX_TXS: usize = 1;
-        const MAX_CALLDATA: usize = 32;
         let circuits_params = CircuitsParams {
-            max_txs: MAX_TXS,
-            max_calldata: MAX_CALLDATA,
+            max_txs: 1,
+            max_calldata: 32,
             max_rws: 256,
             max_copy_rows: 256,
             max_exp_steps: 256,
@@ -92,7 +90,7 @@ mod tests {
             max_keccak_rows: 0,
         };
         let (_, circuit, instance, _) =
-            SuperCircuit::<_, MAX_TXS, MAX_CALLDATA, 0x100>::build(block, circuits_params).unwrap();
+            SuperCircuit::build(block, circuits_params, Fr::from(0x100)).unwrap();
         let instance_refs: Vec<&[Fr]> = instance.iter().map(|v| &v[..]).collect();
 
         // Bench setup generation
@@ -120,7 +118,7 @@ mod tests {
             Challenge255<G1Affine>,
             ChaChaRng,
             Blake2bWrite<Vec<u8>, G1Affine, Challenge255<G1Affine>>,
-            SuperCircuit<Fr, MAX_TXS, MAX_CALLDATA, 0x100>,
+            SuperCircuit<Fr>,
         >(
             &general_params,
             &pk,

--- a/gadgets/src/batched_is_zero.rs
+++ b/gadgets/src/batched_is_zero.rs
@@ -158,6 +158,7 @@ mod test {
     impl<F: Field, const N: usize> Circuit<F> for TestCircuit<F, N> {
         type Config = TestCircuitConfig<N>;
         type FloorPlanner = SimpleFloorPlanner;
+        type Params = ();
 
         fn without_witnesses(&self) -> Self {
             Self::default()

--- a/gadgets/src/evm_word.rs
+++ b/gadgets/src/evm_word.rs
@@ -178,6 +178,7 @@ mod tests {
             // commitment which will be provided as public inputs.
             type Config = (WordConfig<F>, Column<Instance>);
             type FloorPlanner = SimpleFloorPlanner;
+            type Params = ();
 
             fn without_witnesses(&self) -> Self {
                 Self::default()

--- a/gadgets/src/is_zero.rs
+++ b/gadgets/src/is_zero.rs
@@ -208,6 +208,7 @@ mod test {
         impl<F: Field> Circuit<F> for TestCircuit<F> {
             type Config = TestCircuitConfig<F>;
             type FloorPlanner = SimpleFloorPlanner;
+            type Params = ();
 
             fn without_witnesses(&self) -> Self {
                 Self::default()
@@ -335,6 +336,7 @@ mod test {
         impl<F: Field> Circuit<F> for TestCircuit<F> {
             type Config = TestCircuitConfig<F>;
             type FloorPlanner = SimpleFloorPlanner;
+            type Params = ();
 
             fn without_witnesses(&self) -> Self {
                 Self::default()

--- a/gadgets/src/less_than.rs
+++ b/gadgets/src/less_than.rs
@@ -243,6 +243,7 @@ mod test {
         impl<F: Field> Circuit<F> for TestCircuit<F> {
             type Config = TestCircuitConfig<F>;
             type FloorPlanner = SimpleFloorPlanner;
+            type Params = ();
 
             fn without_witnesses(&self) -> Self {
                 Self::default()
@@ -363,6 +364,7 @@ mod test {
         impl<F: Field> Circuit<F> for TestCircuit<F> {
             type Config = TestCircuitConfig<F>;
             type FloorPlanner = SimpleFloorPlanner;
+            type Params = ();
 
             fn without_witnesses(&self) -> Self {
                 Self::default()

--- a/gadgets/src/monotone.rs
+++ b/gadgets/src/monotone.rs
@@ -137,6 +137,7 @@ mod test {
     {
         type Config = TestCircuitConfig;
         type FloorPlanner = SimpleFloorPlanner;
+        type Params = ();
 
         fn without_witnesses(&self) -> Self {
             Self::default()

--- a/gadgets/src/mul_add.rs
+++ b/gadgets/src/mul_add.rs
@@ -443,6 +443,7 @@ mod test {
         impl<F: Field> Circuit<F> for TestCircuit<F> {
             type Config = TestCircuitConfig<F>;
             type FloorPlanner = SimpleFloorPlanner;
+            type Params = ();
 
             fn configure(meta: &mut halo2_proofs::plonk::ConstraintSystem<F>) -> Self::Config {
                 let q_enable = meta.complex_selector();

--- a/integration-tests/src/integration_test_circuits.rs
+++ b/integration-tests/src/integration_test_circuits.rs
@@ -119,7 +119,7 @@ lazy_static! {
     TokioMutex::new(IntegrationTest::new("Keccak", KECCAK_CIRCUIT_DEGREE));
 
     /// Integration test for Copy circuit
-    pub static ref SUPER_CIRCUIT_TEST: TokioMutex<IntegrationTest<SuperCircuit::<Fr, MAX_TXS, MAX_CALLDATA, TEST_MOCK_RANDOMNESS>>> =
+    pub static ref SUPER_CIRCUIT_TEST: TokioMutex<IntegrationTest<SuperCircuit::<Fr>>> =
     TokioMutex::new(IntegrationTest::new("Super", SUPER_CIRCUIT_DEGREE));
 
      /// Integration test for Exp circuit

--- a/testool/src/statetest/executor.rs
+++ b/testool/src/statetest/executor.rs
@@ -16,9 +16,6 @@ use std::{collections::HashMap, str::FromStr};
 use thiserror::Error;
 use zkevm_circuits::{super_circuit::SuperCircuit, test_util::CircuitTestBuilder, witness::Block};
 
-const MAX_TXS: usize = 1;
-const MAX_CALLDATA: usize = 32;
-
 #[derive(PartialEq, Eq, Error, Debug)]
 pub enum StateTestError {
     #[error("CannotGenerateCircuitInput({0})")]
@@ -277,8 +274,8 @@ pub fn run_test(
         geth_data.sign(&wallets);
 
         let circuits_params = CircuitsParams {
-            max_txs: MAX_TXS,
-            max_calldata: MAX_CALLDATA,
+            max_txs: 1,
+            max_calldata: 32,
             max_rws: 256,
             max_copy_rows: 256,
             max_exp_steps: 256,
@@ -287,8 +284,7 @@ pub fn run_test(
             max_keccak_rows: 0,
         };
         let (k, circuit, instance, _builder) =
-            SuperCircuit::<Fr, MAX_TXS, MAX_CALLDATA, 0x100>::build(geth_data, circuits_params)
-                .unwrap();
+            SuperCircuit::<Fr>::build(geth_data, circuits_params, Fr::from(0x100)).unwrap();
         builder = _builder;
 
         let prover = MockProver::run(k, &circuit, instance).unwrap();

--- a/zkevm-circuits/Cargo.toml
+++ b/zkevm-circuits/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_04_20" }
+halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", features = ["circuit-params"], tag = "v2023_04_20" }
 num = "0.4"
 sha3 = "0.10"
 array-init = "2.0.0"

--- a/zkevm-circuits/src/bytecode_circuit/dev.rs
+++ b/zkevm-circuits/src/bytecode_circuit/dev.rs
@@ -14,6 +14,7 @@ use halo2_proofs::{
 impl<F: Field> Circuit<F> for BytecodeCircuit<F> {
     type Config = (BytecodeCircuitConfig<F>, Challenges);
     type FloorPlanner = SimpleFloorPlanner;
+    type Params = ();
 
     fn without_witnesses(&self) -> Self {
         Self::default()

--- a/zkevm-circuits/src/bytecode_circuit/test.rs
+++ b/zkevm-circuits/src/bytecode_circuit/test.rs
@@ -13,7 +13,7 @@ use log::error;
 fn bytecode_circuit_unusable_rows() {
     assert_eq!(
         BytecodeCircuit::<Fr>::unusable_rows(),
-        unusable_rows::<Fr, BytecodeCircuit::<Fr>>(),
+        unusable_rows::<Fr, BytecodeCircuit::<Fr>>(()),
     )
 }
 

--- a/zkevm-circuits/src/copy_circuit/dev.rs
+++ b/zkevm-circuits/src/copy_circuit/dev.rs
@@ -14,6 +14,7 @@ use halo2_proofs::{
 impl<F: Field> Circuit<F> for CopyCircuit<F> {
     type Config = (CopyCircuitConfig<F>, Challenges<Challenge>);
     type FloorPlanner = SimpleFloorPlanner;
+    type Params = ();
 
     fn without_witnesses(&self) -> Self {
         Self::default()

--- a/zkevm-circuits/src/copy_circuit/test.rs
+++ b/zkevm-circuits/src/copy_circuit/test.rs
@@ -22,7 +22,7 @@ use mock::{test_ctx::helpers::account_0_code_account_1_no_code, TestContext, MOC
 fn copy_circuit_unusable_rows() {
     assert_eq!(
         CopyCircuit::<Fr>::unusable_rows(),
-        unusable_rows::<Fr, CopyCircuit::<Fr>>(),
+        unusable_rows::<Fr, CopyCircuit::<Fr>>(()),
     )
 }
 

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -329,6 +329,7 @@ pub(crate) mod cached {
     impl Circuit<Fr> for EvmCircuitCached {
         type Config = (EvmCircuitConfig<Fr>, Challenges);
         type FloorPlanner = SimpleFloorPlanner;
+        type Params = ();
 
         fn without_witnesses(&self) -> Self {
             Self(self.0.without_witnesses())
@@ -359,6 +360,7 @@ pub(crate) mod cached {
 impl<F: Field> Circuit<F> for EvmCircuit<F> {
     type Config = (EvmCircuitConfig<F>, Challenges);
     type FloorPlanner = SimpleFloorPlanner;
+    type Params = ();
 
     fn without_witnesses(&self) -> Self {
         Self::default()
@@ -470,7 +472,7 @@ mod evm_circuit_stats {
     fn evm_circuit_unusable_rows() {
         assert_eq!(
             EvmCircuit::<Fr>::unusable_rows(),
-            unusable_rows::<Fr, EvmCircuit::<Fr>>(),
+            unusable_rows::<Fr, EvmCircuit::<Fr>>(()),
         )
     }
 

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/test_util.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/test_util.rs
@@ -90,6 +90,7 @@ impl<G> UnitTestMathGadgetBaseCircuit<G> {
 impl<F: Field, G: MathGadgetContainer<F>> Circuit<F> for UnitTestMathGadgetBaseCircuit<G> {
     type Config = (UnitTestMathGadgetBaseCircuitConfig<F, G>, Challenges);
     type FloorPlanner = SimpleFloorPlanner;
+    type Params = ();
 
     fn without_witnesses(&self) -> Self {
         UnitTestMathGadgetBaseCircuit {

--- a/zkevm-circuits/src/exp_circuit/dev.rs
+++ b/zkevm-circuits/src/exp_circuit/dev.rs
@@ -14,6 +14,7 @@ use halo2_proofs::{
 impl<F: Field> Circuit<F> for ExpCircuit<F> {
     type Config = (ExpCircuitConfig<F>, Challenges);
     type FloorPlanner = SimpleFloorPlanner;
+    type Params = ();
 
     fn without_witnesses(&self) -> Self {
         Self::default()

--- a/zkevm-circuits/src/exp_circuit/test.rs
+++ b/zkevm-circuits/src/exp_circuit/test.rs
@@ -19,7 +19,7 @@ use mock::TestContext;
 fn exp_circuit_unusable_rows() {
     assert_eq!(
         ExpCircuit::<Fr>::unusable_rows(),
-        unusable_rows::<Fr, ExpCircuit::<Fr>>(),
+        unusable_rows::<Fr, ExpCircuit::<Fr>>(()),
     )
 }
 

--- a/zkevm-circuits/src/keccak_circuit/dev.rs
+++ b/zkevm-circuits/src/keccak_circuit/dev.rs
@@ -14,6 +14,7 @@ use halo2_proofs::{
 impl<F: Field> Circuit<F> for KeccakCircuit<F> {
     type Config = (KeccakCircuitConfig<F>, Challenges);
     type FloorPlanner = SimpleFloorPlanner;
+    type Params = ();
 
     fn without_witnesses(&self) -> Self {
         Self::default()

--- a/zkevm-circuits/src/keccak_circuit/table.rs
+++ b/zkevm-circuits/src/keccak_circuit/table.rs
@@ -246,6 +246,7 @@ mod tests {
     impl Circuit<F> for TableTestCircuit {
         type Config = [TableColumn; 2];
         type FloorPlanner = SimpleFloorPlanner;
+        type Params = ();
 
         fn without_witnesses(&self) -> Self {
             self.clone()

--- a/zkevm-circuits/src/keccak_circuit/test.rs
+++ b/zkevm-circuits/src/keccak_circuit/test.rs
@@ -22,7 +22,7 @@ fn serial_keccak_circuit_unusable_rows() {
         std::env::set_var("KECCAK_ROWS", format!("{keccak_rows}"));
         assert_eq!(
             KeccakCircuit::<Fr>::unusable_rows(),
-            unusable_rows::<Fr, KeccakCircuit::<Fr>>(),
+            unusable_rows::<Fr, KeccakCircuit::<Fr>>(()),
         )
     }
     std::env::set_var("KECCAK_ROWS", format!("{DEFAULT_KECCAK_ROWS}"));

--- a/zkevm-circuits/src/pi_circuit.rs
+++ b/zkevm-circuits/src/pi_circuit.rs
@@ -5,8 +5,6 @@ mod param;
 mod dev;
 #[cfg(any(feature = "test", test))]
 mod test;
-#[cfg(any(feature = "test", test, feature = "test-circuits"))]
-pub use dev::PiTestCircuit;
 
 use eth_types::{
     geth_types::{BlockConstants, Transaction},

--- a/zkevm-circuits/src/pi_circuit/dev.rs
+++ b/zkevm-circuits/src/pi_circuit/dev.rs
@@ -1,74 +1,39 @@
 use super::*;
 
-// We define the PiTestCircuit as a wrapper over PiCircuit extended to take the
-// generic const parameters MAX_TXS and MAX_CALLDATA.  This is necessary because
-// the trait Circuit requires an implementation of `configure` that doesn't take
-// any circuit parameters, and the PiCircuit defines gates that use rotations
-// that depend on MAX_TXS and MAX_CALLDATA, so these two values are required
-// during the configuration.
-/// Test Circuit for PiCircuit
-#[derive(Default, Clone)]
-pub struct PiTestCircuit<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize>(
-    pub PiCircuit<F>,
-);
-
-impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize> SubCircuit<F>
-    for PiTestCircuit<F, MAX_TXS, MAX_CALLDATA>
-{
-    type Config = PiCircuitConfig<F>;
-
-    fn unusable_rows() -> usize {
-        PiCircuit::<F>::unusable_rows()
-    }
-
-    fn new_from_block(block: &witness::Block<F>) -> Self {
-        assert_eq!(block.circuits_params.max_txs, MAX_TXS);
-        assert_eq!(block.circuits_params.max_calldata, MAX_CALLDATA);
-
-        Self(PiCircuit::new_from_block(block))
-    }
-
-    fn min_num_rows_block(block: &witness::Block<F>) -> (usize, usize) {
-        assert_eq!(block.circuits_params.max_txs, MAX_TXS);
-        assert_eq!(block.circuits_params.max_calldata, MAX_CALLDATA);
-
-        PiCircuit::min_num_rows_block(block)
-    }
-
-    /// Compute the public inputs for this circuit.
-    fn instance(&self) -> Vec<Vec<F>> {
-        self.0.instance()
-    }
-
-    fn synthesize_sub(
-        &self,
-        _config: &Self::Config,
-        _challenges: &Challenges<Value<F>>,
-        _layouter: &mut impl Layouter<F>,
-    ) -> Result<(), Error> {
-        panic!("use PiCircuit for embedding instead");
-    }
+/// Public Input Circuit configuration parameters
+#[derive(Default)]
+pub struct PiCircuitParams {
+    /// Max Txs
+    pub max_txs: usize,
+    /// Max Calldata
+    pub max_calldata: usize,
 }
 
-impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize> Circuit<F>
-    for PiTestCircuit<F, MAX_TXS, MAX_CALLDATA>
-{
+impl<F: Field> Circuit<F> for PiCircuit<F> {
     type Config = (PiCircuitConfig<F>, Challenges);
     type FloorPlanner = SimpleFloorPlanner;
+    type Params = PiCircuitParams;
 
     fn without_witnesses(&self) -> Self {
         Self::default()
     }
 
-    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+    fn params(&self) -> Self::Params {
+        PiCircuitParams {
+            max_txs: self.max_txs,
+            max_calldata: self.max_calldata,
+        }
+    }
+
+    fn configure_with_params(meta: &mut ConstraintSystem<F>, params: Self::Params) -> Self::Config {
         let block_table = BlockTable::construct(meta);
         let tx_table = TxTable::construct(meta);
         (
             PiCircuitConfig::new(
                 meta,
                 PiCircuitConfigArgs {
-                    max_txs: MAX_TXS,
-                    max_calldata: MAX_CALLDATA,
+                    max_txs: params.max_txs,
+                    max_calldata: params.max_calldata,
                     block_table,
                     tx_table,
                 },
@@ -77,12 +42,16 @@ impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize> Circuit<F>
         )
     }
 
+    fn configure(_meta: &mut ConstraintSystem<F>) -> Self::Config {
+        unreachable!();
+    }
+
     fn synthesize(
         &self,
         (config, challenges): Self::Config,
         mut layouter: impl Layouter<F>,
     ) -> Result<(), Error> {
         let challenges = challenges.values(&mut layouter);
-        self.0.synthesize_sub(&config, &challenges, &mut layouter)
+        self.synthesize_sub(&config, &challenges, &mut layouter)
     }
 }

--- a/zkevm-circuits/src/root_circuit.rs
+++ b/zkevm-circuits/src/root_circuit.rs
@@ -110,6 +110,7 @@ where
 {
     type Config = AggregationConfig;
     type FloorPlanner = SimpleFloorPlanner;
+    type Params = ();
 
     fn without_witnesses(&self) -> Self {
         Self {

--- a/zkevm-circuits/src/root_circuit/aggregation.rs
+++ b/zkevm-circuits/src/root_circuit/aggregation.rs
@@ -446,6 +446,7 @@ where
 {
     type Config = AggregationConfig;
     type FloorPlanner = SimpleFloorPlanner;
+    type Params = ();
 
     fn without_witnesses(&self) -> Self {
         Self {
@@ -609,6 +610,7 @@ pub mod test {
     impl<F: Field> Circuit<F> for StandardPlonk<F> {
         type Config = StandardPlonkConfig;
         type FloorPlanner = V1;
+        type Params = ();
 
         fn without_witnesses(&self) -> Self {
             *self

--- a/zkevm-circuits/src/root_circuit/test.rs
+++ b/zkevm-circuits/src/root_circuit/test.rs
@@ -20,12 +20,10 @@ use rand::rngs::OsRng;
 fn test_root_circuit() {
     let (params, protocol, proof, instance) = {
         // Preprocess
-        const MAX_TXS: usize = 1;
-        const MAX_CALLDATA: usize = 32;
         const TEST_MOCK_RANDOMNESS: u64 = 0x100;
         let circuits_params = CircuitsParams {
-            max_txs: MAX_TXS,
-            max_calldata: MAX_CALLDATA,
+            max_txs: 1,
+            max_calldata: 32,
             max_rws: 256,
             max_copy_rows: 256,
             max_exp_steps: 256,
@@ -34,11 +32,8 @@ fn test_root_circuit() {
             max_keccak_rows: 0,
         };
         let (k, circuit, instance, _) =
-            SuperCircuit::<_, MAX_TXS, MAX_CALLDATA, TEST_MOCK_RANDOMNESS>::build(
-                block_1tx(),
-                circuits_params,
-            )
-            .unwrap();
+            SuperCircuit::<_>::build(block_1tx(), circuits_params, TEST_MOCK_RANDOMNESS.into())
+                .unwrap();
         let params = ParamsKZG::<Bn256>::setup(k, OsRng);
         let pk = keygen_pk(&params, keygen_vk(&params, &circuit).unwrap(), &circuit).unwrap();
         let protocol = compile(

--- a/zkevm-circuits/src/state_circuit/dev.rs
+++ b/zkevm-circuits/src/state_circuit/dev.rs
@@ -17,6 +17,7 @@ where
 {
     type Config = (StateCircuitConfig<F>, Challenges);
     type FloorPlanner = SimpleFloorPlanner;
+    type Params = ();
 
     fn without_witnesses(&self) -> Self {
         Self::default()

--- a/zkevm-circuits/src/state_circuit/test.rs
+++ b/zkevm-circuits/src/state_circuit/test.rs
@@ -32,7 +32,7 @@ const N_ROWS: usize = 1 << 16;
 fn state_circuit_unusable_rows() {
     assert_eq!(
         StateCircuit::<Fr>::unusable_rows(),
-        unusable_rows::<Fr, StateCircuit::<Fr>>(),
+        unusable_rows::<Fr, StateCircuit::<Fr>>(()),
     )
 }
 

--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -98,17 +98,17 @@ pub struct SuperCircuitConfig<F: Field> {
 }
 
 /// Circuit configuration arguments
-pub struct SuperCircuitConfigArgs {
+pub struct SuperCircuitConfigArgs<F: Field> {
     /// Max txs
     pub max_txs: usize,
     /// Max calldata
     pub max_calldata: usize,
     /// Mock randomness
-    pub mock_randomness: u64,
+    pub mock_randomness: F,
 }
 
 impl<F: Field> SubCircuitConfig<F> for SuperCircuitConfig<F> {
-    type ConfigArgs = SuperCircuitConfigArgs;
+    type ConfigArgs = SuperCircuitConfigArgs<F>;
 
     /// Configure SuperCircuitConfig
     fn new(
@@ -131,9 +131,8 @@ impl<F: Field> SubCircuitConfig<F> for SuperCircuitConfig<F> {
 
         // Use a mock randomness instead of the randomness derived from the challange
         // (either from mock or real prover) to help debugging assignments.
-        let power_of_randomness: [Expression<F>; 31] = array::from_fn(|i| {
-            Expression::Constant(F::from(mock_randomness).pow([1 + i as u64, 0, 0, 0]))
-        });
+        let power_of_randomness: [Expression<F>; 31] =
+            array::from_fn(|i| Expression::Constant(mock_randomness.pow([1 + i as u64, 0, 0, 0])));
 
         let challenges = Challenges::mock(
             power_of_randomness[0].clone(),
@@ -225,12 +224,7 @@ impl<F: Field> SubCircuitConfig<F> for SuperCircuitConfig<F> {
 
 /// The Super Circuit contains all the zkEVM circuits
 #[derive(Clone, Default, Debug)]
-pub struct SuperCircuit<
-    F: Field,
-    const MAX_TXS: usize,
-    const MAX_CALLDATA: usize,
-    const MOCK_RANDOMNESS: u64,
-> {
+pub struct SuperCircuit<F: Field> {
     /// EVM Circuit
     pub evm_circuit: EvmCircuit<F>,
     /// State Circuit
@@ -247,15 +241,16 @@ pub struct SuperCircuit<
     pub exp_circuit: ExpCircuit<F>,
     /// Keccak Circuit
     pub keccak_circuit: KeccakCircuit<F>,
+    /// Circuits Parameters
+    pub circuits_params: CircuitsParams,
+    /// Mock randomness
+    pub mock_randomness: F,
 }
 
-impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize, const MOCK_RANDOMNESS: u64>
-    SuperCircuit<F, MAX_TXS, MAX_CALLDATA, MOCK_RANDOMNESS>
-{
+impl<F: Field> SuperCircuit<F> {
     /// Return the number of rows required to verify a given block
     pub fn get_num_rows_required(block: &Block<F>) -> usize {
         let num_rows_evm_circuit = EvmCircuit::<F>::get_num_rows_required(block);
-        assert_eq!(block.circuits_params.max_txs, MAX_TXS);
         let num_rows_tx_circuit =
             TxCircuitConfig::<F>::get_num_rows_required(block.circuits_params.max_txs);
         num_rows_evm_circuit.max(num_rows_tx_circuit)
@@ -265,9 +260,7 @@ impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize, const MOCK_RANDO
 // Eventhough the SuperCircuit is not a subcircuit we implement the SubCircuit
 // trait for it in order to get the `new_from_block` and `instance` methods that
 // allow us to generalize integration tests.
-impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize, const MOCK_RANDOMNESS: u64>
-    SubCircuit<F> for SuperCircuit<F, MAX_TXS, MAX_CALLDATA, MOCK_RANDOMNESS>
-{
+impl<F: Field> SubCircuit<F> for SuperCircuit<F> {
     type Config = SuperCircuitConfig<F>;
 
     fn unusable_rows() -> usize {
@@ -294,7 +287,7 @@ impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize, const MOCK_RANDO
         let exp_circuit = ExpCircuit::new_from_block(block);
         let keccak_circuit = KeccakCircuit::new_from_block(block);
 
-        SuperCircuit::<_, MAX_TXS, MAX_CALLDATA, MOCK_RANDOMNESS> {
+        SuperCircuit::<_> {
             evm_circuit,
             state_circuit,
             tx_circuit,
@@ -303,6 +296,8 @@ impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize, const MOCK_RANDO
             copy_circuit,
             exp_circuit,
             keccak_circuit,
+            circuits_params: block.circuits_params,
+            mock_randomness: block.randomness,
         }
     }
 
@@ -368,25 +363,44 @@ impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize, const MOCK_RANDO
     }
 }
 
-impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize, const MOCK_RANDOMNESS: u64>
-    Circuit<F> for SuperCircuit<F, MAX_TXS, MAX_CALLDATA, MOCK_RANDOMNESS>
-{
+/// Super Circuit configuration parameters
+#[derive(Default)]
+pub struct SuperCircuitParams<F: Field> {
+    max_txs: usize,
+    max_calldata: usize,
+    mock_randomness: F,
+}
+
+impl<F: Field> Circuit<F> for SuperCircuit<F> {
     type Config = SuperCircuitConfig<F>;
     type FloorPlanner = SimpleFloorPlanner;
+    type Params = SuperCircuitParams<F>;
 
     fn without_witnesses(&self) -> Self {
         Self::default()
     }
 
-    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+    fn params(&self) -> Self::Params {
+        SuperCircuitParams {
+            max_txs: self.circuits_params.max_txs,
+            max_calldata: self.circuits_params.max_calldata,
+            mock_randomness: self.mock_randomness,
+        }
+    }
+
+    fn configure_with_params(meta: &mut ConstraintSystem<F>, params: Self::Params) -> Self::Config {
         Self::Config::new(
             meta,
             SuperCircuitConfigArgs {
-                max_txs: MAX_TXS,
-                max_calldata: MAX_CALLDATA,
-                mock_randomness: MOCK_RANDOMNESS,
+                max_txs: params.max_txs,
+                max_calldata: params.max_calldata,
+                mock_randomness: params.mock_randomness,
             },
         )
+    }
+
+    fn configure(_meta: &mut ConstraintSystem<F>) -> Self::Config {
+        unreachable!();
     }
 
     fn synthesize(
@@ -418,9 +432,7 @@ impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize, const MOCK_RANDO
     }
 }
 
-impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize, const MOCK_RANDOMNESS: u64>
-    SuperCircuit<F, MAX_TXS, MAX_CALLDATA, MOCK_RANDOMNESS>
-{
+impl<F: Field> SuperCircuit<F> {
     /// From the witness data, generate a SuperCircuit instance with all of the
     /// sub-circuits filled with their corresponding witnesses.
     ///
@@ -430,6 +442,7 @@ impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize, const MOCK_RANDO
     pub fn build(
         geth_data: GethData,
         circuits_params: CircuitsParams,
+        mock_randomness: F,
     ) -> Result<(u32, Self, Vec<Vec<F>>, CircuitInputBuilder), bus_mapping::Error> {
         let block_data =
             BlockData::new_from_geth_data_with_params(geth_data.clone(), circuits_params);
@@ -438,7 +451,7 @@ impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize, const MOCK_RANDO
             .handle_block(&geth_data.eth_block, &geth_data.geth_traces)
             .expect("could not handle block tx");
 
-        let ret = Self::build_from_circuit_input_builder(&builder)?;
+        let ret = Self::build_from_circuit_input_builder(&builder, mock_randomness)?;
         Ok((ret.0, ret.1, ret.2, builder))
     }
 
@@ -449,18 +462,16 @@ impl<F: Field, const MAX_TXS: usize, const MAX_CALLDATA: usize, const MOCK_RANDO
     /// the Public Inputs needed.
     pub fn build_from_circuit_input_builder(
         builder: &CircuitInputBuilder,
+        mock_randomness: F,
     ) -> Result<(u32, Self, Vec<Vec<F>>), bus_mapping::Error> {
         let mut block = block_convert(&builder.block, &builder.code_db).unwrap();
-        block.randomness = F::from(MOCK_RANDOMNESS);
-        assert_eq!(block.circuits_params.max_txs, MAX_TXS);
-        assert_eq!(block.circuits_params.max_calldata, MAX_CALLDATA);
+        block.randomness = mock_randomness;
 
         let (_, rows_needed) = Self::min_num_rows_block(&block);
         let k = log2_ceil(Self::unusable_rows() + rows_needed);
         log::debug!("super circuit uses k = {}", k);
 
-        let circuit =
-            SuperCircuit::<_, MAX_TXS, MAX_CALLDATA, MOCK_RANDOMNESS>::new_from_block(&block);
+        let circuit = SuperCircuit::new_from_block(&block);
 
         let instance = circuit.instance();
         Ok((k, circuit, instance))

--- a/zkevm-circuits/src/super_circuit/test.rs
+++ b/zkevm-circuits/src/super_circuit/test.rs
@@ -12,23 +12,20 @@ use eth_types::{address, bytecode, geth_types::GethData, Word};
 #[test]
 fn super_circuit_degree() {
     let mut cs = ConstraintSystem::<Fr>::default();
-    SuperCircuit::<_, 1, 32, 0x100>::configure(&mut cs);
+    let params = SuperCircuitParams {
+        max_txs: 1,
+        max_calldata: 32,
+        mock_randomness: Fr::from(0x100),
+    };
+    SuperCircuit::configure_with_params(&mut cs, params);
     log::info!("super circuit degree: {}", cs.degree());
     log::info!("super circuit minimum_rows: {}", cs.minimum_rows());
     assert!(cs.degree() <= 9);
 }
 
-fn test_super_circuit<
-    const MAX_TXS: usize,
-    const MAX_CALLDATA: usize,
-    const MOCK_RANDOMNESS: u64,
->(
-    block: GethData,
-    circuits_params: CircuitsParams,
-) {
+fn test_super_circuit(block: GethData, circuits_params: CircuitsParams, mock_randomness: Fr) {
     let (k, circuit, instance, _) =
-        SuperCircuit::<Fr, MAX_TXS, MAX_CALLDATA, MOCK_RANDOMNESS>::build(block, circuits_params)
-            .unwrap();
+        SuperCircuit::<Fr>::build(block, circuits_params, mock_randomness).unwrap();
     let prover = MockProver::run(k, &circuit, instance).unwrap();
     let res = prover.verify_par();
     if let Err(err) = res {
@@ -131,11 +128,9 @@ const TEST_MOCK_RANDOMNESS: u64 = 0x100;
 #[test]
 fn serial_test_super_circuit_1tx_1max_tx() {
     let block = block_1tx();
-    const MAX_TXS: usize = 1;
-    const MAX_CALLDATA: usize = 32;
     let circuits_params = CircuitsParams {
-        max_txs: MAX_TXS,
-        max_calldata: MAX_CALLDATA,
+        max_txs: 1,
+        max_calldata: 32,
         max_rws: 256,
         max_copy_rows: 256,
         max_exp_steps: 256,
@@ -143,17 +138,15 @@ fn serial_test_super_circuit_1tx_1max_tx() {
         max_evm_rows: 0,
         max_keccak_rows: 0,
     };
-    test_super_circuit::<MAX_TXS, MAX_CALLDATA, TEST_MOCK_RANDOMNESS>(block, circuits_params);
+    test_super_circuit(block, circuits_params, Fr::from(TEST_MOCK_RANDOMNESS));
 }
 #[ignore]
 #[test]
 fn serial_test_super_circuit_1tx_2max_tx() {
     let block = block_1tx();
-    const MAX_TXS: usize = 2;
-    const MAX_CALLDATA: usize = 32;
     let circuits_params = CircuitsParams {
-        max_txs: MAX_TXS,
-        max_calldata: MAX_CALLDATA,
+        max_txs: 2,
+        max_calldata: 32,
         max_rws: 256,
         max_copy_rows: 256,
         max_exp_steps: 256,
@@ -161,17 +154,15 @@ fn serial_test_super_circuit_1tx_2max_tx() {
         max_evm_rows: 0,
         max_keccak_rows: 0,
     };
-    test_super_circuit::<MAX_TXS, MAX_CALLDATA, TEST_MOCK_RANDOMNESS>(block, circuits_params);
+    test_super_circuit(block, circuits_params, Fr::from(TEST_MOCK_RANDOMNESS));
 }
 #[ignore]
 #[test]
 fn serial_test_super_circuit_2tx_2max_tx() {
     let block = block_2tx();
-    const MAX_TXS: usize = 2;
-    const MAX_CALLDATA: usize = 32;
     let circuits_params = CircuitsParams {
-        max_txs: MAX_TXS,
-        max_calldata: MAX_CALLDATA,
+        max_txs: 2,
+        max_calldata: 32,
         max_rws: 256,
         max_copy_rows: 256,
         max_exp_steps: 256,
@@ -179,5 +170,5 @@ fn serial_test_super_circuit_2tx_2max_tx() {
         max_evm_rows: 0,
         max_keccak_rows: 0,
     };
-    test_super_circuit::<MAX_TXS, MAX_CALLDATA, TEST_MOCK_RANDOMNESS>(block, circuits_params);
+    test_super_circuit(block, circuits_params, Fr::from(TEST_MOCK_RANDOMNESS));
 }

--- a/zkevm-circuits/src/tx_circuit/dev.rs
+++ b/zkevm-circuits/src/tx_circuit/dev.rs
@@ -16,6 +16,7 @@ use log::error;
 impl<F: Field> Circuit<F> for TxCircuit<F> {
     type Config = (TxCircuitConfig<F>, Challenges);
     type FloorPlanner = SimpleFloorPlanner;
+    type Params = ();
 
     fn without_witnesses(&self) -> Self {
         Self::default()

--- a/zkevm-circuits/src/tx_circuit/sign_verify.rs
+++ b/zkevm-circuits/src/tx_circuit/sign_verify.rs
@@ -753,6 +753,7 @@ mod sign_verify_tests {
     impl<F: Field> Circuit<F> for TestCircuitSignVerify<F> {
         type Config = TestCircuitSignVerifyConfig;
         type FloorPlanner = SimpleFloorPlanner;
+        type Params = ();
 
         fn without_witnesses(&self) -> Self {
             Self::default()

--- a/zkevm-circuits/src/tx_circuit/test.rs
+++ b/zkevm-circuits/src/tx_circuit/test.rs
@@ -12,7 +12,7 @@ use mock::AddrOrWallet;
 fn tx_circuit_unusable_rows() {
     assert_eq!(
         TxCircuit::<Fr>::unusable_rows(),
-        unusable_rows::<Fr, TxCircuit::<Fr>>(),
+        unusable_rows::<Fr, TxCircuit::<Fr>>(()),
     )
 }
 

--- a/zkevm-circuits/src/util.rs
+++ b/zkevm-circuits/src/util.rs
@@ -229,9 +229,9 @@ pub(crate) fn get_push_size(byte: u8) -> u64 {
 /// For circuit with column queried at more than 3 distinct rotation, we can
 /// calculate the unusable rows as (x - 3) + 6 where x is the number of distinct
 /// rotation.
-pub(crate) fn unusable_rows<F: Field, C: Circuit<F>>() -> usize {
+pub(crate) fn unusable_rows<F: Field, C: Circuit<F>>(params: C::Params) -> usize {
     let mut cs = ConstraintSystem::default();
-    C::configure(&mut cs);
+    C::configure_with_params(&mut cs, params);
 
     cs.blinding_factors() + 1
 }

--- a/zkevm-circuits/tests/prover_error.rs
+++ b/zkevm-circuits/tests/prover_error.rs
@@ -1,8 +1,8 @@
 // This file is intended to be used with fixtures generated from zkevm-chain.
 // Copy the `errors/<block number>` directory into the zkevm-circuits git root
 // as `block` and run via `cargo test -p zkevm-circuits --features test
-// prover_error -- --nocapture --ignored`. Change any constant variables like
-// `MAX_TXS` to suit your needs.
+// prover_error -- --nocapture --ignored`. Change any circuit parameters like
+// `max_txs` to suit your needs.
 use bus_mapping::{circuit_input_builder::CircuitsParams, mock::BlockData};
 use env_logger::Env;
 use eth_types::{
@@ -36,14 +36,12 @@ fn load_json(path: &str) -> Value {
 #[ignore]
 fn prover_error() {
     // change any of these values to your needs
-    const MAX_TXS: usize = 1;
-    const MAX_CALLDATA: usize = 256;
     const MOCK_RANDOMNESS: u64 = 0x100;
     let k = 19;
     let chain_id = Word::from(99);
     let circuit_params = CircuitsParams {
-        max_txs: MAX_TXS,
-        max_calldata: MAX_CALLDATA,
+        max_txs: 1,
+        max_calldata: 256,
         max_rws: 16388,
         ..Default::default()
     };
@@ -104,8 +102,7 @@ fn prover_error() {
         block.randomness = Fr::from(MOCK_RANDOMNESS);
         block
     };
-    let circuit =
-        SuperCircuit::<_, MAX_TXS, MAX_CALLDATA, MOCK_RANDOMNESS>::new_from_block(&block_witness);
+    let circuit = SuperCircuit::new_from_block(&block_witness);
     let res = MockProver::run(k, &circuit, circuit.instance())
         .expect("MockProver::run")
         .verify_par();


### PR DESCRIPTION
Refactor SuperCircuit and PiCircuit to use circuit parameters instead of associated constants.

Resolve https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/1393

### Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Contents

Using the `circuit-params` feature recently introduced in our fork of halo2 allows simplifying the code for circuits that require runtime parameters at configuration time.  It removes the annoying associated const of the circuit types, and also allows having a single circuit type (no need for an extra circuit test type).
