### PR TITLE
fix(testool): fix coinbase, solves #1160

### DIFF
--- a/testool/src/statetest/spec.rs
+++ b/testool/src/statetest/spec.rs
@@ -250,11 +250,20 @@ impl StateTest {
             );
         }
 
+        pre.insert(
+            *mock::MOCK_COINBASE,
+            Account {
+                address: *mock::MOCK_COINBASE,
+                balance: U256::from(1),
+                ..Default::default()
+            },
+        );
+
         let state_test = StateTest {
             path: String::default(),
             id: String::default(),
             env: Env {
-                current_coinbase: Address::default(),
+                current_coinbase: *mock::MOCK_COINBASE,
                 current_difficulty: U256::default(),
                 current_gas_limit: 16000000,
                 current_number: 1,


### PR DESCRIPTION
### Description

When running `testool --oneliner`, set the coinbase to `MOCK_COINBASE` and top up with 1 wei to register it into the state db.

### Issue Link

#1160 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update