### PR TITLE
[word-lo-hi] evm circuit 

### DIFF
--- a/zkevm-circuits/src/copy_circuit/dev.rs
+++ b/zkevm-circuits/src/copy_circuit/dev.rs
@@ -57,7 +57,6 @@ impl<F: Field> Circuit<F> for CopyCircuit<F> {
             &self.external_data.txs,
             self.external_data.max_txs,
             self.external_data.max_calldata,
-            &challenge_values,
         )?;
 
         config.0.rw_table.load(
@@ -66,11 +65,10 @@ impl<F: Field> Circuit<F> for CopyCircuit<F> {
             self.external_data.max_rws,
         )?;
 
-        config.0.bytecode_table.load(
-            &mut layouter,
-            self.external_data.bytecodes.values(),
-            &challenge_values,
-        )?;
+        config
+            .0
+            .bytecode_table
+            .load(&mut layouter, self.external_data.bytecodes.values())?;
         self.synthesize_sub(&config.0, &challenge_values, &mut layouter)
     }
 }

--- a/zkevm-circuits/src/copy_circuit/util.rs
+++ b/zkevm-circuits/src/copy_circuit/util.rs
@@ -1,22 +1,12 @@
-use crate::evm_circuit::util::rlc;
+use crate::util::word::Word;
 use bus_mapping::circuit_input_builder::NumberOrHash;
 use eth_types::Field;
 use halo2_proofs::circuit::Value;
 
 /// Encode the type `NumberOrHash` into a field element
-pub fn number_or_hash_to_field<F: Field>(v: &NumberOrHash, challenge: Value<F>) -> Value<F> {
+pub fn number_or_hash_to_field<F: Field>(v: &NumberOrHash) -> Word<Value<F>> {
     match v {
-        NumberOrHash::Number(n) => Value::known(F::from(*n as u64)),
-        NumberOrHash::Hash(h) => {
-            // since code hash in the bytecode table is represented in
-            // the little-endian form, we reverse the big-endian bytes
-            // of H256.
-            let le_bytes = {
-                let mut b = h.to_fixed_bytes();
-                b.reverse();
-                b
-            };
-            challenge.map(|challenge| rlc::value(&le_bytes, challenge))
-        }
+        NumberOrHash::Number(n) => Word::from(*n as u64).into_value(),
+        NumberOrHash::Hash(h) => Word::from(*h).into_value(),
     }
 }

--- a/zkevm-circuits/src/copy_circuit/util.rs
+++ b/zkevm-circuits/src/copy_circuit/util.rs
@@ -4,7 +4,7 @@ use eth_types::Field;
 use halo2_proofs::circuit::Value;
 
 /// Encode the type `NumberOrHash` into a field element
-pub fn number_or_hash_to_field<F: Field>(v: &NumberOrHash) -> Word<Value<F>> {
+pub fn number_or_hash_to_word<F: Field>(v: &NumberOrHash) -> Word<Value<F>> {
     match v {
         NumberOrHash::Number(n) => Word::from(*n as u64).into_value(),
         NumberOrHash::Hash(h) => Word::from(*h).into_value(),

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -411,7 +411,6 @@ impl<F: Field> Circuit<F> for EvmCircuit<F> {
             &block.txs,
             block.circuits_params.max_txs,
             block.circuits_params.max_calldata,
-            &challenges,
         )?;
         block.rws.check_rw_counter_sanity();
         config.rw_table.load(
@@ -421,10 +420,8 @@ impl<F: Field> Circuit<F> for EvmCircuit<F> {
         )?;
         config
             .bytecode_table
-            .load(&mut layouter, block.bytecodes.values(), &challenges)?;
-        config
-            .block_table
-            .load(&mut layouter, &block.context, challenges.evm_word())?;
+            .load(&mut layouter, block.bytecodes.values())?;
+        config.block_table.load(&mut layouter, &block.context)?;
         config.copy_table.load(&mut layouter, block, &challenges)?;
         config
             .keccak_table

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -111,14 +111,13 @@ mod sstore;
 mod stop;
 mod swap;
 
-use self::sha3::Sha3Gadget;
+use self::{block_ctx::BlockCtxGadget, sha3::Sha3Gadget};
 use add_sub::AddSubGadget;
 use addmod::AddModGadget;
 use address::AddressGadget;
 use balance::BalanceGadget;
 use begin_tx::BeginTxGadget;
 use bitwise::BitwiseGadget;
-use block_ctx::{BlockCtxU160Gadget, BlockCtxU256Gadget, BlockCtxU64Gadget};
 use blockhash::BlockHashGadget;
 use byte::ByteGadget;
 use calldatacopy::CallDataCopyGadget;
@@ -281,9 +280,7 @@ pub struct ExecutionConfig<F> {
     stop_gadget: Box<StopGadget<F>>,
     swap_gadget: Box<SwapGadget<F>>,
     blockhash_gadget: Box<BlockHashGadget<F>>,
-    block_ctx_u64_gadget: Box<BlockCtxU64Gadget<F>>,
-    block_ctx_u160_gadget: Box<BlockCtxU160Gadget<F>>,
-    block_ctx_u256_gadget: Box<BlockCtxU256Gadget<F>>,
+    block_ctx_gadget: Box<BlockCtxGadget<F>>,
     // error gadgets
     error_oog_call: Box<ErrorOOGCallGadget<F>>,
     error_oog_constant: Box<ErrorOOGConstantGadget<F>>,
@@ -548,9 +545,7 @@ impl<F: Field> ExecutionConfig<F> {
             sstore_gadget: configure_gadget!(),
             stop_gadget: configure_gadget!(),
             swap_gadget: configure_gadget!(),
-            block_ctx_u64_gadget: configure_gadget!(),
-            block_ctx_u160_gadget: configure_gadget!(),
-            block_ctx_u256_gadget: configure_gadget!(),
+            block_ctx_gadget: configure_gadget!(),
             // error gadgets
             error_oog_constant: configure_gadget!(),
             error_oog_static_memory_gadget: configure_gadget!(),
@@ -1216,9 +1211,7 @@ impl<F: Field> ExecutionConfig<F> {
             ExecutionState::SAR => assign_exec_step!(self.sar_gadget),
             ExecutionState::SCMP => assign_exec_step!(self.signed_comparator_gadget),
             ExecutionState::SDIV_SMOD => assign_exec_step!(self.sdiv_smod_gadget),
-            ExecutionState::BLOCKCTXU64 => assign_exec_step!(self.block_ctx_u64_gadget),
-            ExecutionState::BLOCKCTXU160 => assign_exec_step!(self.block_ctx_u160_gadget),
-            ExecutionState::BLOCKCTXU256 => assign_exec_step!(self.block_ctx_u256_gadget),
+            ExecutionState::BLOCKCTX => assign_exec_step!(self.block_ctx_gadget),
             ExecutionState::BLOCKHASH => assign_exec_step!(self.blockhash_gadget),
             ExecutionState::SELFBALANCE => assign_exec_step!(self.selfbalance_gadget),
             // dummy gadgets

--- a/zkevm-circuits/src/evm_circuit/execution/add_sub.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/add_sub.rs
@@ -41,7 +41,7 @@ impl<F: Field> ExecutionGadget<F> for AddSubGadget<F> {
         let a = cb.query_word32();
         let b = cb.query_word32();
         let c = cb.query_word32();
-        let add_words = AddWordsGadget::construct_new(cb, [a.clone(), b.clone()], c.clone());
+        let add_words = AddWordsGadget::construct(cb, [a.clone(), b.clone()], c.clone());
 
         // Swap a and c if opcode is SUB
         let is_sub = PairSelectGadget::construct(

--- a/zkevm-circuits/src/evm_circuit/execution/balance.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/balance.rs
@@ -47,11 +47,11 @@ impl<F: Field> ExecutionGadget<F> for BalanceGadget<F> {
         let tx_id = cb.call_context(None, CallContextFieldTag::TxId);
         let mut reversion_info = cb.reversion_info_read(None);
         let is_warm = cb.query_bool();
-        cb.account_access_list_write_word(
+        cb.account_access_list_write(
             tx_id.expr(),
             address.to_word(),
-            Word::from_lo_unchecked(1.expr()),
-            Word::from_lo_unchecked(is_warm.expr()),
+            1.expr(),
+            is_warm.expr(),
             Some(&mut reversion_info),
         );
         let code_hash = cb.query_word_unchecked();

--- a/zkevm-circuits/src/evm_circuit/execution/balance.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/balance.rs
@@ -1,6 +1,7 @@
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
+        param::N_BYTES_ACCOUNT_ADDRESS,
         step::ExecutionState,
         util::{
             common_gadget::SameContextGadget,
@@ -8,29 +9,29 @@ use crate::{
                 ConstrainBuilderCommon, EVMConstraintBuilder, ReversionInfo, StepStateTransition,
                 Transition::Delta,
             },
-            math_gadget::IsZeroGadget,
-            not, select, CachedRegion, Cell, Word,
+            math_gadget::IsZeroWordGadget,
+            not, select, AccountAddress, CachedRegion, Cell,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
     table::{AccountFieldTag, CallContextFieldTag},
     util::{
-        word::{Word32Cell, WordExpr},
+        word::{Word, Word32Cell, WordCell, WordExpr},
         Expr,
     },
 };
-use eth_types::{evm_types::GasCost, Field, ToLittleEndian};
+use eth_types::{evm_types::GasCost, Field, ToLittleEndian, ToWord};
 use halo2_proofs::{circuit::Value, plonk::Error};
 
 #[derive(Clone, Debug)]
 pub(crate) struct BalanceGadget<F> {
     same_context: SameContextGadget<F>,
-    address_word: Word<F>,
+    address: AccountAddress<F>,
     reversion_info: ReversionInfo<F>,
     tx_id: Cell<F>,
     is_warm: Cell<F>,
-    code_hash: Word32Cell<F>,
-    not_exists: IsZeroGadget<F>,
+    code_hash: WordCell<F>,
+    not_exists: IsZeroWordGadget<F, WordCell<F>>,
     balance: Word32Cell<F>,
 }
 
@@ -40,31 +41,35 @@ impl<F: Field> ExecutionGadget<F> for BalanceGadget<F> {
     const EXECUTION_STATE: ExecutionState = ExecutionState::BALANCE;
 
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
-        let address = cb.query_word_rlc();
+        let address = cb.query_account_address();
         cb.stack_pop_word(address.to_word());
 
         let tx_id = cb.call_context(None, CallContextFieldTag::TxId);
         let mut reversion_info = cb.reversion_info_read(None);
         let is_warm = cb.query_bool();
-        cb.account_access_list_write(
+        cb.account_access_list_write_word(
             tx_id.expr(),
-            address.expr(),
-            1.expr(),
-            is_warm.expr(),
+            address.to_word(),
+            Word::from_lo_unchecked(1.expr()),
+            Word::from_lo_unchecked(is_warm.expr()),
             Some(&mut reversion_info),
         );
-        let code_hash = cb.query_word32();
+        let code_hash = cb.query_word_unchecked();
         // For non-existing accounts the code_hash must be 0 in the rw_table.
         cb.account_read_word(
-            address.expr(),
+            address.to_word(),
             AccountFieldTag::CodeHash,
             code_hash.to_word(),
         );
-        let not_exists = IsZeroGadget::construct(cb, code_hash.expr());
+        let not_exists = IsZeroWordGadget::construct(cb, &code_hash);
         let exists = not::expr(not_exists.expr());
         let balance = cb.query_word32();
         cb.condition(exists.expr(), |cb| {
-            cb.account_read_word(address.expr(), AccountFieldTag::Balance, balance.to_word());
+            cb.account_read_word(
+                address.to_word(),
+                AccountFieldTag::Balance,
+                balance.to_word(),
+            );
         });
         cb.condition(not_exists.expr(), |cb| {
             cb.require_zero_word("balance is zero when non_exists", balance.to_word());
@@ -92,7 +97,7 @@ impl<F: Field> ExecutionGadget<F> for BalanceGadget<F> {
 
         Self {
             same_context,
-            address_word: address,
+            address,
             reversion_info,
             tx_id,
             is_warm,
@@ -114,8 +119,15 @@ impl<F: Field> ExecutionGadget<F> for BalanceGadget<F> {
         self.same_context.assign_exec_step(region, offset, step)?;
 
         let address = block.get_rws(step, 0).stack_value();
-        self.address_word
-            .assign(region, offset, Some(address.to_le_bytes()))?;
+        self.address.assign(
+            region,
+            offset,
+            Some(
+                address.to_le_bytes()[0..N_BYTES_ACCOUNT_ADDRESS]
+                    .try_into()
+                    .unwrap(),
+            ),
+        )?;
 
         self.tx_id
             .assign(region, offset, Value::known(F::from(tx.id as u64)))?;
@@ -133,16 +145,15 @@ impl<F: Field> ExecutionGadget<F> for BalanceGadget<F> {
 
         let code_hash = block.get_rws(step, 5).account_value_pair().0;
         self.code_hash
-            .assign(region, offset, Some(code_hash.to_le_bytes()))?;
+            .assign_u256(region, offset, code_hash.to_word())?;
         self.not_exists
-            .assign_value(region, offset, region.word_rlc(code_hash))?;
+            .assign_value(region, offset, Value::known(Word::from(code_hash)))?;
         let balance = if code_hash.is_zero() {
             eth_types::Word::zero()
         } else {
             block.get_rws(step, 6).account_value_pair().0
         };
-        self.balance
-            .assign(region, offset, Some(balance.to_le_bytes()))?;
+        self.balance.assign_u256(region, offset, balance)?;
 
         Ok(())
     }

--- a/zkevm-circuits/src/evm_circuit/execution/balance.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/balance.rs
@@ -1,7 +1,6 @@
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
-        param::N_BYTES_ACCOUNT_ADDRESS,
         step::ExecutionState,
         util::{
             common_gadget::SameContextGadget,
@@ -20,7 +19,7 @@ use crate::{
         Expr,
     },
 };
-use eth_types::{evm_types::GasCost, Field, ToLittleEndian, ToWord};
+use eth_types::{evm_types::GasCost, Field, ToWord};
 use halo2_proofs::{circuit::Value, plonk::Error};
 
 #[derive(Clone, Debug)]
@@ -119,15 +118,7 @@ impl<F: Field> ExecutionGadget<F> for BalanceGadget<F> {
         self.same_context.assign_exec_step(region, offset, step)?;
 
         let address = block.get_rws(step, 0).stack_value();
-        self.address.assign(
-            region,
-            offset,
-            Some(
-                address.to_le_bytes()[0..N_BYTES_ACCOUNT_ADDRESS]
-                    .try_into()
-                    .unwrap(),
-            ),
-        )?;
+        self.address.assign_u256(region, offset, address)?;
 
         self.tx_id
             .assign(region, offset, Value::known(F::from(tx.id as u64)))?;

--- a/zkevm-circuits/src/evm_circuit/execution/balance.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/balance.rs
@@ -47,7 +47,7 @@ impl<F: Field> ExecutionGadget<F> for BalanceGadget<F> {
         let tx_id = cb.call_context(None, CallContextFieldTag::TxId);
         let mut reversion_info = cb.reversion_info_read(None);
         let is_warm = cb.query_bool();
-        cb.account_access_list_write(
+        cb.account_access_list_write_unchecked(
             tx_id.expr(),
             address.to_word(),
             1.expr(),

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -272,7 +272,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             cb.account_write_word(
                 call_callee_address.to_word(),
                 AccountFieldTag::Nonce,
-                Word::from_lo_unchecked(1.expr()),
+                Word::one(),
                 Word::zero(),
                 Some(&mut reversion_info),
             );
@@ -394,10 +394,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             |cb| {
                 // Setup first call's context.
                 for (field_tag, value) in [
-                    (
-                        CallContextFieldTag::Depth,
-                        Word::from_lo_unchecked(1.expr()),
-                    ),
+                    (CallContextFieldTag::Depth, Word::one()),
                     (
                         CallContextFieldTag::CallerAddress,
                         tx_caller_address.to_word(),

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -1,7 +1,7 @@
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
-        param::{N_BYTES_ACCOUNT_ADDRESS, N_BYTES_GAS, N_BYTES_U64, N_BYTES_WORD},
+        param::{N_BYTES_ACCOUNT_ADDRESS, N_BYTES_GAS, N_BYTES_U64},
         step::ExecutionState,
         util::{
             and,
@@ -12,34 +12,42 @@ use crate::{
             },
             is_precompiled,
             math_gadget::{
-                ConstantDivisionGadget, ContractCreateGadget, IsEqualGadget, IsZeroGadget,
+                ConstantDivisionGadget, ContractCreateGadget, IsEqualWordGadget, IsZeroWordGadget,
                 MulWordByU64Gadget, RangeCheckGadget,
             },
-            not, or, select, CachedRegion, Cell, StepRws,
+            not, or, select, AccountAddress, CachedRegion, Cell, StepRws, U64Cell,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
     table::{
         AccountFieldTag, BlockContextFieldTag, CallContextFieldTag, TxFieldTag as TxContextFieldTag,
     },
-    util::{word::Word32Cell, Expr},
+    util::{
+        word::{Word, Word32Cell, WordCell, WordExpr},
+        Expr,
+    },
 };
-use eth_types::{evm_types::GasCost, Field, ToLittleEndian, ToScalar};
+use bus_mapping::state_db::CodeDB;
+use eth_types::{evm_types::GasCost, Field, ToWord, U256};
 use ethers_core::utils::{get_contract_address, keccak256};
-use gadgets::util::expr_from_bytes;
-use halo2_proofs::{circuit::Value, plonk::Error};
+use halo2_proofs::{
+    circuit::Value,
+    plonk::{Error, Expression},
+};
+use itertools::Itertools;
 
 #[derive(Clone, Debug)]
 pub(crate) struct BeginTxGadget<F> {
-    tx_id: Cell<F>,
+    // tx_id is query in current scope. The range should be determined here
+    tx_id: U64Cell<F>,
     tx_nonce: Cell<F>,
     tx_gas: Cell<F>,
     tx_gas_price: Word32Cell<F>,
     mul_gas_fee_by_gas: MulWordByU64Gadget<F>,
-    tx_caller_address: Cell<F>,
-    tx_caller_address_is_zero: IsZeroGadget<F>,
-    tx_callee_address: Cell<F>,
-    call_callee_address: Cell<F>,
+    tx_caller_address: WordCell<F>,
+    tx_caller_address_is_zero: IsZeroWordGadget<F, WordCell<F>>,
+    tx_callee_address: WordCell<F>,
+    call_callee_address: AccountAddress<F>,
     tx_is_create: Cell<F>,
     tx_value: Word32Cell<F>,
     tx_call_data_length: Cell<F>,
@@ -48,14 +56,14 @@ pub(crate) struct BeginTxGadget<F> {
     reversion_info: ReversionInfo<F>,
     sufficient_gas_left: RangeCheckGadget<F, N_BYTES_GAS>,
     transfer_with_gas_fee: TransferWithGasFeeGadget<F>,
-    phase2_code_hash: Cell<F>,
-    is_empty_code_hash: IsEqualGadget<F>,
-    caller_nonce_hash_bytes: [Cell<F>; N_BYTES_WORD],
+    code_hash: WordCell<F>,
+    is_empty_code_hash: IsEqualWordGadget<F, Word<Expression<F>>, Word<Expression<F>>>,
+    caller_nonce_hash_bytes: Word32Cell<F>,
     create: ContractCreateGadget<F, false>,
-    callee_not_exists: IsZeroGadget<F>,
+    callee_not_exists: IsZeroWordGadget<F, WordCell<F>>,
     is_caller_callee_equal: Cell<F>,
     // EIP-3651 (Warm COINBASE)
-    coinbase: Cell<F>,
+    coinbase: Word32Cell<F>,
     // Caller, callee and a list addresses are added to the access list before
     // coinbase, and may be duplicate.
     // <https://github.com/ethereum/go-ethereum/blob/604e215d1bb070dff98fb76aa965064c74e3633f/core/state/statedb.go#LL1119C9-L1119C9>
@@ -71,47 +79,49 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
         // Use rw_counter of the step which triggers next call as its call_id.
         let call_id = cb.curr.state.rw_counter.clone();
 
-        let tx_id = cb.query_cell();
-        cb.call_context_lookup(
-            1.expr(),
+        let tx_id = cb.query_u64();
+        cb.call_context_lookup_write_unchecked(
             Some(call_id.expr()),
             CallContextFieldTag::TxId,
-            tx_id.expr(),
+            tx_id.to_word(),
         ); // rwc_delta += 1
         let mut reversion_info = cb.reversion_info_write(None); // rwc_delta += 2
-        cb.call_context_lookup(
-            1.expr(),
+        cb.call_context_lookup_write_unchecked(
             Some(call_id.expr()),
             CallContextFieldTag::IsSuccess,
-            reversion_info.is_persistent(),
+            Word::from_lo_unchecked(reversion_info.is_persistent()),
         ); // rwc_delta += 1
 
-        let [tx_nonce, tx_gas, tx_caller_address, tx_callee_address, tx_is_create, tx_call_data_length, tx_call_data_gas_cost] =
-            [
-                TxContextFieldTag::Nonce,
-                TxContextFieldTag::Gas,
-                TxContextFieldTag::CallerAddress,
-                TxContextFieldTag::CalleeAddress,
-                TxContextFieldTag::IsCreate,
-                TxContextFieldTag::CallDataLength,
-                TxContextFieldTag::CallDataGasCost,
-            ]
-            .map(|field_tag| cb.tx_context(tx_id.expr(), field_tag, None));
-        let tx_caller_address_is_zero = IsZeroGadget::construct(cb, tx_caller_address.expr());
+        let [tx_nonce, tx_gas, tx_is_create, tx_call_data_length, tx_call_data_gas_cost] = [
+            TxContextFieldTag::Nonce,
+            TxContextFieldTag::Gas,
+            TxContextFieldTag::IsCreate,
+            TxContextFieldTag::CallDataLength,
+            TxContextFieldTag::CallDataGasCost,
+        ]
+        .map(|field_tag| cb.tx_context(tx_id.expr(), field_tag, None));
+        let [tx_gas_price, tx_value] = [TxContextFieldTag::GasPrice, TxContextFieldTag::Value]
+            .map(|field_tag| cb.tx_context_as_word32(tx_id.expr(), field_tag, None));
+
+        let [tx_caller_address, tx_callee_address] = [
+            TxContextFieldTag::CallerAddress,
+            TxContextFieldTag::CalleeAddress,
+        ]
+        .map(|field_tag| cb.tx_context_as_word(tx_id.expr(), field_tag, None));
+
+        let tx_caller_address_is_zero = IsZeroWordGadget::construct(cb, &tx_caller_address);
         cb.require_equal(
             "CallerAddress != 0 (not a padding tx)",
             tx_caller_address_is_zero.expr(),
             false.expr(),
         );
-        let [tx_gas_price, tx_value] = [TxContextFieldTag::GasPrice, TxContextFieldTag::Value]
-            .map(|field_tag| cb.tx_context_as_word(tx_id.expr(), field_tag, None));
 
-        let call_callee_address = cb.query_cell();
+        let call_callee_address = cb.query_account_address();
         cb.condition(not::expr(tx_is_create.expr()), |cb| {
-            cb.require_equal(
+            cb.require_equal_word(
                 "Tx to non-zero address",
-                tx_callee_address.expr(),
-                call_callee_address.expr(),
+                tx_callee_address.to_word(),
+                call_callee_address.to_word(),
             );
         });
 
@@ -122,11 +132,11 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
 
         // Increase caller's nonce.
         // (tx caller's nonce always increases even tx ends with error)
-        cb.account_write(
-            tx_caller_address.expr(),
+        cb.account_write_word(
+            tx_caller_address.to_word(),
             AccountFieldTag::Nonce,
-            tx_nonce.expr() + 1.expr(),
-            tx_nonce.expr(),
+            Word::from_lo_unchecked(tx_nonce.expr() + 1.expr()),
+            Word::from_lo_unchecked(tx_nonce.expr()),
             None,
         ); // rwc_delta += 1
 
@@ -134,7 +144,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
         // transaction format)
         // Calculate transaction gas fee
         let mul_gas_fee_by_gas =
-            MulWordByU64Gadget::construct(cb, tx_gas_price.clone().into(), tx_gas.expr());
+            MulWordByU64Gadget::construct(cb, tx_gas_price.clone(), tx_gas.expr());
 
         let tx_call_data_word_length =
             ConstantDivisionGadget::construct(cb, tx_call_data_length.expr() + 31.expr(), 32);
@@ -161,41 +171,45 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
         let sufficient_gas_left = RangeCheckGadget::construct(cb, gas_left.clone());
 
         // Prepare access list of caller and callee
-        cb.account_access_list_write(
+        cb.account_access_list_write_word(
             tx_id.expr(),
-            tx_caller_address.expr(),
-            1.expr(),
-            0.expr(),
+            tx_caller_address.to_word(),
+            Word::from_lo_unchecked(1.expr()),
+            Word::zero(),
             None,
         ); // rwc_delta += 1
         let is_caller_callee_equal = cb.query_bool();
-        cb.account_access_list_write(
+        cb.account_access_list_write_word(
             tx_id.expr(),
-            tx_callee_address.expr(),
-            1.expr(),
+            tx_callee_address.to_word(),
+            Word::from_lo_unchecked(1.expr()),
             // No extra constraint being used here.
             // Correctness will be enforced in build_tx_access_list_account_constraints
-            is_caller_callee_equal.expr(),
+            Word::from_lo_unchecked(is_caller_callee_equal.expr()),
             None,
         ); // rwc_delta += 1
 
         // Query coinbase address.
-        let coinbase = cb.query_cell();
+        let coinbase = cb.query_word32();
         let is_coinbase_warm = cb.query_bool();
-        cb.block_lookup(BlockContextFieldTag::Coinbase.expr(), None, coinbase.expr());
-        cb.account_access_list_write(
+        cb.block_lookup_word(
+            BlockContextFieldTag::Coinbase.expr(),
+            None,
+            coinbase.to_word(),
+        );
+        cb.account_access_list_write_word(
             tx_id.expr(),
-            coinbase.expr(),
-            1.expr(),
-            is_coinbase_warm.expr(),
+            coinbase.to_word(),
+            Word::from_lo_unchecked(1.expr()),
+            Word::from_lo_unchecked(is_coinbase_warm.expr()),
             None,
         ); // rwc_delta += 1
 
         // Read code_hash of callee
-        let phase2_code_hash = cb.query_cell_phase2();
+        let code_hash = cb.query_word_unchecked();
         let is_empty_code_hash =
-            IsEqualGadget::construct(cb, phase2_code_hash.expr(), cb.empty_code_hash_rlc());
-        let callee_not_exists = IsZeroGadget::construct(cb, phase2_code_hash.expr());
+            IsEqualWordGadget::construct(cb, &code_hash.to_word(), &cb.empty_code_hash_word());
+        let callee_not_exists = IsZeroWordGadget::construct(cb, &code_hash);
         // no_callee_code is true when the account exists and has empty
         // code hash, or when the account doesn't exist (which we encode with
         // code_hash = 0).
@@ -203,37 +217,44 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
 
         // TODO: And not precompile
         cb.condition(not::expr(tx_is_create.expr()), |cb| {
-            cb.account_read(
-                tx_callee_address.expr(),
+            cb.account_read_word(
+                tx_callee_address.to_word(),
                 AccountFieldTag::CodeHash,
-                phase2_code_hash.expr(),
+                code_hash.to_word(),
             ); // rwc_delta += 1
         });
 
         // Transfer value from caller to callee, creating account if necessary.
-        let transfer_with_gas_fee = TransferWithGasFeeGadget::construct_new(
+        let transfer_with_gas_fee = TransferWithGasFeeGadget::construct(
             cb,
-            tx_caller_address.expr(),
-            tx_callee_address.expr(),
+            tx_caller_address.to_word(),
+            tx_callee_address.to_word(),
             not::expr(callee_not_exists.expr()),
             or::expr([tx_is_create.expr(), callee_not_exists.expr()]),
-            tx_value.clone().into(),
+            tx_value.clone(),
             mul_gas_fee_by_gas.product().clone(),
             &mut reversion_info,
         );
 
-        let caller_nonce_hash_bytes = array_init::array_init(|_| cb.query_byte());
+        let caller_nonce_hash_bytes = cb.query_word32();
         let create = ContractCreateGadget::construct(cb);
-        cb.require_equal(
+        cb.require_equal_word(
             "tx caller address equivalence",
-            tx_caller_address.expr(),
-            create.caller_address(),
+            tx_caller_address.to_word(),
+            create.caller_address_word(),
         );
         cb.condition(tx_is_create.expr(), |cb| {
-            cb.require_equal(
+            cb.require_equal_word(
                 "call callee address equivalence",
-                call_callee_address.expr(),
-                expr_from_bytes(&caller_nonce_hash_bytes[0..N_BYTES_ACCOUNT_ADDRESS]),
+                call_callee_address.to_word(),
+                AccountAddress::<F>::new(
+                    caller_nonce_hash_bytes.limbs[0..N_BYTES_ACCOUNT_ADDRESS]
+                        .to_vec()
+                        .try_into()
+                        .unwrap(),
+                    256.expr(),
+                )
+                .to_word(),
             );
         });
         cb.require_equal(
@@ -244,48 +265,53 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
 
         // 1. Handle contract creation transaction.
         cb.condition(tx_is_create.expr(), |cb| {
-            let output_rlc = cb.word_rlc::<N_BYTES_WORD>(
-                caller_nonce_hash_bytes
-                    .iter()
-                    .map(Expr::expr)
-                    .collect::<Vec<_>>()
-                    .try_into()
-                    .unwrap(),
+            cb.keccak_table_lookup_word(
+                create.input_rlc(cb),
+                create.input_length(),
+                caller_nonce_hash_bytes.to_word(),
             );
-            cb.keccak_table_lookup(create.input_rlc(cb), create.input_length(), output_rlc);
 
-            cb.account_write(
-                call_callee_address.expr(),
+            cb.account_write_word(
+                call_callee_address.to_word(),
                 AccountFieldTag::Nonce,
-                1.expr(),
-                0.expr(),
+                Word::from_lo_unchecked(1.expr()),
+                Word::zero(),
                 Some(&mut reversion_info),
             );
             for (field_tag, value) in [
-                (CallContextFieldTag::Depth, 1.expr()),
-                (CallContextFieldTag::CallerAddress, tx_caller_address.expr()),
+                (CallContextFieldTag::Depth, Word::one()),
+                (
+                    CallContextFieldTag::CallerAddress,
+                    tx_caller_address.to_word(),
+                ),
                 (
                     CallContextFieldTag::CalleeAddress,
-                    call_callee_address.expr(),
+                    call_callee_address.to_word(),
                 ),
-                (CallContextFieldTag::CallDataOffset, 0.expr()),
+                (CallContextFieldTag::CallDataOffset, Word::zero()),
                 (
                     CallContextFieldTag::CallDataLength,
-                    tx_call_data_length.expr(),
+                    Word::from_lo_unchecked(tx_call_data_length.expr()),
                 ),
-                (CallContextFieldTag::Value, tx_value.expr()),
-                (CallContextFieldTag::IsStatic, 0.expr()),
-                (CallContextFieldTag::LastCalleeId, 0.expr()),
-                (CallContextFieldTag::LastCalleeReturnDataOffset, 0.expr()),
-                (CallContextFieldTag::LastCalleeReturnDataLength, 0.expr()),
-                (CallContextFieldTag::IsRoot, 1.expr()),
-                (CallContextFieldTag::IsCreate, 1.expr()),
+                (CallContextFieldTag::Value, tx_value.to_word()),
+                (CallContextFieldTag::IsStatic, Word::zero()),
+                (CallContextFieldTag::LastCalleeId, Word::zero()),
+                (
+                    CallContextFieldTag::LastCalleeReturnDataOffset,
+                    Word::zero(),
+                ),
+                (
+                    CallContextFieldTag::LastCalleeReturnDataLength,
+                    Word::zero(),
+                ),
+                (CallContextFieldTag::IsRoot, Word::one()),
+                (CallContextFieldTag::IsCreate, Word::one()),
                 (
                     CallContextFieldTag::CodeHash,
-                    cb.curr.state.code_hash.expr(),
+                    cb.curr.state.code_hash.to_word(),
                 ),
             ] {
-                cb.call_context_lookup(true.expr(), Some(call_id.expr()), field_tag, value);
+                cb.call_context_lookup_write_unchecked(Some(call_id.expr()), field_tag, value);
             }
 
             cb.require_step_state_transition(StepStateTransition {
@@ -317,7 +343,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                 call_id: To(call_id.expr()),
                 is_root: To(true.expr()),
                 is_create: To(tx_is_create.expr()),
-                code_hash: To(cb.curr.state.code_hash.expr()),
+                code_hash: To(cb.curr.state.code_hash.to_word()),
                 gas_left: To(gas_left.clone()),
                 // There are a + 1 reversible writes:
                 //  - a TransferWithGasFeeGadget
@@ -370,24 +396,42 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             |cb| {
                 // Setup first call's context.
                 for (field_tag, value) in [
-                    (CallContextFieldTag::Depth, 1.expr()),
-                    (CallContextFieldTag::CallerAddress, tx_caller_address.expr()),
-                    (CallContextFieldTag::CalleeAddress, tx_callee_address.expr()),
-                    (CallContextFieldTag::CallDataOffset, 0.expr()),
+                    (
+                        CallContextFieldTag::Depth,
+                        Word::from_lo_unchecked(1.expr()),
+                    ),
+                    (
+                        CallContextFieldTag::CallerAddress,
+                        tx_caller_address.to_word(),
+                    ),
+                    (
+                        CallContextFieldTag::CalleeAddress,
+                        tx_callee_address.to_word(),
+                    ),
+                    (CallContextFieldTag::CallDataOffset, Word::zero()),
                     (
                         CallContextFieldTag::CallDataLength,
-                        tx_call_data_length.expr(),
+                        Word::from_lo_unchecked(tx_call_data_length.expr()),
                     ),
-                    (CallContextFieldTag::Value, tx_value.expr()),
-                    (CallContextFieldTag::IsStatic, 0.expr()),
-                    (CallContextFieldTag::LastCalleeId, 0.expr()),
-                    (CallContextFieldTag::LastCalleeReturnDataOffset, 0.expr()),
-                    (CallContextFieldTag::LastCalleeReturnDataLength, 0.expr()),
-                    (CallContextFieldTag::IsRoot, 1.expr()),
-                    (CallContextFieldTag::IsCreate, tx_is_create.expr()),
-                    (CallContextFieldTag::CodeHash, phase2_code_hash.expr()),
+                    (CallContextFieldTag::Value, tx_value.to_word()),
+                    (CallContextFieldTag::IsStatic, Word::zero()),
+                    (CallContextFieldTag::LastCalleeId, Word::zero()),
+                    (
+                        CallContextFieldTag::LastCalleeReturnDataOffset,
+                        Word::zero(),
+                    ),
+                    (
+                        CallContextFieldTag::LastCalleeReturnDataLength,
+                        Word::zero(),
+                    ),
+                    (CallContextFieldTag::IsRoot, Word::one()),
+                    (
+                        CallContextFieldTag::IsCreate,
+                        Word::from_lo_unchecked(tx_is_create.expr()),
+                    ),
+                    (CallContextFieldTag::CodeHash, code_hash.to_word()),
                 ] {
-                    cb.call_context_lookup(true.expr(), Some(call_id.expr()), field_tag, value);
+                    cb.call_context_lookup_write_unchecked(Some(call_id.expr()), field_tag, value);
                 }
 
                 cb.require_step_state_transition(StepStateTransition {
@@ -419,7 +463,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                     call_id: To(call_id.expr()),
                     is_root: To(true.expr()),
                     is_create: To(tx_is_create.expr()),
-                    code_hash: To(phase2_code_hash.expr()),
+                    code_hash: To(code_hash.to_word()),
                     gas_left: To(gas_left),
                     reversible_write_counter: To(transfer_with_gas_fee.reversible_w_delta()),
                     log_id: To(0.expr()),
@@ -432,21 +476,21 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             tx_id,
             tx_nonce,
             tx_gas,
-            tx_gas_price: tx_gas_price.into(),
+            tx_gas_price,
             mul_gas_fee_by_gas,
             tx_caller_address,
             tx_caller_address_is_zero,
             tx_callee_address,
             call_callee_address,
             tx_is_create,
-            tx_value: tx_value.into(),
+            tx_value,
             tx_call_data_length,
             tx_call_data_gas_cost,
             tx_call_data_word_length,
             reversion_info,
             sufficient_gas_left,
             transfer_with_gas_fee,
-            phase2_code_hash,
+            code_hash,
             is_empty_code_hash,
             caller_nonce_hash_bytes,
             create,
@@ -492,46 +536,44 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
         };
 
         self.tx_id
-            .assign(region, offset, Value::known(F::from(tx.id as u64)))?;
+            .assign(region, offset, Some(tx.id.to_le_bytes()))?;
         self.tx_nonce
             .assign(region, offset, Value::known(F::from(tx.nonce)))?;
         self.tx_gas
             .assign(region, offset, Value::known(F::from(tx.gas)))?;
         self.tx_gas_price
-            .assign(region, offset, Some(tx.gas_price.to_le_bytes()))?;
+            .assign_u256(region, offset, tx.gas_price)?;
         self.mul_gas_fee_by_gas
             .assign(region, offset, tx.gas_price, tx.gas, gas_fee)?;
-        let caller_address = tx
-            .caller_address
-            .to_scalar()
-            .expect("unexpected Address -> Scalar conversion failure");
-        let callee_address = tx
-            .callee_address
-            .to_scalar()
-            .expect("unexpected Address -> Scalar conversion failure");
         self.tx_caller_address
-            .assign(region, offset, Value::known(caller_address))?;
-        self.tx_caller_address_is_zero
-            .assign(region, offset, caller_address)?;
+            .assign_h160(region, offset, tx.caller_address)?;
+        self.tx_caller_address_is_zero.assign_u256(
+            region,
+            offset,
+            U256::from_big_endian(&tx.caller_address.to_fixed_bytes()),
+        )?;
         self.tx_callee_address
-            .assign(region, offset, Value::known(callee_address))?;
+            .assign_h160(region, offset, tx.callee_address)?;
         self.call_callee_address.assign(
             region,
             offset,
-            Value::known(
-                if tx.is_create {
-                    get_contract_address(tx.caller_address, tx.nonce)
-                } else {
-                    tx.callee_address
-                }
-                .to_scalar()
-                .expect("unexpected Address -> Scalar conversion failure"),
-            ),
+            if tx.is_create {
+                get_contract_address(tx.caller_address, tx.nonce)
+            } else {
+                tx.callee_address
+            }
+            .to_fixed_bytes()
+            .iter()
+            .rev()
+            .copied()
+            .collect_vec()
+            .try_into()
+            .ok(),
         )?;
         self.is_caller_callee_equal.assign(
             region,
             offset,
-            Value::known(F::from((caller_address == callee_address) as u64)),
+            Value::known(F::from((tx.caller_address == tx.callee_address) as u64)),
         )?;
         self.tx_is_create
             .assign(region, offset, Value::known(F::from(tx.is_create as u64)))?;
@@ -564,16 +606,17 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             tx.value,
             gas_fee,
         )?;
-        self.phase2_code_hash
-            .assign(region, offset, region.word_rlc(callee_code_hash))?;
-        self.is_empty_code_hash.assign_value(
+        // TODO handle endian issue
+        self.code_hash
+            .assign_u256(region, offset, callee_code_hash)?; // big endian assignment
+        self.is_empty_code_hash.assign_u256(
             region,
             offset,
-            region.word_rlc(callee_code_hash),
-            region.empty_code_hash_rlc(),
+            callee_code_hash, // here is big endian
+            CodeDB::empty_code_hash().to_word(),
         )?;
         self.callee_not_exists
-            .assign_value(region, offset, region.word_rlc(callee_code_hash))?;
+            .assign_u256(region, offset, callee_code_hash)?;
 
         let untrimmed_contract_addr = {
             let mut stream = ethers_core::utils::rlp::RlpStream::new();
@@ -581,16 +624,13 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             stream.append(&tx.caller_address);
             stream.append(&eth_types::U256::from(tx.nonce));
             let rlp_encoding = stream.out().to_vec();
-            keccak256(&rlp_encoding)
+            keccak256(rlp_encoding)
         };
-        for (c, v) in self
-            .caller_nonce_hash_bytes
-            .iter()
-            .rev()
-            .zip(untrimmed_contract_addr.iter())
-        {
-            c.assign(region, offset, Value::known(F::from(*v as u64)))?;
-        }
+        self.caller_nonce_hash_bytes.assign_u256(
+            region,
+            offset,
+            U256::from_big_endian(&untrimmed_contract_addr),
+        )?;
         self.create.assign(
             region,
             offset,
@@ -600,17 +640,8 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             None,
         )?;
 
-        self.coinbase.assign(
-            region,
-            offset,
-            Value::known(
-                block
-                    .context
-                    .coinbase
-                    .to_scalar()
-                    .expect("unexpected Address -> Scalar conversion failure"),
-            ),
-        )?;
+        self.coinbase
+            .assign_h160(region, offset, block.context.coinbase)?;
         self.is_coinbase_warm.assign(
             region,
             offset,

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -63,7 +63,7 @@ pub(crate) struct BeginTxGadget<F> {
     callee_not_exists: IsZeroWordGadget<F, WordCell<F>>,
     is_caller_callee_equal: Cell<F>,
     // EIP-3651 (Warm COINBASE)
-    coinbase: Word32Cell<F>,
+    coinbase: WordCell<F>,
     // Caller, callee and a list addresses are added to the access list before
     // coinbase, and may be duplicate.
     // <https://github.com/ethereum/go-ethereum/blob/604e215d1bb070dff98fb76aa965064c74e3633f/core/state/statedb.go#LL1119C9-L1119C9>
@@ -190,7 +190,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
         ); // rwc_delta += 1
 
         // Query coinbase address.
-        let coinbase = cb.query_word32();
+        let coinbase = cb.query_word_unchecked();
         let is_coinbase_warm = cb.query_bool();
         cb.block_lookup_word(
             BlockContextFieldTag::Coinbase.expr(),
@@ -606,13 +606,12 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             tx.value,
             gas_fee,
         )?;
-        // TODO handle endian issue
         self.code_hash
-            .assign_u256(region, offset, callee_code_hash)?; // big endian assignment
+            .assign_u256(region, offset, callee_code_hash)?;
         self.is_empty_code_hash.assign_u256(
             region,
             offset,
-            callee_code_hash, // here is big endian
+            callee_code_hash,
             CodeDB::empty_code_hash().to_word(),
         )?;
         self.callee_not_exists

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -171,21 +171,21 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
         let sufficient_gas_left = RangeCheckGadget::construct(cb, gas_left.clone());
 
         // Prepare access list of caller and callee
-        cb.account_access_list_write_word(
+        cb.account_access_list_write(
             tx_id.expr(),
             tx_caller_address.to_word(),
-            Word::from_lo_unchecked(1.expr()),
-            Word::zero(),
+            1.expr(),
+            0.expr(),
             None,
         ); // rwc_delta += 1
         let is_caller_callee_equal = cb.query_bool();
-        cb.account_access_list_write_word(
+        cb.account_access_list_write(
             tx_id.expr(),
             tx_callee_address.to_word(),
-            Word::from_lo_unchecked(1.expr()),
+            1.expr(),
             // No extra constraint being used here.
             // Correctness will be enforced in build_tx_access_list_account_constraints
-            Word::from_lo_unchecked(is_caller_callee_equal.expr()),
+            is_caller_callee_equal.expr(),
             None,
         ); // rwc_delta += 1
 
@@ -197,11 +197,11 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             None,
             coinbase.to_word(),
         );
-        cb.account_access_list_write_word(
+        cb.account_access_list_write(
             tx_id.expr(),
             coinbase.to_word(),
-            Word::from_lo_unchecked(1.expr()),
-            Word::from_lo_unchecked(is_coinbase_warm.expr()),
+            1.expr(),
+            is_coinbase_warm.expr(),
             None,
         ); // rwc_delta += 1
 

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -80,13 +80,13 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
         let call_id = cb.curr.state.rw_counter.clone();
 
         let tx_id = cb.query_u64();
-        cb.call_context_lookup_write_unchecked(
+        cb.call_context_lookup_write(
             Some(call_id.expr()),
             CallContextFieldTag::TxId,
             tx_id.to_word(),
         ); // rwc_delta += 1
-        let mut reversion_info = cb.reversion_info_write(None); // rwc_delta += 2
-        cb.call_context_lookup_write_unchecked(
+        let mut reversion_info = cb.reversion_info_write_unchecked(None); // rwc_delta += 2
+        cb.call_context_lookup_write(
             Some(call_id.expr()),
             CallContextFieldTag::IsSuccess,
             Word::from_lo_unchecked(reversion_info.is_persistent()),
@@ -171,7 +171,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
         let sufficient_gas_left = RangeCheckGadget::construct(cb, gas_left.clone());
 
         // Prepare access list of caller and callee
-        cb.account_access_list_write(
+        cb.account_access_list_write_unchecked(
             tx_id.expr(),
             tx_caller_address.to_word(),
             1.expr(),
@@ -179,7 +179,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             None,
         ); // rwc_delta += 1
         let is_caller_callee_equal = cb.query_bool();
-        cb.account_access_list_write(
+        cb.account_access_list_write_unchecked(
             tx_id.expr(),
             tx_callee_address.to_word(),
             1.expr(),
@@ -197,7 +197,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             None,
             coinbase.to_word(),
         );
-        cb.account_access_list_write(
+        cb.account_access_list_write_unchecked(
             tx_id.expr(),
             coinbase.to_word(),
             1.expr(),
@@ -311,7 +311,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                     cb.curr.state.code_hash.to_word(),
                 ),
             ] {
-                cb.call_context_lookup_write_unchecked(Some(call_id.expr()), field_tag, value);
+                cb.call_context_lookup_write(Some(call_id.expr()), field_tag, value);
             }
 
             cb.require_step_state_transition(StepStateTransition {
@@ -431,7 +431,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                     ),
                     (CallContextFieldTag::CodeHash, code_hash.to_word()),
                 ] {
-                    cb.call_context_lookup_write_unchecked(Some(call_id.expr()), field_tag, value);
+                    cb.call_context_lookup_write(Some(call_id.expr()), field_tag, value);
                 }
 
                 cb.require_step_state_transition(StepStateTransition {

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -34,7 +34,6 @@ use halo2_proofs::{
     circuit::Value,
     plonk::{Error, Expression},
 };
-use itertools::Itertools;
 
 #[derive(Clone, Debug)]
 pub(crate) struct BeginTxGadget<F> {
@@ -252,7 +251,6 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                         .to_vec()
                         .try_into()
                         .unwrap(),
-                    256.expr(),
                 )
                 .to_word(),
             );
@@ -554,21 +552,14 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
         )?;
         self.tx_callee_address
             .assign_h160(region, offset, tx.callee_address)?;
-        self.call_callee_address.assign(
+        self.call_callee_address.assign_h160(
             region,
             offset,
             if tx.is_create {
                 get_contract_address(tx.caller_address, tx.nonce)
             } else {
                 tx.callee_address
-            }
-            .to_fixed_bytes()
-            .iter()
-            .rev()
-            .copied()
-            .collect_vec()
-            .try_into()
-            .ok(),
+            },
         )?;
         self.is_caller_callee_equal.assign(
             region,

--- a/zkevm-circuits/src/evm_circuit/execution/bitwise.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/bitwise.rs
@@ -6,21 +6,24 @@ use crate::{
         util::{
             common_gadget::SameContextGadget,
             constraint_builder::{EVMConstraintBuilder, StepStateTransition, Transition::Delta},
-            CachedRegion, Word,
+            CachedRegion,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
-    util::Expr,
+    util::{
+        word::{Word32Cell, WordExpr},
+        Expr,
+    },
 };
-use eth_types::{evm_types::OpcodeId, Field, ToLittleEndian};
+use eth_types::{evm_types::OpcodeId, Field};
 use halo2_proofs::plonk::Error;
 
 #[derive(Clone, Debug)]
 pub(crate) struct BitwiseGadget<F> {
     same_context: SameContextGadget<F>,
-    a: Word<F>,
-    b: Word<F>,
-    c: Word<F>,
+    a: Word32Cell<F>,
+    b: Word32Cell<F>,
+    c: Word32Cell<F>,
 }
 
 impl<F: Field> ExecutionGadget<F> for BitwiseGadget<F> {
@@ -31,13 +34,13 @@ impl<F: Field> ExecutionGadget<F> for BitwiseGadget<F> {
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
         let opcode = cb.query_cell();
 
-        let a = cb.query_word_rlc();
-        let b = cb.query_word_rlc();
-        let c = cb.query_word_rlc();
+        let a = cb.query_word32();
+        let b = cb.query_word32();
+        let c = cb.query_word32();
 
-        cb.stack_pop(a.expr());
-        cb.stack_pop(b.expr());
-        cb.stack_push(c.expr());
+        cb.stack_pop_word(a.to_word());
+        cb.stack_pop_word(b.to_word());
+        cb.stack_push_word(c.to_word());
 
         // Because opcode AND, OR, and XOR are continuous, so we can make the
         // FixedTableTag of them also continuous, and use the opcode delta from
@@ -50,9 +53,9 @@ impl<F: Field> ExecutionGadget<F> for BitwiseGadget<F> {
                 Lookup::Fixed {
                     tag: tag.clone(),
                     values: [
-                        a.cells[idx].expr(),
-                        b.cells[idx].expr(),
-                        c.cells[idx].expr(),
+                        a.limbs[idx].expr(),
+                        b.limbs[idx].expr(),
+                        c.limbs[idx].expr(),
                     ],
                 },
             );
@@ -88,9 +91,9 @@ impl<F: Field> ExecutionGadget<F> for BitwiseGadget<F> {
         self.same_context.assign_exec_step(region, offset, step)?;
 
         let [a, b, c] = [0, 1, 2].map(|index| block.get_rws(step, index).stack_value());
-        self.a.assign(region, offset, Some(a.to_le_bytes()))?;
-        self.b.assign(region, offset, Some(b.to_le_bytes()))?;
-        self.c.assign(region, offset, Some(c.to_le_bytes()))?;
+        self.a.assign_u256(region, offset, a)?;
+        self.b.assign_u256(region, offset, b)?;
+        self.c.assign_u256(region, offset, c)?;
 
         Ok(())
     }

--- a/zkevm-circuits/src/evm_circuit/execution/block_ctx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/block_ctx.rs
@@ -6,29 +6,32 @@ use crate::{
         util::{
             common_gadget::SameContextGadget,
             constraint_builder::{EVMConstraintBuilder, StepStateTransition, Transition::Delta},
-            from_bytes, CachedRegion, RandomLinearCombination,
+            CachedRegion,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
     table::BlockContextFieldTag,
-    util::Expr,
+    util::{
+        word::{WordCell, WordExpr},
+        Expr,
+    },
 };
 use bus_mapping::evm::OpcodeId;
-use eth_types::{Field, ToLittleEndian};
+use eth_types::Field;
 use halo2_proofs::plonk::Error;
 
 #[derive(Clone, Debug)]
 pub(crate) struct BlockCtxGadget<F, const N_BYTES: usize> {
     same_context: SameContextGadget<F>,
-    value: RandomLinearCombination<F, N_BYTES>,
+    value: WordCell<F>,
 }
 
 impl<F: Field, const N_BYTES: usize> BlockCtxGadget<F, N_BYTES> {
     fn construct(cb: &mut EVMConstraintBuilder<F>) -> Self {
-        let value = cb.query_word_rlc();
+        let value = cb.query_word_unchecked(); // block lookup below
 
         // Push the const generic parameter N_BYTES value to the stack
-        cb.stack_push(value.expr());
+        cb.stack_push_word(value.to_word());
 
         // Get op's FieldTag
         let opcode = cb.query_cell();
@@ -37,12 +40,7 @@ impl<F: Field, const N_BYTES: usize> BlockCtxGadget<F, N_BYTES> {
 
         // Lookup block table with block context ops
         // TIMESTAMP/NUMBER/GASLIMIT, COINBASE and DIFFICULTY/BASEFEE
-        let value_expr = if N_BYTES == N_BYTES_WORD {
-            value.expr()
-        } else {
-            from_bytes::expr(&value.cells)
-        };
-        cb.block_lookup(blockctx_tag, None, value_expr);
+        cb.block_lookup_word(blockctx_tag, None, value.to_word());
 
         // State transition
         let step_state_transition = StepStateTransition {
@@ -92,11 +90,9 @@ impl<F: Field> ExecutionGadget<F> for BlockCtxU64Gadget<F> {
 
         let value = block.get_rws(step, 0).stack_value();
 
-        self.value_u64.value.assign(
-            region,
-            offset,
-            Some(u64::try_from(value).unwrap().to_le_bytes()),
-        )?;
+        self.value_u64
+            .value
+            .assign_u64(region, offset, u64::try_from(value).unwrap())?;
 
         Ok(())
     }
@@ -133,15 +129,7 @@ impl<F: Field> ExecutionGadget<F> for BlockCtxU160Gadget<F> {
 
         let value = block.get_rws(step, 0).stack_value();
 
-        self.value_u160.value.assign(
-            region,
-            offset,
-            Some(
-                value.to_le_bytes()[..N_BYTES_ACCOUNT_ADDRESS]
-                    .try_into()
-                    .unwrap(),
-            ),
-        )?;
+        self.value_u160.value.assign_u256(region, offset, value)?;
 
         Ok(())
     }
@@ -178,9 +166,7 @@ impl<F: Field> ExecutionGadget<F> for BlockCtxU256Gadget<F> {
 
         let value = block.get_rws(step, 0).stack_value();
 
-        self.value_u256
-            .value
-            .assign(region, offset, Some(value.to_le_bytes()))?;
+        self.value_u256.value.assign_u256(region, offset, value)?;
 
         Ok(())
     }

--- a/zkevm-circuits/src/evm_circuit/execution/calldatacopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldatacopy.rs
@@ -15,7 +15,10 @@ use crate::{
         witness::{Block, Call, ExecStep, Transaction},
     },
     table::CallContextFieldTag,
-    util::Expr,
+    util::{
+        word::{Word, WordExpr},
+        Expr,
+    },
 };
 use bus_mapping::{circuit_input_builder::CopyDataType, evm::OpcodeId};
 use eth_types::{evm_types::GasCost, Field, ToScalar};
@@ -48,24 +51,27 @@ impl<F: Field> ExecutionGadget<F> for CallDataCopyGadget<F> {
         let call_data_length = cb.query_cell();
         let call_data_offset = cb.query_cell();
 
-        let length = cb.query_word_rlc();
-        let memory_offset = cb.query_cell_phase2();
+        let length = cb.query_memory_address();
+        let memory_offset = cb.query_word_unchecked();
         let data_offset = WordByteCapGadget::construct(cb, call_data_length.expr());
 
         // Pop memory_offset, data_offset, length from stack
-        cb.stack_pop(memory_offset.expr());
-        cb.stack_pop(data_offset.original_word());
-        cb.stack_pop(length.expr());
+        cb.stack_pop_word(memory_offset.to_word());
+        cb.stack_pop_word(data_offset.original_word_new().to_word());
+        cb.stack_pop_word(length.to_word());
 
         // Lookup the calldata_length and caller_address in Tx context table or
         // Call context table
         cb.condition(cb.curr.state.is_root.expr(), |cb| {
-            cb.call_context_lookup(false.expr(), None, CallContextFieldTag::TxId, src_id.expr());
-            cb.call_context_lookup(
-                false.expr(),
+            cb.call_context_lookup_read(
+                None,
+                CallContextFieldTag::TxId,
+                Word::from_lo_unchecked(src_id.expr()),
+            );
+            cb.call_context_lookup_read(
                 None,
                 CallContextFieldTag::CallDataLength,
-                call_data_length.expr(),
+                Word::from_lo_unchecked(call_data_length.expr()),
             );
             cb.require_zero(
                 "call_data_offset == 0 in the root call",
@@ -73,23 +79,20 @@ impl<F: Field> ExecutionGadget<F> for CallDataCopyGadget<F> {
             );
         });
         cb.condition(1.expr() - cb.curr.state.is_root.expr(), |cb| {
-            cb.call_context_lookup(
-                false.expr(),
+            cb.call_context_lookup_read(
                 None,
                 CallContextFieldTag::CallerId,
-                src_id.expr(),
+                Word::from_lo_unchecked(src_id.expr()),
             );
-            cb.call_context_lookup(
-                false.expr(),
+            cb.call_context_lookup_read(
                 None,
                 CallContextFieldTag::CallDataLength,
-                call_data_length.expr(),
+                Word::from_lo_unchecked(call_data_length.expr()),
             );
-            cb.call_context_lookup(
-                false.expr(),
+            cb.call_context_lookup_read(
                 None,
                 CallContextFieldTag::CallDataOffset,
-                call_data_offset.expr(),
+                Word::from_lo_unchecked(call_data_offset.expr()),
             );
         });
 
@@ -121,9 +124,9 @@ impl<F: Field> ExecutionGadget<F> for CallDataCopyGadget<F> {
             let src_addr_end = call_data_offset.expr() + call_data_length.expr();
 
             cb.copy_table_lookup(
-                src_id.expr(),
+                Word::from_lo_unchecked(src_id.expr()),
                 src_tag,
-                cb.curr.state.call_id.expr(),
+                Word::from_lo_unchecked(cb.curr.state.call_id.expr()),
                 CopyDataType::Memory.expr(),
                 src_addr,
                 src_addr_end,

--- a/zkevm-circuits/src/evm_circuit/execution/calldataload.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldataload.rs
@@ -22,7 +22,10 @@ use crate::{
         witness::{Block, Call, ExecStep, Transaction},
     },
     table::{CallContextFieldTag, TxContextFieldTag},
-    util::Expr,
+    util::{
+        word::{Word, Word32, WordExpr},
+        Expr,
+    },
 };
 
 use super::ExecutionGadget;
@@ -65,22 +68,20 @@ impl<F: Field> ExecutionGadget<F> for CallDataLoadGadget<F> {
         let call_data_offset = cb.query_cell();
 
         let data_offset = WordByteCapGadget::construct(cb, call_data_length.expr());
-        cb.stack_pop(data_offset.original_word());
+        cb.stack_pop_word(data_offset.original_word_new().to_word());
 
         cb.condition(
             and::expr([data_offset.not_overflow(), cb.curr.state.is_root.expr()]),
             |cb| {
-                cb.call_context_lookup(
-                    false.expr(),
+                cb.call_context_lookup_read(
                     None,
                     CallContextFieldTag::TxId,
-                    src_id.expr(),
+                    Word::from_lo_unchecked(src_id.expr()),
                 );
-                cb.call_context_lookup(
-                    false.expr(),
+                cb.call_context_lookup_read(
                     None,
                     CallContextFieldTag::CallDataLength,
-                    call_data_length.expr(),
+                    Word::from_lo_unchecked(call_data_length.expr()),
                 );
                 cb.require_equal(
                     "if is_root then call_data_offset == 0",
@@ -96,23 +97,20 @@ impl<F: Field> ExecutionGadget<F> for CallDataLoadGadget<F> {
                 not::expr(cb.curr.state.is_root.expr()),
             ]),
             |cb| {
-                cb.call_context_lookup(
-                    false.expr(),
+                cb.call_context_lookup_read(
                     None,
                     CallContextFieldTag::CallerId,
-                    src_id.expr(),
+                    Word::from_lo_unchecked(src_id.expr()),
                 );
-                cb.call_context_lookup(
-                    false.expr(),
+                cb.call_context_lookup_read(
                     None,
                     CallContextFieldTag::CallDataLength,
-                    call_data_length.expr(),
+                    Word::from_lo_unchecked(call_data_length.expr()),
                 );
-                cb.call_context_lookup(
-                    false.expr(),
+                cb.call_context_lookup_read(
                     None,
                     CallContextFieldTag::CallDataOffset,
-                    call_data_offset.expr(),
+                    Word::from_lo_unchecked(call_data_offset.expr()),
                 );
             },
         );
@@ -139,11 +137,11 @@ impl<F: Field> ExecutionGadget<F> for CallDataLoadGadget<F> {
                         cb.curr.state.is_root.expr(),
                     ]),
                     |cb| {
-                        cb.tx_context_lookup(
+                        cb.tx_context_lookup_word(
                             src_id.expr(),
                             TxContextFieldTag::CallData,
                             Some(src_addr.expr() + idx.expr()),
-                            buffer_reader.byte(idx),
+                            Word::from_lo_unchecked(buffer_reader.byte(idx)),
                         );
                     },
                 );
@@ -174,13 +172,13 @@ impl<F: Field> ExecutionGadget<F> for CallDataLoadGadget<F> {
         // Add a lookup constraint for the 32-bytes that should have been pushed
         // to the stack.
         let calldata_word: [Expression<F>; N_BYTES_WORD] = calldata_word.try_into().unwrap();
-        let calldata_word = cb.word_rlc(calldata_word);
-        cb.require_zero(
+        let calldata_word = Word32::new(calldata_word);
+        cb.require_zero_word(
             "Stack push result must be 0 if stack pop offset is Uint64 overflow",
-            data_offset.overflow() * calldata_word.expr(),
+            calldata_word.to_word().mul_selector(data_offset.overflow()),
         );
 
-        cb.stack_push(calldata_word);
+        cb.stack_push_word(calldata_word.to_word());
 
         let step_state_transition = StepStateTransition {
             rw_counter: Delta(cb.rw_counter_offset()),

--- a/zkevm-circuits/src/evm_circuit/execution/calldatasize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldatasize.rs
@@ -1,7 +1,6 @@
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
-        param::N_BYTES_CALLDATASIZE,
         step::ExecutionState,
         util::{
             common_gadget::SameContextGadget,
@@ -17,8 +16,8 @@ use crate::{
     },
 };
 use bus_mapping::evm::OpcodeId;
-use eth_types::{Field, ToLittleEndian};
-use halo2_proofs::{circuit::Value, plonk::Error};
+use eth_types::Field;
+use halo2_proofs::plonk::Error;
 
 #[derive(Clone, Debug)]
 pub(crate) struct CallDataSizeGadget<F> {
@@ -74,15 +73,8 @@ impl<F: Field> ExecutionGadget<F> for CallDataSizeGadget<F> {
 
         let call_data_size = block.get_rws(step, 1).stack_value();
 
-        self.call_data_size.assign_lo(
-            region,
-            offset,
-            Value::known(F::from(u64::from_le_bytes(
-                call_data_size.to_le_bytes()[..N_BYTES_CALLDATASIZE]
-                    .try_into()
-                    .unwrap(),
-            ))),
-        )?;
+        self.call_data_size
+            .assign_u64(region, offset, call_data_size.as_u64())?;
 
         Ok(())
     }

--- a/zkevm-circuits/src/evm_circuit/execution/calldatasize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldatasize.rs
@@ -6,21 +6,24 @@ use crate::{
         util::{
             common_gadget::SameContextGadget,
             constraint_builder::{EVMConstraintBuilder, StepStateTransition, Transition::Delta},
-            from_bytes, CachedRegion, RandomLinearCombination,
+            CachedRegion,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
     table::CallContextFieldTag,
-    util::Expr,
+    util::{
+        word::{WordCell, WordExpr},
+        Expr,
+    },
 };
 use bus_mapping::evm::OpcodeId;
 use eth_types::{Field, ToLittleEndian};
-use halo2_proofs::plonk::Error;
+use halo2_proofs::{circuit::Value, plonk::Error};
 
 #[derive(Clone, Debug)]
 pub(crate) struct CallDataSizeGadget<F> {
     same_context: SameContextGadget<F>,
-    call_data_size: RandomLinearCombination<F, N_BYTES_CALLDATASIZE>,
+    call_data_size: WordCell<F>,
 }
 
 impl<F: Field> ExecutionGadget<F> for CallDataSizeGadget<F> {
@@ -32,16 +35,15 @@ impl<F: Field> ExecutionGadget<F> for CallDataSizeGadget<F> {
         let opcode = cb.query_cell();
 
         // Add lookup constraint in the call context for the calldatasize field.
-        let call_data_size = cb.query_word_rlc();
-        cb.call_context_lookup(
-            false.expr(),
+        let call_data_size = cb.query_word_unchecked();
+        cb.call_context_lookup_read(
             None,
             CallContextFieldTag::CallDataLength,
-            from_bytes::expr(&call_data_size.cells),
+            call_data_size.to_word(),
         );
 
         // The calldatasize should be pushed to the top of the stack.
-        cb.stack_push(call_data_size.expr());
+        cb.stack_push_word(call_data_size.to_word());
 
         let step_state_transition = StepStateTransition {
             rw_counter: Delta(2.expr()),
@@ -72,14 +74,14 @@ impl<F: Field> ExecutionGadget<F> for CallDataSizeGadget<F> {
 
         let call_data_size = block.get_rws(step, 1).stack_value();
 
-        self.call_data_size.assign(
+        self.call_data_size.assign_lo(
             region,
             offset,
-            Some(
+            Value::known(F::from(u64::from_le_bytes(
                 call_data_size.to_le_bytes()[..N_BYTES_CALLDATASIZE]
                     .try_into()
                     .unwrap(),
-            ),
+            ))),
         )?;
 
         Ok(())

--- a/zkevm-circuits/src/evm_circuit/execution/caller.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/caller.rs
@@ -1,27 +1,28 @@
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
-        param::N_BYTES_ACCOUNT_ADDRESS,
         step::ExecutionState,
         util::{
             common_gadget::SameContextGadget,
             constraint_builder::{EVMConstraintBuilder, StepStateTransition, Transition::Delta},
-            from_bytes, CachedRegion, RandomLinearCombination,
+            CachedRegion,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
     table::CallContextFieldTag,
-    util::Expr,
+    util::{
+        word::{WordCell, WordExpr},
+        Expr,
+    },
 };
 use bus_mapping::evm::OpcodeId;
-use eth_types::{Field, ToLittleEndian};
+use eth_types::Field;
 use halo2_proofs::plonk::Error;
 
 #[derive(Clone, Debug)]
 pub(crate) struct CallerGadget<F> {
     same_context: SameContextGadget<F>,
-    // Using RLC to match against rw_table->stack_op value
-    caller_address: RandomLinearCombination<F, N_BYTES_ACCOUNT_ADDRESS>,
+    caller_address: WordCell<F>,
 }
 
 impl<F: Field> ExecutionGadget<F> for CallerGadget<F> {
@@ -30,18 +31,17 @@ impl<F: Field> ExecutionGadget<F> for CallerGadget<F> {
     const EXECUTION_STATE: ExecutionState = ExecutionState::CALLER;
 
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
-        let caller_address = cb.query_word_rlc();
+        let caller_address = cb.query_word_unchecked();
 
         // Lookup rw_table -> call_context with caller address
-        cb.call_context_lookup(
-            false.expr(),
+        cb.call_context_lookup_read(
             None, // cb.curr.state.call_id
             CallContextFieldTag::CallerAddress,
-            from_bytes::expr(&caller_address.cells),
+            caller_address.to_word(),
         );
 
         // Push the value to the stack
-        cb.stack_push(caller_address.expr());
+        cb.stack_push_word(caller_address.to_word());
 
         // State transition
         let opcode = cb.query_cell();
@@ -73,15 +73,7 @@ impl<F: Field> ExecutionGadget<F> for CallerGadget<F> {
 
         let caller = block.get_rws(step, 1).stack_value();
 
-        self.caller_address.assign(
-            region,
-            offset,
-            Some(
-                caller.to_le_bytes()[..N_BYTES_ACCOUNT_ADDRESS]
-                    .try_into()
-                    .unwrap(),
-            ),
-        )?;
+        self.caller_address.assign_u256(region, offset, caller)?;
 
         Ok(())
     }

--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -120,11 +120,11 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
         // Add callee to access list
         let is_warm = cb.query_bool();
         let is_warm_prev = cb.query_bool();
-        cb.account_access_list_write_word(
+        cb.account_access_list_write(
             tx_id.expr(),
             call_gadget.callee_address_word(),
-            Word::from_lo_unchecked(is_warm.expr()),
-            Word::from_lo_unchecked(is_warm_prev.expr()),
+            is_warm.expr(),
+            is_warm_prev.expr(),
             Some(&mut reversion_info),
         );
 

--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -1,17 +1,22 @@
-use crate::evm_circuit::{
-    execution::ExecutionGadget,
-    param::{N_BYTES_GAS, N_BYTES_U64},
-    step::ExecutionState,
-    util::{
-        and,
-        common_gadget::{CommonCallGadget, TransferGadget},
-        constraint_builder::{
-            ConstrainBuilderCommon, EVMConstraintBuilder, ReversionInfo, StepStateTransition,
-            Transition::{Delta, To},
+use crate::{
+    evm_circuit::{
+        execution::ExecutionGadget,
+        param::{N_BYTES_GAS, N_BYTES_U64},
+        step::ExecutionState,
+        util::{
+            and,
+            common_gadget::{CommonCallGadget, TransferGadget},
+            constraint_builder::{
+                ConstrainBuilderCommon, EVMConstraintBuilder, ReversionInfo, StepStateTransition,
+                Transition::{Delta, To},
+            },
+            math_gadget::{
+                ConstantDivisionGadget, IsZeroGadget, LtGadget, LtWordGadget, MinMaxGadget,
+            },
+            not, or, select, CachedRegion, Cell,
         },
-        math_gadget::{ConstantDivisionGadget, IsZeroGadget, LtGadget, LtWordGadget, MinMaxGadget},
-        not, or, select, CachedRegion, Cell, Word,
     },
+    util::word::{Word, WordCell, WordExpr},
 };
 
 use crate::{
@@ -20,7 +25,7 @@ use crate::{
     util::Expr,
 };
 use bus_mapping::evm::OpcodeId;
-use eth_types::{evm_types::GAS_STIPEND_CALL_WITH_VALUE, Field, ToLittleEndian, ToScalar, U256};
+use eth_types::{evm_types::GAS_STIPEND_CALL_WITH_VALUE, Field, U256};
 use halo2_proofs::{circuit::Value, plonk::Error};
 
 /// Gadget for call related opcodes. It supports `OpcodeId::CALL`,
@@ -36,18 +41,18 @@ pub(crate) struct CallOpGadget<F> {
     is_staticcall: IsZeroGadget<F>,
     tx_id: Cell<F>,
     reversion_info: ReversionInfo<F>,
-    current_callee_address: Cell<F>,
-    current_caller_address: Cell<F>,
+    current_callee_address: WordCell<F>,
+    current_caller_address: WordCell<F>,
     is_static: Cell<F>,
     depth: Cell<F>,
     call: CommonCallGadget<F, true>,
-    current_value: Word<F>,
+    current_value: WordCell<F>,
     is_warm: Cell<F>,
     is_warm_prev: Cell<F>,
     callee_reversion_info: ReversionInfo<F>,
     transfer: TransferGadget<F>,
     // current handling Call* opcode's caller balance
-    caller_balance_word: Word<F>,
+    caller_balance_word: WordCell<F>,
     // check if insufficient balance case
     is_insufficient_balance: LtWordGadget<F>,
     is_depth_ok: LtGadget<F, N_BYTES_U64>,
@@ -75,17 +80,15 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
 
         let tx_id = cb.call_context(None, CallContextFieldTag::TxId);
         let mut reversion_info = cb.reversion_info_read(None);
-        let [is_static, depth, current_callee_address] = [
-            CallContextFieldTag::IsStatic,
-            CallContextFieldTag::Depth,
-            CallContextFieldTag::CalleeAddress,
-        ]
-        .map(|field_tag| cb.call_context(None, field_tag));
+        let [is_static, depth] = [CallContextFieldTag::IsStatic, CallContextFieldTag::Depth]
+            .map(|field_tag| cb.call_context(None, field_tag));
 
+        let current_callee_address =
+            cb.call_context_read_as_word(None, CallContextFieldTag::CalleeAddress);
         let (current_caller_address, current_value) = cb.condition(is_delegatecall.expr(), |cb| {
             (
-                cb.call_context(None, CallContextFieldTag::CallerAddress),
-                cb.call_context_read(None, CallContextFieldTag::Value),
+                cb.call_context_read_as_word(None, CallContextFieldTag::CallerAddress),
+                cb.call_context_read_as_word(None, CallContextFieldTag::Value),
             )
         });
 
@@ -97,31 +100,31 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
             is_staticcall.expr(),
         );
         cb.condition(not::expr(is_call.expr() + is_callcode.expr()), |cb| {
-            cb.require_zero(
+            cb.require_zero_word(
                 "for non call/call code, value is zero",
-                call_gadget.value.expr(),
+                call_gadget.value.to_word(),
             );
         });
 
-        let caller_address = select::expr(
+        let caller_address = Word::select(
             is_delegatecall.expr(),
-            current_caller_address.expr(),
-            current_callee_address.expr(),
+            current_caller_address.to_word(),
+            current_callee_address.to_word(),
         );
-        let callee_address = select::expr(
+        let callee_address = Word::select(
             is_callcode.expr() + is_delegatecall.expr(),
-            current_callee_address.expr(),
-            call_gadget.callee_address_expr(),
+            current_callee_address.to_word(),
+            call_gadget.callee_address_word(),
         );
 
         // Add callee to access list
         let is_warm = cb.query_bool();
         let is_warm_prev = cb.query_bool();
-        cb.account_access_list_write(
+        cb.account_access_list_write_word(
             tx_id.expr(),
-            call_gadget.callee_address_expr(),
-            is_warm.expr(),
-            is_warm_prev.expr(),
+            call_gadget.callee_address_word(),
+            Word::from_lo_unchecked(is_warm.expr()),
+            Word::from_lo_unchecked(is_warm_prev.expr()),
             Some(&mut reversion_info),
         );
 
@@ -147,14 +150,17 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
             );
         });
 
-        let caller_balance_word = cb.query_word_rlc();
-        cb.account_read(
-            caller_address.expr(),
+        let caller_balance_word = cb.query_word_unchecked();
+        cb.account_read_word(
+            caller_address.to_word(),
             AccountFieldTag::Balance,
-            caller_balance_word.expr(),
+            caller_balance_word.to_word(),
         );
-        let is_insufficient_balance =
-            LtWordGadget::construct(cb, &caller_balance_word, &call_gadget.value.clone().into());
+        let is_insufficient_balance = LtWordGadget::construct(
+            cb,
+            &caller_balance_word.to_word(),
+            &call_gadget.value.to_word(),
+        );
         // depth < 1025
         let is_depth_ok = LtGadget::construct(cb, depth.expr(), 1025.expr());
 
@@ -180,8 +186,8 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
             |cb| {
                 TransferGadget::construct(
                     cb,
-                    caller_address.expr(),
-                    callee_address.expr(),
+                    caller_address.to_word(),
+                    callee_address.to_word(),
                     not::expr(call_gadget.callee_not_exists.expr()),
                     0.expr(),
                     call_gadget.value.clone(),
@@ -235,7 +241,7 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
                     CallContextFieldTag::LastCalleeReturnDataOffset,
                     CallContextFieldTag::LastCalleeReturnDataLength,
                 ] {
-                    cb.call_context_lookup(true.expr(), None, field_tag, 0.expr());
+                    cb.call_context_lookup_write_unchecked(None, field_tag, Word::zero());
                 }
 
                 // For CALL opcode, it has an extra stack pop `value` (+1) and if the value is
@@ -280,7 +286,7 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
                 CallContextFieldTag::LastCalleeReturnDataOffset,
                 CallContextFieldTag::LastCalleeReturnDataLength,
             ] {
-                cb.call_context_lookup(true.expr(), None, field_tag, 0.expr());
+                cb.call_context_lookup_write_unchecked(None, field_tag, Word::zero());
             }
 
             cb.require_step_state_transition(StepStateTransition {
@@ -323,50 +329,88 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
                         cb.curr.state.reversible_write_counter.expr() + 1.expr(),
                     ),
                 ] {
-                    cb.call_context_lookup(true.expr(), None, field_tag, value);
+                    cb.call_context_lookup_write_unchecked(
+                        None,
+                        field_tag,
+                        Word::from_lo_unchecked(value),
+                    );
                 }
 
                 // Setup next call's context.
                 let cd_address = call_gadget.cd_address.clone();
                 let rd_address = call_gadget.rd_address.clone();
                 for (field_tag, value) in [
-                    (CallContextFieldTag::CallerId, cb.curr.state.call_id.expr()),
-                    (CallContextFieldTag::TxId, tx_id.expr()),
-                    (CallContextFieldTag::Depth, depth.expr() + 1.expr()),
+                    (
+                        CallContextFieldTag::CallerId,
+                        Word::from_lo_unchecked(cb.curr.state.call_id.expr()),
+                    ),
+                    (
+                        CallContextFieldTag::TxId,
+                        Word::from_lo_unchecked(tx_id.expr()),
+                    ),
+                    (
+                        CallContextFieldTag::Depth,
+                        Word::from_lo_unchecked(depth.expr() + 1.expr()),
+                    ),
                     (CallContextFieldTag::CallerAddress, caller_address),
                     (CallContextFieldTag::CalleeAddress, callee_address),
-                    (CallContextFieldTag::CallDataOffset, cd_address.offset()),
-                    (CallContextFieldTag::CallDataLength, cd_address.length()),
-                    (CallContextFieldTag::ReturnDataOffset, rd_address.offset()),
-                    (CallContextFieldTag::ReturnDataLength, rd_address.length()),
+                    (
+                        CallContextFieldTag::CallDataOffset,
+                        Word::from_lo_unchecked(cd_address.offset()),
+                    ),
+                    (
+                        CallContextFieldTag::CallDataLength,
+                        Word::from_lo_unchecked(cd_address.length()),
+                    ),
+                    (
+                        CallContextFieldTag::ReturnDataOffset,
+                        Word::from_lo_unchecked(rd_address.offset()),
+                    ),
+                    (
+                        CallContextFieldTag::ReturnDataLength,
+                        Word::from_lo_unchecked(rd_address.length()),
+                    ),
                     (
                         CallContextFieldTag::Value,
-                        select::expr(
+                        Word::select(
                             is_delegatecall.expr(),
-                            current_value.expr(),
-                            call_gadget.value.expr(),
+                            current_value.to_word(),
+                            call_gadget.value.to_word(),
                         ),
                     ),
                     (
                         CallContextFieldTag::IsSuccess,
-                        call_gadget.is_success.expr(),
+                        Word::from_lo_unchecked(call_gadget.is_success.expr()),
                     ),
                     (
                         CallContextFieldTag::IsStatic,
-                        or::expr([is_static.expr(), is_staticcall.expr()]),
+                        Word::from_lo_unchecked(or::expr([is_static.expr(), is_staticcall.expr()])),
                     ),
-                    (CallContextFieldTag::LastCalleeId, 0.expr()),
-                    (CallContextFieldTag::LastCalleeReturnDataOffset, 0.expr()),
-                    (CallContextFieldTag::LastCalleeReturnDataLength, 0.expr()),
-                    (CallContextFieldTag::IsRoot, 0.expr()),
-                    (CallContextFieldTag::IsCreate, 0.expr()),
+                    (CallContextFieldTag::LastCalleeId, Word::zero()),
+                    (
+                        CallContextFieldTag::LastCalleeReturnDataOffset,
+                        Word::zero(),
+                    ),
+                    (
+                        CallContextFieldTag::LastCalleeReturnDataLength,
+                        Word::zero(),
+                    ),
+                    (CallContextFieldTag::IsRoot, Word::zero()),
+                    (CallContextFieldTag::IsCreate, Word::zero()),
                     (
                         CallContextFieldTag::CodeHash,
-                        call_gadget.callee_code_hash.expr(),
+                        call_gadget.callee_code_hash.to_word(),
                     ),
                 ] {
-                    cb.call_context_lookup(
-                        true.expr(),
+                    cb.call_context_lookup_write_unchecked(
+                        Some(callee_call_id.expr()),
+                        field_tag,
+                        value,
+                    );
+                }
+
+                for (field_tag, value) in [] {
+                    cb.call_context_lookup_write_unchecked(
                         Some(callee_call_id.expr()),
                         field_tag,
                         value,
@@ -399,7 +443,7 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
                     call_id: To(callee_call_id.expr()),
                     is_root: To(false.expr()),
                     is_create: To(false.expr()),
-                    code_hash: To(call_gadget.callee_code_hash.expr()),
+                    code_hash: To(call_gadget.callee_code_hash.to_word()),
                     gas_left: To(callee_gas_left),
                     // For CALL opcode, `transfer` invocation has two account write if value is not
                     // zero.
@@ -489,7 +533,7 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
         // get caller balance
         let (caller_balance, _) = block.get_rws(step, 17 + rw_offset).account_value_pair();
         self.caller_balance_word
-            .assign(region, offset, Some(caller_balance.to_le_bytes()))?;
+            .assign_u256(region, offset, caller_balance)?;
         self.is_insufficient_balance
             .assign(region, offset, caller_balance, value)?;
 
@@ -532,26 +576,12 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
             call.rw_counter_end_of_reversion,
             call.is_persistent,
         )?;
-        self.current_callee_address.assign(
-            region,
-            offset,
-            Value::known(
-                current_callee_address
-                    .to_scalar()
-                    .expect("unexpected Address -> Scalar conversion failure"),
-            ),
-        )?;
-        self.current_caller_address.assign(
-            region,
-            offset,
-            Value::known(
-                current_caller_address
-                    .to_scalar()
-                    .expect("unexpected Address -> Scalar conversion failure"),
-            ),
-        )?;
+        self.current_callee_address
+            .assign_u256(region, offset, current_callee_address)?;
+        self.current_caller_address
+            .assign_u256(region, offset, current_caller_address)?;
         self.current_value
-            .assign(region, offset, Some(current_value.to_le_bytes()))?;
+            .assign_u256(region, offset, current_value)?;
         self.is_static
             .assign(region, offset, Value::known(F::from(is_static.low_u64())))?;
         self.depth

--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -402,10 +402,6 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
                     cb.call_context_lookup_write(Some(callee_call_id.expr()), field_tag, value);
                 }
 
-                for (field_tag, value) in [] {
-                    cb.call_context_lookup_write(Some(callee_call_id.expr()), field_tag, value);
-                }
-
                 // Give gas stipend if value is not zero
                 let callee_gas_left = callee_gas_left
                     + call_gadget.has_value.clone() * GAS_STIPEND_CALL_WITH_VALUE.expr();

--- a/zkevm-circuits/src/evm_circuit/execution/codecopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/codecopy.rs
@@ -16,7 +16,10 @@ use crate::{
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
-    util::Expr,
+    util::{
+        word::{Word, WordExpr},
+        Expr,
+    },
 };
 
 use super::ExecutionGadget;
@@ -53,23 +56,23 @@ impl<F: Field> ExecutionGadget<F> for CodeCopyGadget<F> {
 
         let code_size = cb.query_cell();
 
-        let size = cb.query_word_rlc();
-        let dst_memory_offset = cb.query_cell_phase2();
+        let length = cb.query_memory_address();
+        let dst_memory_offset = cb.query_word_unchecked();
         let code_offset = WordByteCapGadget::construct(cb, code_size.expr());
 
         // Pop items from stack.
-        cb.stack_pop(dst_memory_offset.expr());
-        cb.stack_pop(code_offset.original_word());
-        cb.stack_pop(size.expr());
+        cb.stack_pop_word(dst_memory_offset.to_word());
+        cb.stack_pop_word(code_offset.original_word_new().to_word());
+        cb.stack_pop_word(Word::from_lo_unchecked(length.expr()));
 
         // Construct memory address in the destionation (memory) to which we copy code.
-        let dst_memory_addr = MemoryAddressGadget::construct(cb, dst_memory_offset, size);
+        let dst_memory_addr = MemoryAddressGadget::construct(cb, dst_memory_offset, length);
 
         // Fetch the hash of bytecode running in current environment.
         let code_hash = cb.curr.state.code_hash.clone();
 
         // Fetch the bytecode length from the bytecode table.
-        cb.bytecode_length(code_hash.expr(), code_size.expr());
+        cb.bytecode_length_word(code_hash.to_word(), code_size.expr());
 
         // Calculate the next memory size and the gas cost for this memory
         // access. This also accounts for the dynamic gas required to copy bytes to
@@ -91,9 +94,9 @@ impl<F: Field> ExecutionGadget<F> for CodeCopyGadget<F> {
             );
 
             cb.copy_table_lookup(
-                code_hash.expr(),
+                code_hash.to_word(),
                 CopyDataType::Bytecode.expr(),
-                cb.curr.state.call_id.expr(),
+                Word::from_lo_unchecked(cb.curr.state.call_id.expr()),
                 CopyDataType::Memory.expr(),
                 src_addr,
                 code_size.expr(),

--- a/zkevm-circuits/src/evm_circuit/execution/codesize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/codesize.rs
@@ -1,4 +1,3 @@
-use array_init::array_init;
 use bus_mapping::evm::OpcodeId;
 use eth_types::Field;
 use halo2_proofs::{circuit::Value, plonk::Error};
@@ -11,11 +10,11 @@ use crate::{
             constraint_builder::{
                 ConstrainBuilderCommon, EVMConstraintBuilder, StepStateTransition, Transition,
             },
-            from_bytes, CachedRegion, Cell,
+            CachedRegion, Cell, U64Cell,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
-    util::Expr,
+    util::{word::WordExpr, Expr},
 };
 
 use super::ExecutionGadget;
@@ -23,7 +22,7 @@ use super::ExecutionGadget;
 #[derive(Clone, Debug)]
 pub(crate) struct CodesizeGadget<F> {
     same_context: SameContextGadget<F>,
-    codesize_bytes: [Cell<F>; 8],
+    codesize_bytes: U64Cell<F>,
     codesize: Cell<F>,
 }
 
@@ -35,19 +34,19 @@ impl<F: Field> ExecutionGadget<F> for CodesizeGadget<F> {
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
         let opcode = cb.query_cell();
 
-        let codesize_bytes = array_init(|_| cb.query_byte());
+        let codesize_bytes = cb.query_u64();
 
         let code_hash = cb.curr.state.code_hash.clone();
         let codesize = cb.query_cell();
-        cb.bytecode_length(code_hash.expr(), codesize.expr());
+        cb.bytecode_length_word(code_hash.to_word(), codesize.expr());
 
         cb.require_equal(
             "Constraint: bytecode length lookup == codesize",
-            from_bytes::expr(&codesize_bytes),
+            codesize_bytes.to_word().lo(),
             codesize.expr(),
         );
 
-        cb.stack_push(cb.word_rlc(codesize_bytes.clone().map(|c| c.expr())));
+        cb.stack_push_word(codesize_bytes.to_word());
 
         let step_state_transition = StepStateTransition {
             gas_left: Transition::Delta(-OpcodeId::CODESIZE.constant_gas_cost().expr()),
@@ -78,13 +77,8 @@ impl<F: Field> ExecutionGadget<F> for CodesizeGadget<F> {
 
         let codesize = block.get_rws(step, 0).stack_value().as_u64();
 
-        for (c, b) in self
-            .codesize_bytes
-            .iter()
-            .zip(codesize.to_le_bytes().iter())
-        {
-            c.assign(region, offset, Value::known(F::from(*b as u64)))?;
-        }
+        self.codesize_bytes
+            .assign(region, offset, Some(codesize.to_le_bytes()))?;
 
         self.codesize
             .assign(region, offset, Value::known(F::from(codesize)))?;

--- a/zkevm-circuits/src/evm_circuit/execution/codesize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/codesize.rs
@@ -42,7 +42,7 @@ impl<F: Field> ExecutionGadget<F> for CodesizeGadget<F> {
 
         cb.require_equal(
             "Constraint: bytecode length lookup == codesize",
-            codesize_bytes.to_word().lo(),
+            codesize_bytes.expr(),
             codesize.expr(),
         );
 

--- a/zkevm-circuits/src/evm_circuit/execution/create.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/create.rs
@@ -291,8 +291,8 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                 cb.account_write_word(
                     contract_addr.to_word(),
                     AccountFieldTag::Nonce,
-                    Word::from_lo_unchecked(1.expr()),
-                    Word::from_lo_unchecked(0.expr()),
+                    Word::one(),
+                    Word::zero(),
                     Some(&mut callee_reversion_info),
                 );
 

--- a/zkevm-circuits/src/evm_circuit/execution/create.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/create.rs
@@ -183,7 +183,7 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
             );
 
             // add callee to access list
-            cb.account_access_list_write(
+            cb.account_access_list_write_unchecked(
                 tx_id.expr(),
                 contract_addr.to_word(),
                 1.expr(),
@@ -238,10 +238,11 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                 Word::from_lo_unchecked(cb.curr.state.reversible_write_counter.expr() + 2.expr()),
             ),
         ] {
-            cb.call_context_lookup_write_unchecked(None, field_tag, value);
+            cb.call_context_lookup_write(None, field_tag, value);
         }
 
-        let mut callee_reversion_info = cb.reversion_info_write(Some(callee_call_id.expr()));
+        let mut callee_reversion_info =
+            cb.reversion_info_write_unchecked(Some(callee_call_id.expr()));
         let transfer = cb.condition(
             and::expr([is_precheck_ok.clone(), not_address_collision.expr()]),
             |cb| {
@@ -343,11 +344,7 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                         ),
                         (CallContextFieldTag::CodeHash, create.code_hash_word()),
                     ] {
-                        cb.call_context_lookup_write_unchecked(
-                            Some(callee_call_id.expr()),
-                            field_tag,
-                            value,
-                        );
+                        cb.call_context_lookup_write(Some(callee_call_id.expr()), field_tag, value);
                     }
 
                     cb.require_step_state_transition(StepStateTransition {
@@ -372,7 +369,7 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                         CallContextFieldTag::LastCalleeReturnDataOffset,
                         CallContextFieldTag::LastCalleeReturnDataLength,
                     ] {
-                        cb.call_context_lookup_write_unchecked(None, field_tag, Word::zero());
+                        cb.call_context_lookup_write(None, field_tag, Word::zero());
                     }
                     cb.require_step_state_transition(StepStateTransition {
                         rw_counter: Delta(cb.rw_counter_offset()),
@@ -415,7 +412,7 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                     CallContextFieldTag::LastCalleeReturnDataOffset,
                     CallContextFieldTag::LastCalleeReturnDataLength,
                 ] {
-                    cb.call_context_lookup_write_unchecked(None, field_tag, Word::zero());
+                    cb.call_context_lookup_write(None, field_tag, Word::zero());
                 }
 
                 cb.require_step_state_transition(StepStateTransition {

--- a/zkevm-circuits/src/evm_circuit/execution/create.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/create.rs
@@ -109,7 +109,6 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                 .to_vec()
                 .try_into()
                 .unwrap(),
-            256.expr(),
         );
 
         // stack operations

--- a/zkevm-circuits/src/evm_circuit/execution/create.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/create.rs
@@ -183,11 +183,11 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
             );
 
             // add callee to access list
-            cb.account_access_list_write_word(
+            cb.account_access_list_write(
                 tx_id.expr(),
                 contract_addr.to_word(),
-                Word::from_lo_unchecked(1.expr()),
-                Word::from_lo_unchecked(was_warm.expr()),
+                1.expr(),
+                was_warm.expr(),
                 Some(&mut reversion_info),
             );
 

--- a/zkevm-circuits/src/evm_circuit/execution/create.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/create.rs
@@ -13,24 +13,31 @@ use crate::{
                 Transition::{Delta, To},
             },
             math_gadget::{
-                ConstantDivisionGadget, ContractCreateGadget, IsZeroGadget, LtGadget, LtWordGadget,
+                ConstantDivisionGadget, ContractCreateGadget, IsZeroGadget, IsZeroWordGadget,
+                LtGadget, LtWordGadget,
             },
             memory_gadget::{MemoryAddressGadget, MemoryExpansionGadget},
-            not, CachedRegion, Cell, Word,
+            not, AccountAddress, CachedRegion, Cell, Word, WordExpr,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
     table::{AccountFieldTag, CallContextFieldTag},
-    util::{word::Word32Cell, Expr},
+    util::{
+        word::{Word32Cell, WordCell},
+        Expr,
+    },
 };
 use bus_mapping::{circuit_input_builder::CopyDataType, evm::OpcodeId, state_db::CodeDB};
 use eth_types::{
     evm_types::{GasCost, INIT_CODE_WORD_GAS},
-    Field, ToBigEndian, ToLittleEndian, ToScalar, U256,
+    Field, ToBigEndian, ToScalar, U256,
 };
 use ethers_core::utils::keccak256;
-use gadgets::util::{and, expr_from_bytes, or, select};
-use halo2_proofs::{circuit::Value, plonk::Error};
+use gadgets::util::{and, or, select};
+use halo2_proofs::{
+    circuit::Value,
+    plonk::{Error, Expression},
+};
 
 use std::iter::once;
 
@@ -47,22 +54,22 @@ pub(crate) struct CreateGadget<F, const IS_CREATE2: bool, const S: ExecutionStat
     was_warm: Cell<F>,
     value: Word32Cell<F>,
 
-    caller_balance: Word<F>,
+    caller_balance: WordCell<F>,
     callee_reversion_info: ReversionInfo<F>,
     callee_nonce: Cell<F>,
-    prev_code_hash: Cell<F>,
+    prev_code_hash: WordCell<F>,
     transfer: TransferGadget<F>,
     create: ContractCreateGadget<F, IS_CREATE2>,
 
     init_code: MemoryAddressGadget<F>,
     init_code_word_size: ConstantDivisionGadget<F, N_BYTES_MEMORY_ADDRESS>,
     init_code_rlc: Cell<F>,
-    keccak_output: Word<F>,
+    keccak_output: Word32Cell<F>,
 
     is_depth_in_range: LtGadget<F, N_BYTES_U64>,
     is_insufficient_balance: LtWordGadget<F>,
     is_nonce_in_range: LtGadget<F, N_BYTES_U64>,
-    not_address_collision: IsZeroGadget<F>,
+    not_address_collision: IsZeroWordGadget<F, Word<Expression<F>>>,
 
     memory_expansion: MemoryExpansionGadget<F, 1, N_BYTES_MEMORY_WORD_SIZE>,
     gas_left: ConstantDivisionGadget<F, N_BYTES_GAS>,
@@ -95,50 +102,46 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
         let depth = cb.call_context(None, CallContextFieldTag::Depth);
         let mut reversion_info = cb.reversion_info_read(None);
 
-        let keccak_output = cb.query_word_rlc();
+        let keccak_output = cb.query_word32();
         let create = ContractCreateGadget::construct(cb);
-        let contract_addr = expr_from_bytes(&keccak_output.cells[..N_BYTES_ACCOUNT_ADDRESS]);
-        let contract_addr_rlc = cb.word_rlc::<N_BYTES_ACCOUNT_ADDRESS>(
-            keccak_output
-                .cells
-                .iter()
-                .take(N_BYTES_ACCOUNT_ADDRESS)
-                .map(Expr::expr)
-                .collect::<Vec<_>>()
+        let contract_addr = AccountAddress::new(
+            keccak_output.limbs[..N_BYTES_ACCOUNT_ADDRESS]
+                .to_vec()
                 .try_into()
                 .unwrap(),
+            256.expr(),
         );
 
         // stack operations
         let value = cb.query_word32();
-        let offset = cb.query_cell_phase2();
-        let length = cb.query_word_rlc();
-        cb.stack_pop(value.expr());
-        cb.stack_pop(offset.expr());
-        cb.stack_pop(length.expr());
+        let length = cb.query_memory_address();
+        let offset = cb.query_word_unchecked();
+        cb.stack_pop_word(value.to_word());
+        cb.stack_pop_word(offset.to_word());
+        cb.stack_pop_word(length.to_word());
         cb.condition(is_create2.expr(), |cb| {
-            cb.stack_pop(create.salt_word_rlc(cb).expr());
+            cb.stack_pop_word(create.salt_word());
         });
-        cb.stack_push(is_success.expr() * contract_addr_rlc);
+        cb.stack_push_word(contract_addr.to_word().mul_selector(is_success.expr()));
 
         // read caller's balance and nonce
         let caller_nonce = create.caller_nonce();
-        let caller_balance = cb.query_word_rlc();
-        cb.account_read(
-            create.caller_address(),
+        let caller_balance = cb.query_word_unchecked();
+        cb.account_read_word(
+            create.caller_address_word(),
             AccountFieldTag::Balance,
-            caller_balance.expr(),
+            caller_balance.to_word(),
         );
-        cb.account_read(
-            create.caller_address(),
+        cb.account_read_word(
+            create.caller_address_word(),
             AccountFieldTag::Nonce,
-            caller_nonce.expr(),
+            Word::from_lo_unchecked(caller_nonce.expr()),
         );
 
         // Pre-check: call depth, user's nonce and user's balance
         let is_depth_in_range = LtGadget::construct(cb, depth.expr(), 1025.expr());
         let is_insufficient_balance =
-            LtWordGadget::construct(cb, &caller_balance, &value.clone().into());
+            LtWordGadget::construct(cb, &caller_balance.to_word(), &value.to_word());
         let is_nonce_in_range = LtGadget::construct(cb, caller_nonce.expr(), u64::MAX.expr());
         let is_precheck_ok = and::expr([
             is_depth_in_range.expr(),
@@ -167,63 +170,75 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
 
         let was_warm = cb.query_bool();
         let init_code_rlc = cb.query_cell_phase2();
-        let prev_code_hash = cb.query_cell();
+        let prev_code_hash = cb.query_word_unchecked();
         let callee_nonce = cb.query_cell();
         let not_address_collision = cb.condition(is_precheck_ok.expr(), |cb| {
             // increase caller's nonce
-            cb.account_write(
-                create.caller_address(),
+            cb.account_write_word(
+                create.caller_address_word(),
                 AccountFieldTag::Nonce,
-                caller_nonce.expr() + 1.expr(),
-                caller_nonce.expr(),
+                Word::from_lo_unchecked(caller_nonce.expr() + 1.expr()),
+                Word::from_lo_unchecked(caller_nonce.expr()),
                 Some(&mut reversion_info),
             );
 
             // add callee to access list
-            cb.account_access_list_write(
+            cb.account_access_list_write_word(
                 tx_id.expr(),
-                contract_addr.clone(),
-                1.expr(),
-                was_warm.expr(),
+                contract_addr.to_word(),
+                Word::from_lo_unchecked(1.expr()),
+                Word::from_lo_unchecked(was_warm.expr()),
                 Some(&mut reversion_info),
             );
 
             // read contract's previous hash
-            cb.account_read(
-                contract_addr.clone(),
+            cb.account_read_word(
+                contract_addr.to_word(),
                 AccountFieldTag::CodeHash,
-                prev_code_hash.expr(),
+                prev_code_hash.to_word(),
             );
 
             // ErrContractAddressCollision, if any one of following criteria meets.
             // Nonce is not zero or account code hash is not either 0 or EMPTY_CODE_HASH.
-            IsZeroGadget::construct(
+            // Here use `isZeroWord(callee_nonce + prev_code_hash_word * (prev_code_hash_word -
+            // empty_code_hash_word))` to represent `(callee_nonce == 0 && (prev_code_hash_word == 0
+            // or prev_code_hash_word == empty_code_hash_word))`
+            let prev_code_hash_word = prev_code_hash.to_word();
+            IsZeroWordGadget::construct(
                 cb,
-                callee_nonce.expr()
-                    + prev_code_hash.expr() * (prev_code_hash.expr() - cb.empty_code_hash_rlc()),
+                &Word::from_lo_unchecked(callee_nonce.expr()).add_unchecked(
+                    prev_code_hash_word.clone().mul_unchecked(
+                        prev_code_hash_word.sub_unchecked(cb.empty_code_hash_word()),
+                    ),
+                ),
             )
         });
 
         for (field_tag, value) in [
             (
                 CallContextFieldTag::ProgramCounter,
-                cb.curr.state.program_counter.expr() + 1.expr(),
+                Word::from_lo_unchecked(cb.curr.state.program_counter.expr() + 1.expr()),
             ),
             (
                 CallContextFieldTag::StackPointer,
-                cb.curr.state.stack_pointer.expr() + 2.expr() + is_create2.expr(),
+                Word::from_lo_unchecked(
+                    cb.curr.state.stack_pointer.expr() + 2.expr() + is_create2.expr(),
+                ),
             ),
-            (CallContextFieldTag::GasLeft, gas_left.quotient()),
+            (
+                CallContextFieldTag::GasLeft,
+                Word::from_lo_unchecked(gas_left.quotient()),
+            ),
             (
                 CallContextFieldTag::MemorySize,
-                memory_expansion.next_memory_word_size(),
+                Word::from_lo_unchecked(memory_expansion.next_memory_word_size()),
             ),
             (
                 CallContextFieldTag::ReversibleWriteCounter,
-                cb.curr.state.reversible_write_counter.expr() + 2.expr(),
+                Word::from_lo_unchecked(cb.curr.state.reversible_write_counter.expr() + 2.expr()),
             ),
         ] {
-            cb.call_context_lookup(true.expr(), None, field_tag, value);
+            cb.call_context_lookup_write_unchecked(None, field_tag, value);
         }
 
         let mut callee_reversion_info = cb.reversion_info_write(Some(callee_call_id.expr()));
@@ -234,9 +249,9 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                     // the init code is being copied from memory to bytecode, so a copy table lookup
                     // to verify that the associated fields for the copy event.
                     cb.copy_table_lookup(
-                        current_call_id.expr(),
+                        Word::from_lo_unchecked(current_call_id.expr()),
                         CopyDataType::Memory.expr(),
-                        create.code_hash_word_rlc(cb),
+                        create.code_hash_word(),
                         CopyDataType::Bytecode.expr(),
                         init_code.offset(),
                         init_code.address(),
@@ -248,10 +263,10 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                 });
 
                 // keccak table lookup to verify contract address.
-                cb.keccak_table_lookup(
+                cb.keccak_table_lookup_word(
                     create.input_rlc(cb),
                     create.input_length(),
-                    keccak_output.expr(),
+                    keccak_output.to_word(),
                 );
 
                 // propagate is_persistent
@@ -264,8 +279,8 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                 // transfer
                 let transfer = TransferGadget::construct(
                     cb,
-                    create.caller_address(),
-                    contract_addr.clone(),
+                    create.caller_address_word(),
+                    contract_addr.to_word(),
                     0.expr(),
                     1.expr(),
                     value.clone(),
@@ -273,37 +288,62 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                 );
 
                 // EIP 161, the nonce of a newly created contract is 1
-                cb.account_write(
-                    contract_addr.clone(),
+                cb.account_write_word(
+                    contract_addr.to_word(),
                     AccountFieldTag::Nonce,
-                    1.expr(),
-                    0.expr(),
+                    Word::from_lo_unchecked(1.expr()),
+                    Word::from_lo_unchecked(0.expr()),
                     Some(&mut callee_reversion_info),
                 );
 
                 cb.condition(init_code.has_length(), |cb| {
                     for (field_tag, value) in [
-                        (CallContextFieldTag::CallerId, current_call_id.expr()),
-                        (CallContextFieldTag::IsSuccess, is_success.expr()),
+                        (
+                            CallContextFieldTag::CallerId,
+                            Word::from_lo_unchecked(current_call_id.expr()),
+                        ),
+                        (
+                            CallContextFieldTag::IsSuccess,
+                            Word::from_lo_unchecked(is_success.expr()),
+                        ),
                         (
                             CallContextFieldTag::IsPersistent,
-                            callee_reversion_info.is_persistent(),
+                            Word::from_lo_unchecked(callee_reversion_info.is_persistent()),
                         ),
-                        (CallContextFieldTag::TxId, tx_id.expr()),
-                        (CallContextFieldTag::CallerAddress, create.caller_address()),
-                        (CallContextFieldTag::CalleeAddress, contract_addr),
+                        (
+                            CallContextFieldTag::TxId,
+                            Word::from_lo_unchecked(tx_id.expr()),
+                        ),
+                        (
+                            CallContextFieldTag::CallerAddress,
+                            create.caller_address_word(),
+                        ),
+                        (CallContextFieldTag::CalleeAddress, contract_addr.to_word()),
                         (
                             CallContextFieldTag::RwCounterEndOfReversion,
-                            callee_reversion_info.rw_counter_end_of_reversion(),
+                            Word::from_lo_unchecked(
+                                callee_reversion_info.rw_counter_end_of_reversion(),
+                            ),
                         ),
-                        (CallContextFieldTag::Depth, depth.expr() + 1.expr()),
-                        (CallContextFieldTag::IsRoot, false.expr()),
-                        (CallContextFieldTag::IsStatic, false.expr()),
-                        (CallContextFieldTag::IsCreate, true.expr()),
-                        (CallContextFieldTag::CodeHash, create.code_hash_word_rlc(cb)),
+                        (
+                            CallContextFieldTag::Depth,
+                            Word::from_lo_unchecked(depth.expr() + 1.expr()),
+                        ),
+                        (
+                            CallContextFieldTag::IsRoot,
+                            Word::from_lo_unchecked(false.expr()),
+                        ),
+                        (
+                            CallContextFieldTag::IsStatic,
+                            Word::from_lo_unchecked(false.expr()),
+                        ),
+                        (
+                            CallContextFieldTag::IsCreate,
+                            Word::from_lo_unchecked(true.expr()),
+                        ),
+                        (CallContextFieldTag::CodeHash, create.code_hash_word()),
                     ] {
-                        cb.call_context_lookup(
-                            true.expr(),
+                        cb.call_context_lookup_write_unchecked(
                             Some(callee_call_id.expr()),
                             field_tag,
                             value,
@@ -316,7 +356,7 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                         call_id: To(callee_call_id.expr()),
                         is_root: To(false.expr()),
                         is_create: To(true.expr()),
-                        code_hash: To(create.code_hash_word_rlc(cb)),
+                        code_hash: To(create.code_hash_word()),
                         gas_left: To(callee_gas_left),
                         reversible_write_counter: To(
                             1.expr() + transfer.reversible_w_delta().expr()
@@ -332,7 +372,7 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                         CallContextFieldTag::LastCalleeReturnDataOffset,
                         CallContextFieldTag::LastCalleeReturnDataLength,
                     ] {
-                        cb.call_context_lookup(true.expr(), None, field_tag, 0.expr());
+                        cb.call_context_lookup_write_unchecked(None, field_tag, Word::zero());
                     }
                     cb.require_step_state_transition(StepStateTransition {
                         rw_counter: Delta(cb.rw_counter_offset()),
@@ -375,7 +415,7 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                     CallContextFieldTag::LastCalleeReturnDataOffset,
                     CallContextFieldTag::LastCalleeReturnDataLength,
                 ] {
-                    cb.call_context_lookup(true.expr(), None, field_tag, 0.expr());
+                    cb.call_context_lookup_write_unchecked(None, field_tag, Word::zero());
                 }
 
                 cb.require_step_state_transition(StepStateTransition {
@@ -454,8 +494,7 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
         // stack value starts from 4
         let [value, init_code_start, init_code_length] =
             [4, 5, 6].map(|idx| block.get_rws(step, idx).stack_value());
-        self.value
-            .assign(region, offset, Some(value.to_le_bytes()))?;
+        self.value.assign_u256(region, offset, value)?;
         let salt = if is_create2 {
             block.get_rws(step, 7).stack_value()
         } else {
@@ -474,7 +513,7 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
             };
 
         self.caller_balance
-            .assign(region, offset, Some(caller_balance.to_le_bytes()))?;
+            .assign_u256(region, offset, caller_balance)?;
         let (callee_prev_code_hash, was_warm) = if is_precheck_ok == 1 {
             let (_, was_warm) = block
                 .get_rws(step, rw_offset + 4)
@@ -496,17 +535,20 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
 
         // retrieve code_hash for creating address
         let is_address_collision = !callee_prev_code_hash.is_zero();
-        let code_hash_previous_rlc = if is_address_collision {
-            region.code_hash(callee_prev_code_hash)
-        } else {
-            Value::known(F::ZERO)
-        };
-        self.prev_code_hash
-            .assign(region, offset, code_hash_previous_rlc)?;
-        self.not_address_collision.assign(
+
+        self.prev_code_hash.assign_u256(
             region,
             offset,
-            F::from((is_address_collision).into()),
+            if is_address_collision {
+                callee_prev_code_hash
+            } else {
+                U256::from(0)
+            },
+        )?;
+        self.not_address_collision.assign_u256(
+            region,
+            offset,
+            U256::from(is_address_collision as u8),
         )?;
 
         // gas cost of memory expansion
@@ -583,8 +625,11 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
             let mut keccak_output = keccak256(keccak_input);
             keccak_output.reverse();
 
-            self.keccak_output
-                .assign(region, offset, Some(keccak_output))?;
+            self.keccak_output.assign_u256(
+                region,
+                offset,
+                U256::from_little_endian(&keccak_output),
+            )?;
             self.init_code_rlc.assign(
                 region,
                 offset,

--- a/zkevm-circuits/src/evm_circuit/execution/dup.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/dup.rs
@@ -5,11 +5,14 @@ use crate::{
         util::{
             common_gadget::SameContextGadget,
             constraint_builder::{EVMConstraintBuilder, StepStateTransition, Transition::Delta},
-            CachedRegion, Cell,
+            CachedRegion,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
-    util::Expr,
+    util::{
+        word::{WordCell, WordExpr},
+        Expr,
+    },
 };
 use eth_types::{evm_types::OpcodeId, Field};
 use halo2_proofs::plonk::Error;
@@ -17,7 +20,7 @@ use halo2_proofs::plonk::Error;
 #[derive(Clone, Debug)]
 pub(crate) struct DupGadget<F> {
     same_context: SameContextGadget<F>,
-    value: Cell<F>,
+    value: WordCell<F>,
 }
 
 impl<F: Field> ExecutionGadget<F> for DupGadget<F> {
@@ -28,15 +31,15 @@ impl<F: Field> ExecutionGadget<F> for DupGadget<F> {
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
         let opcode = cb.query_cell();
 
-        let value = cb.query_cell_phase2();
+        let value = cb.query_word_unchecked();
 
         // The stack index we have to peek, deduced from the 'x' value of 'dupx'
         // The offset starts at 0 for DUP1
         let dup_offset = opcode.expr() - OpcodeId::DUP1.expr();
 
         // Peek the value at `dup_offset` and push the value on the stack
-        cb.stack_lookup(false.expr(), dup_offset, value.expr());
-        cb.stack_push(value.expr());
+        cb.stack_lookup_word(false.expr(), dup_offset, value.to_word());
+        cb.stack_push_word(value.to_word());
 
         // State transition
         let step_state_transition = StepStateTransition {
@@ -66,7 +69,7 @@ impl<F: Field> ExecutionGadget<F> for DupGadget<F> {
         self.same_context.assign_exec_step(region, offset, step)?;
 
         let value = block.get_rws(step, 0).stack_value();
-        self.value.assign(region, offset, region.word_rlc(value))?;
+        self.value.assign_u256(region, offset, value)?;
 
         Ok(())
     }

--- a/zkevm-circuits/src/evm_circuit/execution/end_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/end_tx.rs
@@ -150,7 +150,7 @@ impl<F: Field> ExecutionGadget<F> for EndTxGadget<F> {
         cb.condition(
             cb.next.execution_state_selector([ExecutionState::BeginTx]),
             |cb| {
-                cb.call_context_lookup_write_unchecked(
+                cb.call_context_lookup_write(
                     Some(cb.next.state.rw_counter.expr()),
                     CallContextFieldTag::TxId,
                     // tx_id has been lookup and range_check above

--- a/zkevm-circuits/src/evm_circuit/execution/error_invalid_jump.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_invalid_jump.rs
@@ -12,7 +12,7 @@ use crate::{
         witness::{Block, Call, ExecStep, Transaction},
     },
     util::{
-        word::{Word, Word32Cell, WordExpr},
+        word::{Word, WordCell, WordExpr},
         Expr,
     },
 };
@@ -29,8 +29,8 @@ pub(crate) struct ErrorInvalidJumpGadget<F> {
     is_code: Cell<F>,
     is_jump_dest: IsEqualGadget<F>,
     is_jumpi: IsEqualGadget<F>,
-    condition: Word32Cell<F>,
-    is_condition_zero: IsZeroWordGadget<F, Word32Cell<F>>,
+    condition: WordCell<F>,
+    is_condition_zero: IsZeroWordGadget<F, WordCell<F>>,
     common_error_gadget: CommonErrorGadget<F>,
 }
 
@@ -46,7 +46,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorInvalidJumpGadget<F> {
         let opcode = cb.query_cell();
         let value = cb.query_cell();
         let is_code = cb.query_cell();
-        let condition = cb.query_word32();
+        let condition = cb.query_word_unchecked();
 
         cb.require_in_set(
             "ErrorInvalidJump only happend in JUMP or JUMPI",

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_call.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_call.rs
@@ -11,7 +11,7 @@ use crate::{
         },
     },
     table::CallContextFieldTag,
-    util::{word::Word, Expr},
+    util::Expr,
     witness::{Block, Call, ExecStep, Transaction},
 };
 use bus_mapping::evm::OpcodeId;
@@ -64,10 +64,10 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGCallGadget<F> {
 
         // Add callee to access list
         let is_warm = cb.query_bool();
-        cb.account_access_list_read_word(
+        cb.account_access_list_read(
             tx_id.expr(),
             call_gadget.callee_address_word(),
-            Word::from_lo_unchecked(is_warm.expr()),
+            is_warm.expr(),
         );
 
         cb.condition(call_gadget.has_value.expr(), |cb| {

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_call.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_call.rs
@@ -11,7 +11,7 @@ use crate::{
         },
     },
     table::CallContextFieldTag,
-    util::Expr,
+    util::{word::Word, Expr},
     witness::{Block, Call, ExecStep, Transaction},
 };
 use bus_mapping::evm::OpcodeId;
@@ -64,10 +64,10 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGCallGadget<F> {
 
         // Add callee to access list
         let is_warm = cb.query_bool();
-        cb.account_access_list_read(
+        cb.account_access_list_read_word(
             tx_id.expr(),
-            call_gadget.callee_address_expr(),
-            is_warm.expr(),
+            call_gadget.callee_address_word(),
+            Word::from_lo_unchecked(is_warm.expr()),
         );
 
         cb.condition(call_gadget.has_value.expr(), |cb| {

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_log.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_log.rs
@@ -13,7 +13,7 @@ use crate::{
         witness::{Block, Call, ExecStep, Transaction},
     },
     table::CallContextFieldTag,
-    util::Expr,
+    util::{word::WordExpr, Expr},
 };
 use eth_types::{
     evm_types::{GasCost, OpcodeId},
@@ -41,12 +41,12 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGLogGadget<F> {
 
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
         let opcode = cb.query_cell();
-        let mstart = cb.query_cell_phase2();
-        let msize = cb.query_word_rlc();
+        let mstart = cb.query_word_unchecked();
+        let msize = cb.query_memory_address();
 
         // Pop mstart_address, msize from stack
-        cb.stack_pop(mstart.expr());
-        cb.stack_pop(msize.expr());
+        cb.stack_pop_word(mstart.to_word());
+        cb.stack_pop_word(msize.to_word());
 
         // constrain not in static call
         let is_static_call = cb.call_context(None, CallContextFieldTag::IsStatic);

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_memory_copy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_memory_copy.rs
@@ -6,15 +6,17 @@ use crate::{
         util::{
             common_gadget::CommonErrorGadget,
             constraint_builder::{ConstrainBuilderCommon, EVMConstraintBuilder},
-            from_bytes,
             math_gadget::{IsZeroGadget, LtGadget},
             memory_gadget::{MemoryAddressGadget, MemoryCopierGasGadget, MemoryExpansionGadget},
-            select, CachedRegion, Cell, Word,
+            select, AccountAddress, CachedRegion, Cell,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
     table::CallContextFieldTag,
-    util::Expr,
+    util::{
+        word::{Word, WordCell, WordExpr},
+        Expr,
+    },
 };
 use eth_types::{
     evm_types::{GasCost, OpcodeId},
@@ -32,9 +34,9 @@ pub(crate) struct ErrorOOGMemoryCopyGadget<F> {
     is_warm: Cell<F>,
     tx_id: Cell<F>,
     /// Extra stack pop for `EXTCODECOPY`
-    external_address: Word<F>,
+    external_address: AccountAddress<F>,
     /// Source offset
-    src_offset: Word<F>,
+    src_offset: WordCell<F>,
     /// Destination offset and size to copy
     dst_memory_addr: MemoryAddressGadget<F>,
     memory_expansion: MemoryExpansionGadget<F, 1, N_BYTES_MEMORY_WORD_SIZE>,
@@ -62,10 +64,10 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGMemoryCopyGadget<F> {
             ],
         );
 
-        let dst_offset = cb.query_cell_phase2();
-        let src_offset = cb.query_word_rlc();
-        let copy_size = cb.query_word_rlc();
-        let external_address = cb.query_word_rlc();
+        let dst_offset = cb.query_word_unchecked();
+        let src_offset = cb.query_word_unchecked();
+        let copy_size = cb.query_memory_address();
+        let external_address = cb.query_account_address();
         let is_warm = cb.query_bool();
         let tx_id = cb.query_cell();
 
@@ -73,22 +75,26 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGMemoryCopyGadget<F> {
             IsZeroGadget::construct(cb, opcode.expr() - OpcodeId::EXTCODECOPY.expr());
 
         cb.condition(is_extcodecopy.expr(), |cb| {
-            cb.call_context_lookup(false.expr(), None, CallContextFieldTag::TxId, tx_id.expr());
+            cb.call_context_lookup_read(
+                None,
+                CallContextFieldTag::TxId,
+                Word::from_lo_unchecked(tx_id.expr()),
+            );
 
             // Check if EXTCODECOPY external address is warm.
-            cb.account_access_list_read(
+            cb.account_access_list_read_word(
                 tx_id.expr(),
-                from_bytes::expr(&external_address.cells[..N_BYTES_ACCOUNT_ADDRESS]),
-                is_warm.expr(),
+                external_address.to_word(),
+                Word::from_lo_unchecked(is_warm.expr()),
             );
 
             // EXTCODECOPY has an extra stack pop for external address.
-            cb.stack_pop(external_address.expr());
+            cb.stack_pop_word(external_address.to_word());
         });
 
-        cb.stack_pop(dst_offset.expr());
-        cb.stack_pop(src_offset.expr());
-        cb.stack_pop(copy_size.expr());
+        cb.stack_pop_word(dst_offset.to_word());
+        cb.stack_pop_word(src_offset.to_word());
+        cb.stack_pop_word(copy_size.to_word());
 
         let dst_memory_addr = MemoryAddressGadget::construct(cb, dst_offset, copy_size);
         let memory_expansion = MemoryExpansionGadget::construct(cb, [dst_memory_addr.address()]);
@@ -184,10 +190,14 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGMemoryCopyGadget<F> {
             .assign(region, offset, Value::known(F::from(u64::from(is_warm))))?;
         self.tx_id
             .assign(region, offset, Value::known(F::from(transaction.id as u64)))?;
-        self.external_address
-            .assign(region, offset, Some(external_address.to_le_bytes()))?;
-        self.src_offset
-            .assign(region, offset, Some(src_offset.to_le_bytes()))?;
+        self.external_address.assign(
+            region,
+            offset,
+            external_address.to_le_bytes()[0..N_BYTES_ACCOUNT_ADDRESS]
+                .try_into()
+                .ok(),
+        )?;
+        self.src_offset.assign_u256(region, offset, src_offset)?;
         let memory_addr = self
             .dst_memory_addr
             .assign(region, offset, dst_offset, copy_size)?;

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_memory_copy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_memory_copy.rs
@@ -82,11 +82,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGMemoryCopyGadget<F> {
             );
 
             // Check if EXTCODECOPY external address is warm.
-            cb.account_access_list_read_word(
-                tx_id.expr(),
-                external_address.to_word(),
-                Word::from_lo_unchecked(is_warm.expr()),
-            );
+            cb.account_access_list_read(tx_id.expr(), external_address.to_word(), is_warm.expr());
 
             // EXTCODECOPY has an extra stack pop for external address.
             cb.stack_pop_word(external_address.to_word());

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_memory_copy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_memory_copy.rs
@@ -1,7 +1,7 @@
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
-        param::{N_BYTES_ACCOUNT_ADDRESS, N_BYTES_GAS, N_BYTES_MEMORY_WORD_SIZE},
+        param::{N_BYTES_GAS, N_BYTES_MEMORY_WORD_SIZE},
         step::ExecutionState,
         util::{
             common_gadget::CommonErrorGadget,
@@ -20,7 +20,7 @@ use crate::{
 };
 use eth_types::{
     evm_types::{GasCost, OpcodeId},
-    Field, ToLittleEndian, U256,
+    Field, U256,
 };
 use halo2_proofs::{circuit::Value, plonk::Error};
 
@@ -186,13 +186,8 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGMemoryCopyGadget<F> {
             .assign(region, offset, Value::known(F::from(u64::from(is_warm))))?;
         self.tx_id
             .assign(region, offset, Value::known(F::from(transaction.id as u64)))?;
-        self.external_address.assign(
-            region,
-            offset,
-            external_address.to_le_bytes()[0..N_BYTES_ACCOUNT_ADDRESS]
-                .try_into()
-                .ok(),
-        )?;
+        self.external_address
+            .assign_u256(region, offset, external_address)?;
         self.src_offset.assign_u256(region, offset, src_offset)?;
         let memory_addr = self
             .dst_memory_addr

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_sload_sstore.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_sload_sstore.rs
@@ -16,11 +16,14 @@ use crate::{
         witness::{Block, Call, ExecStep, Transaction},
     },
     table::CallContextFieldTag,
-    util::Expr,
+    util::{
+        word::{Word, WordCell, WordExpr},
+        Expr,
+    },
 };
 use eth_types::{
     evm_types::{GasCost, OpcodeId},
-    Field, ToScalar, U256,
+    Field, U256,
 };
 use halo2_proofs::{circuit::Value, plonk::Error};
 
@@ -31,14 +34,14 @@ pub(crate) struct ErrorOOGSloadSstoreGadget<F> {
     opcode: Cell<F>,
     tx_id: Cell<F>,
     is_static: Cell<F>,
-    callee_address: Cell<F>,
-    phase2_key: Cell<F>,
-    phase2_value: Cell<F>,
-    phase2_value_prev: Cell<F>,
-    phase2_original_value: Cell<F>,
+    callee_address: WordCell<F>,
+    key: WordCell<F>,
+    value: WordCell<F>,
+    value_prev: WordCell<F>,
+    original_value: WordCell<F>,
     is_warm: Cell<F>,
     is_sstore: PairSelectGadget<F>,
-    sstore_gas_cost: SstoreGasGadget<F>,
+    sstore_gas_cost: SstoreGasGadget<F, WordCell<F>>,
     insufficient_gas_cost: LtGadget<F, N_BYTES_GAS>,
     // Constrain for SSTORE reentrancy sentry.
     insufficient_gas_sentry: LtGadget<F, N_BYTES_GAS>,
@@ -62,43 +65,43 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGSloadSstoreGadget<F> {
 
         let tx_id = cb.call_context(None, CallContextFieldTag::TxId);
         let is_static = cb.call_context(None, CallContextFieldTag::IsStatic);
-        let callee_address = cb.call_context(None, CallContextFieldTag::CalleeAddress);
+        let callee_address = cb.call_context_read_as_word(None, CallContextFieldTag::CalleeAddress);
 
         // Constrain `is_static` must be false for SSTORE.
         cb.require_zero("is_static == false", is_static.expr() * is_sstore.expr().0);
 
-        let phase2_key = cb.query_cell_phase2();
-        let phase2_value = cb.query_cell_phase2();
-        let phase2_value_prev = cb.query_cell_phase2();
-        let phase2_original_value = cb.query_cell_phase2();
+        let key = cb.query_word_unchecked();
+        let value = cb.query_word_unchecked();
+        let value_prev = cb.query_word_unchecked();
+        let original_value = cb.query_word_unchecked();
         let is_warm = cb.query_bool();
 
-        cb.stack_pop(phase2_key.expr());
-        cb.account_storage_access_list_read(
+        cb.stack_pop_word(key.to_word());
+        cb.account_storage_access_list_read_word(
             tx_id.expr(),
-            callee_address.expr(),
-            phase2_key.expr(),
-            is_warm.expr(),
+            callee_address.to_word(),
+            key.to_word(),
+            Word::from_lo_unchecked(is_warm.expr()),
         );
 
         let sload_gas_cost = SloadGasGadget::construct(cb, is_warm.expr());
         let sstore_gas_cost = cb.condition(is_sstore.expr().0, |cb| {
-            cb.stack_pop(phase2_value.expr());
+            cb.stack_pop_word(value.to_word());
 
-            cb.account_storage_read(
-                callee_address.expr(),
-                phase2_key.expr(),
-                phase2_value_prev.expr(),
+            cb.account_storage_read_word(
+                callee_address.to_word(),
+                key.to_word(),
+                value_prev.to_word(),
                 tx_id.expr(),
-                phase2_original_value.expr(),
+                original_value.to_word(),
             );
 
             SstoreGasGadget::construct(
                 cb,
-                phase2_value.clone(),
-                phase2_value_prev.clone(),
-                phase2_original_value.clone(),
                 is_warm.clone(),
+                value.clone(),
+                value_prev.clone(),
+                original_value.clone(),
             )
         });
 
@@ -137,10 +140,10 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGSloadSstoreGadget<F> {
             tx_id,
             is_static,
             callee_address,
-            phase2_key,
-            phase2_value,
-            phase2_value_prev,
-            phase2_original_value,
+            key,
+            value,
+            value_prev,
+            original_value,
             is_warm,
             is_sstore,
             sstore_gas_cost,
@@ -189,23 +192,13 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGSloadSstoreGadget<F> {
             .assign(region, offset, Value::known(F::from(tx.id as u64)))?;
         self.is_static
             .assign(region, offset, Value::known(F::from(call.is_static as u64)))?;
-        self.callee_address.assign(
-            region,
-            offset,
-            Value::known(
-                call.address
-                    .to_scalar()
-                    .expect("unexpected Address -> Scalar conversion failure"),
-            ),
-        )?;
-        self.phase2_key
-            .assign(region, offset, region.word_rlc(key))?;
-        self.phase2_value
-            .assign(region, offset, region.word_rlc(value))?;
-        self.phase2_value_prev
-            .assign(region, offset, region.word_rlc(value_prev))?;
-        self.phase2_original_value
-            .assign(region, offset, region.word_rlc(original_value))?;
+        self.callee_address
+            .assign_h160(region, offset, call.address)?;
+        self.key.assign_u256(region, offset, key)?;
+        self.value.assign_u256(region, offset, value)?;
+        self.value_prev.assign_u256(region, offset, value_prev)?;
+        self.original_value
+            .assign_u256(region, offset, original_value)?;
         self.is_warm
             .assign(region, offset, Value::known(F::from(is_warm as u64)))?;
 

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_static_memory.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_static_memory.rs
@@ -7,11 +7,14 @@ use crate::{
             constraint_builder::EVMConstraintBuilder,
             math_gadget::{IsEqualGadget, IsZeroGadget, RangeCheckGadget},
             memory_gadget::{address_high, address_low, MemoryExpansionGadget},
-            CachedRegion, Cell, Word,
+            CachedRegion, Cell,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
-    util::Expr,
+    util::{
+        word::{Word32Cell, WordExpr},
+        Expr,
+    },
 };
 use eth_types::{evm_types::OpcodeId, Field, ToLittleEndian};
 use halo2_proofs::plonk::Error;
@@ -19,7 +22,7 @@ use halo2_proofs::plonk::Error;
 #[derive(Clone, Debug)]
 pub(crate) struct ErrorOOGStaticMemoryGadget<F> {
     opcode: Cell<F>,
-    address: Word<F>,
+    address: Word32Cell<F>,
     address_in_range: IsZeroGadget<F>,
     // Allow memory size to expand to 5 bytes, because memory address could be
     // at most 2^40 - 1, after constant division by 32, the memory word size
@@ -45,7 +48,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGStaticMemoryGadget<F> {
         let opcode = cb.query_cell();
 
         // Query address by a full word
-        let address = cb.query_word_rlc();
+        let address = cb.query_word32();
 
         // Check if this is an MSTORE8
         let is_mstore8 = IsEqualGadget::construct(cb, opcode.expr(), OpcodeId::MSTORE8.expr());
@@ -54,11 +57,11 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGStaticMemoryGadget<F> {
         // Get the next memory size and the gas cost for this memory access
         let memory_expansion = MemoryExpansionGadget::construct(
             cb,
-            [address_low::expr(&address) + 1.expr() + (is_not_mstore8 * 31.expr())],
+            [address_low::expr_word(&address) + 1.expr() + (is_not_mstore8 * 31.expr())],
         );
 
         // Check if the memory address is too large
-        let address_in_range = IsZeroGadget::construct(cb, address_high::expr(&address));
+        let address_in_range = IsZeroGadget::construct(cb, address_high::expr_word(&address));
         // Check if the amount of gas available is less than the amount of gas
         // required
         let insufficient_gas = cb.condition(address_in_range.expr(), |cb| {
@@ -71,7 +74,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGStaticMemoryGadget<F> {
 
         // Pop the address from the stack
         // We still have to do this to verify the correctness of `address`
-        cb.stack_pop(address.expr());
+        cb.stack_pop_word(address.to_word());
 
         // TODO: Use ContextSwitchGadget to switch call context to caller's and
         // consume all gas_left.
@@ -99,8 +102,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGStaticMemoryGadget<F> {
 
         // Inputs/Outputs
         let address = block.get_rws(step, 0).stack_value();
-        self.address
-            .assign(region, offset, Some(address.to_le_bytes()))?;
+        self.address.assign_u256(region, offset, address)?;
 
         // Check if this is an MSTORE8
         let is_mstore8 = self.is_mstore8.assign(

--- a/zkevm-circuits/src/evm_circuit/execution/error_return_data_oo_bound.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_return_data_oo_bound.rs
@@ -8,12 +8,15 @@ use crate::{
             constraint_builder::{ConstrainBuilderCommon, EVMConstraintBuilder},
             from_bytes,
             math_gadget::{AddWordsGadget, IsZeroGadget, LtGadget},
-            not, or, sum, CachedRegion, Cell,
+            not, or, sum, CachedRegion, Cell, U64Cell,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
     table::CallContextFieldTag,
-    util::Expr,
+    util::{
+        word::{Word, WordExpr},
+        Expr,
+    },
 };
 use eth_types::{evm_types::OpcodeId, Field, ToLittleEndian, ToScalar};
 use halo2_proofs::{circuit::Value, plonk::Error};
@@ -21,7 +24,7 @@ use halo2_proofs::{circuit::Value, plonk::Error};
 #[derive(Clone, Debug)]
 pub(crate) struct ErrorReturnDataOutOfBoundGadget<F> {
     opcode: Cell<F>,
-    memory_offset: Cell<F>,
+    memory_offset: U64Cell<F>,
     sum: AddWordsGadget<F, 2, false>,
     // Hold the size of the last callee return data.
     return_data_length: Cell<F>,
@@ -40,10 +43,10 @@ impl<F: Field> ExecutionGadget<F> for ErrorReturnDataOutOfBoundGadget<F> {
 
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
         let opcode = cb.query_cell();
-        let memory_offset = cb.query_cell();
-        let data_offset = cb.query_word_rlc();
-        let size = cb.query_word_rlc();
-        let remainder_end = cb.query_word_rlc();
+        let memory_offset = cb.query_u64();
+        let data_offset = cb.query_word32();
+        let size = cb.query_word32();
+        let remainder_end = cb.query_word32();
         let return_data_length = cb.query_cell();
 
         cb.require_equal(
@@ -53,34 +56,33 @@ impl<F: Field> ExecutionGadget<F> for ErrorReturnDataOutOfBoundGadget<F> {
         );
 
         // Pop memory_offset, offset, size from stack
-        cb.stack_pop(memory_offset.expr());
-        cb.stack_pop(data_offset.expr());
-        cb.stack_pop(size.expr());
+        cb.stack_pop_word(memory_offset.to_word());
+        cb.stack_pop_word(data_offset.to_word());
+        cb.stack_pop_word(size.to_word());
 
         // Read last callee return data length
-        cb.call_context_lookup(
-            false.expr(),
+        cb.call_context_lookup_read(
             None,
             CallContextFieldTag::LastCalleeReturnDataLength,
-            return_data_length.expr(),
+            Word::from_lo_unchecked(return_data_length.expr()),
         );
 
         // Check if `data_offset` is Uint64 overflow.
-        let data_offset_larger_u64 = sum::expr(&data_offset.cells[N_BYTES_U64..]);
+        let data_offset_larger_u64 = sum::expr(&data_offset.limbs[N_BYTES_U64..]);
         let is_data_offset_within_u64 = IsZeroGadget::construct(cb, data_offset_larger_u64);
 
         // Check if `remainder_end` is Uint64 overflow.
         let sum = AddWordsGadget::construct(cb, [data_offset, size], remainder_end.clone());
         let is_end_u256_overflow = sum.carry().as_ref().unwrap();
 
-        let remainder_end_larger_u64 = sum::expr(&remainder_end.cells[N_BYTES_U64..]);
+        let remainder_end_larger_u64 = sum::expr(&remainder_end.limbs[N_BYTES_U64..]);
         let is_remainder_end_within_u64 = IsZeroGadget::construct(cb, remainder_end_larger_u64);
 
         // check if `remainder_end` exceeds return data length.
         let is_remainder_end_exceed_len = LtGadget::construct(
             cb,
             return_data_length.expr(),
-            from_bytes::expr(&remainder_end.cells[..N_BYTES_U64]),
+            from_bytes::expr(&remainder_end.limbs[..N_BYTES_U64]),
         );
 
         // Need to check if `data_offset + size` is U256 overflow via `AddWordsGadget` carry. If
@@ -132,7 +134,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorReturnDataOutOfBoundGadget<F> {
             [0, 1, 2].map(|index| block.get_rws(step, index).stack_value());
 
         self.memory_offset
-            .assign(region, offset, Value::known(F::from(dest_offset.as_u64())))?;
+            .assign(region, offset, Some(dest_offset.as_u64().to_le_bytes()))?;
 
         let remainder_end = data_offset.overflowing_add(size).0;
         self.sum

--- a/zkevm-circuits/src/evm_circuit/execution/error_write_protection.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_write_protection.rs
@@ -1,7 +1,6 @@
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
-        param::N_BYTES_ACCOUNT_ADDRESS,
         step::ExecutionState,
         util::{
             common_gadget::CommonErrorGadget,
@@ -17,7 +16,7 @@ use crate::{
         Expr,
     },
 };
-use eth_types::{evm_types::OpcodeId, Field, ToLittleEndian, U256};
+use eth_types::{evm_types::OpcodeId, Field, U256};
 use halo2_proofs::{circuit::Value, plonk::Error};
 
 #[derive(Clone, Debug)]
@@ -120,13 +119,8 @@ impl<F: Field> ExecutionGadget<F> for ErrorWriteProtectionGadget<F> {
         }
 
         self.gas.assign_u256(region, offset, gas)?;
-        self.code_address.assign(
-            region,
-            offset,
-            code_address.to_le_bytes()[0..N_BYTES_ACCOUNT_ADDRESS]
-                .try_into()
-                .ok(),
-        )?;
+        self.code_address
+            .assign_u256(region, offset, code_address)?;
         self.value.assign_u256(region, offset, value)?;
 
         self.is_call.assign(

--- a/zkevm-circuits/src/evm_circuit/execution/error_write_protection.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_write_protection.rs
@@ -73,11 +73,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorWriteProtectionGadget<F> {
         });
 
         // current call context is readonly
-        cb.call_context_lookup_read(
-            None,
-            CallContextFieldTag::IsStatic,
-            Word::from_lo_unchecked(1.expr()),
-        );
+        cb.call_context_lookup_read(None, CallContextFieldTag::IsStatic, Word::one());
 
         // constrain not root call as at least one previous staticcall preset.
         cb.require_zero(

--- a/zkevm-circuits/src/evm_circuit/execution/error_write_protection.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_write_protection.rs
@@ -1,17 +1,21 @@
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
+        param::N_BYTES_ACCOUNT_ADDRESS,
         step::ExecutionState,
         util::{
             common_gadget::CommonErrorGadget,
             constraint_builder::{ConstrainBuilderCommon, EVMConstraintBuilder},
-            math_gadget::IsZeroGadget,
-            sum, CachedRegion, Cell, Word as RLCWord,
+            math_gadget::{IsZeroGadget, IsZeroWordGadget},
+            AccountAddress, CachedRegion, Cell,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
     table::CallContextFieldTag,
-    util::Expr,
+    util::{
+        word::{Word, WordCell, WordExpr},
+        Expr,
+    },
 };
 use eth_types::{evm_types::OpcodeId, Field, ToLittleEndian, U256};
 use halo2_proofs::{circuit::Value, plonk::Error};
@@ -20,10 +24,10 @@ use halo2_proofs::{circuit::Value, plonk::Error};
 pub(crate) struct ErrorWriteProtectionGadget<F> {
     opcode: Cell<F>,
     is_call: IsZeroGadget<F>,
-    gas: RLCWord<F>,
-    code_address: RLCWord<F>,
-    value: RLCWord<F>,
-    is_value_zero: IsZeroGadget<F>,
+    gas: WordCell<F>,
+    code_address: AccountAddress<F>,
+    value: WordCell<F>,
+    is_value_zero: IsZeroWordGadget<F, WordCell<F>>,
     common_error_gadget: CommonErrorGadget<F>,
 }
 
@@ -35,10 +39,10 @@ impl<F: Field> ExecutionGadget<F> for ErrorWriteProtectionGadget<F> {
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
         let opcode = cb.query_cell();
         let is_call = IsZeroGadget::construct(cb, opcode.expr() - OpcodeId::CALL.expr());
-        let gas_word = cb.query_word_rlc();
-        let code_address_word = cb.query_word_rlc();
-        let value = cb.query_word_rlc();
-        let is_value_zero = IsZeroGadget::construct(cb, value.expr());
+        let gas_word = cb.query_word_unchecked();
+        let code_address = cb.query_account_address();
+        let value = cb.query_word_unchecked();
+        let is_value_zero = IsZeroWordGadget::construct(cb, &value);
 
         // require_in_set method will spilit into more low degree expressions if exceed
         // max_degree. otherwise need to do fixed lookup for these opcodes
@@ -63,14 +67,18 @@ impl<F: Field> ExecutionGadget<F> for ErrorWriteProtectionGadget<F> {
         // Lookup values from stack if opcode is call
         // Precondition: If there's a StackUnderflow CALL, is handled before this error
         cb.condition(is_call.expr(), |cb| {
-            cb.stack_pop(gas_word.expr());
-            cb.stack_pop(code_address_word.expr());
-            cb.stack_pop(value.expr());
+            cb.stack_pop_word(gas_word.to_word());
+            cb.stack_pop_word(code_address.to_word());
+            cb.stack_pop_word(value.to_word());
             cb.require_zero("value of call is not zero", is_value_zero.expr());
         });
 
         // current call context is readonly
-        cb.call_context_lookup(false.expr(), None, CallContextFieldTag::IsStatic, 1.expr());
+        cb.call_context_lookup_read(
+            None,
+            CallContextFieldTag::IsStatic,
+            Word::from_lo_unchecked(1.expr()),
+        );
 
         // constrain not root call as at least one previous staticcall preset.
         cb.require_zero(
@@ -84,7 +92,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorWriteProtectionGadget<F> {
             opcode,
             is_call,
             gas: gas_word,
-            code_address: code_address_word,
+            code_address,
             value,
             is_value_zero,
             common_error_gadget,
@@ -111,11 +119,15 @@ impl<F: Field> ExecutionGadget<F> for ErrorWriteProtectionGadget<F> {
                 [0, 1, 2].map(|index| block.get_rws(step, index).stack_value());
         }
 
-        self.gas.assign(region, offset, Some(gas.to_le_bytes()))?;
-        self.code_address
-            .assign(region, offset, Some(code_address.to_le_bytes()))?;
-        self.value
-            .assign(region, offset, Some(value.to_le_bytes()))?;
+        self.gas.assign_u256(region, offset, gas)?;
+        self.code_address.assign(
+            region,
+            offset,
+            code_address.to_le_bytes()[0..N_BYTES_ACCOUNT_ADDRESS]
+                .try_into()
+                .ok(),
+        )?;
+        self.value.assign_u256(region, offset, value)?;
 
         self.is_call.assign(
             region,
@@ -123,7 +135,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorWriteProtectionGadget<F> {
             F::from(opcode.as_u64()) - F::from(OpcodeId::CALL.as_u64()),
         )?;
         self.is_value_zero
-            .assign(region, offset, sum::value(&value.to_le_bytes()))?;
+            .assign(region, offset, Word::from(value))?;
 
         self.common_error_gadget.assign(
             region,

--- a/zkevm-circuits/src/evm_circuit/execution/extcodecopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodecopy.rs
@@ -75,11 +75,11 @@ impl<F: Field> ExecutionGadget<F> for ExtcodecopyGadget<F> {
         let tx_id = cb.call_context(None, CallContextFieldTag::TxId);
         let mut reversion_info = cb.reversion_info_read(None);
         let is_warm = cb.query_bool();
-        cb.account_access_list_write_word(
+        cb.account_access_list_write(
             tx_id.expr(),
             external_address.to_word(),
-            Word::from_lo_unchecked(1.expr()),
-            Word::from_lo_unchecked(is_warm.expr()),
+            1.expr(),
+            is_warm.expr(),
             Some(&mut reversion_info),
         );
 

--- a/zkevm-circuits/src/evm_circuit/execution/extcodecopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodecopy.rs
@@ -8,33 +8,36 @@ use crate::{
                 ConstrainBuilderCommon, EVMConstraintBuilder, ReversionInfo, StepStateTransition,
                 Transition,
             },
-            from_bytes,
-            math_gadget::IsZeroGadget,
+            math_gadget::IsZeroWordGadget,
             memory_gadget::{MemoryAddressGadget, MemoryCopierGasGadget, MemoryExpansionGadget},
-            not, select, CachedRegion, Cell, Word,
+            not, select, AccountAddress, CachedRegion, Cell,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
     table::{AccountFieldTag, CallContextFieldTag},
+    util::word::{Word, Word32Cell, WordExpr},
 };
 use bus_mapping::circuit_input_builder::CopyDataType;
-use eth_types::{evm_types::GasCost, Field, ToLittleEndian, ToScalar};
+use eth_types::{evm_types::GasCost, Field, ToScalar};
 use gadgets::util::Expr;
-use halo2_proofs::{circuit::Value, plonk::Error};
+use halo2_proofs::{
+    circuit::Value,
+    plonk::{Error, Expression},
+};
 
 use super::ExecutionGadget;
 
 #[derive(Clone, Debug)]
 pub(crate) struct ExtcodecopyGadget<F> {
     same_context: SameContextGadget<F>,
-    external_address_word: Word<F>,
+    external_address_word: Word32Cell<F>,
     memory_address: MemoryAddressGadget<F>,
     code_offset: WordByteCapGadget<F, N_BYTES_U64>,
     tx_id: Cell<F>,
     reversion_info: ReversionInfo<F>,
     is_warm: Cell<F>,
-    code_hash: Cell<F>,
-    not_exists: IsZeroGadget<F>,
+    code_hash: Word32Cell<F>,
+    not_exists: IsZeroWordGadget<F, Word<Expression<F>>>,
     code_size: Cell<F>,
     copy_rwc_inc: Cell<F>,
     memory_expansion: MemoryExpansionGadget<F, 1, N_BYTES_MEMORY_WORD_SIZE>,
@@ -49,42 +52,47 @@ impl<F: Field> ExecutionGadget<F> for ExtcodecopyGadget<F> {
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
         let opcode = cb.query_cell();
 
-        let external_address_word = cb.query_word_rlc();
-        let external_address =
-            from_bytes::expr(&external_address_word.cells[..N_BYTES_ACCOUNT_ADDRESS]);
+        let external_address_word = cb.query_word32();
+        let external_address = AccountAddress::new(
+            external_address_word.limbs[..N_BYTES_ACCOUNT_ADDRESS]
+                .to_vec()
+                .try_into()
+                .unwrap(),
+            256.expr(),
+        );
 
         let code_size = cb.query_cell();
 
-        let memory_length = cb.query_word_rlc();
-        let memory_offset = cb.query_cell_phase2();
+        let memory_length = cb.query_memory_address();
+        let memory_offset = cb.query_word_unchecked();
         let code_offset = WordByteCapGadget::construct(cb, code_size.expr());
 
-        cb.stack_pop(external_address_word.expr());
-        cb.stack_pop(memory_offset.expr());
-        cb.stack_pop(code_offset.original_word());
-        cb.stack_pop(memory_length.expr());
+        cb.stack_pop_word(external_address_word.to_word());
+        cb.stack_pop_word(memory_offset.to_word());
+        cb.stack_pop_word(code_offset.original_word_new().to_word());
+        cb.stack_pop_word(memory_length.to_word());
 
         let tx_id = cb.call_context(None, CallContextFieldTag::TxId);
         let mut reversion_info = cb.reversion_info_read(None);
         let is_warm = cb.query_bool();
-        cb.account_access_list_write(
+        cb.account_access_list_write_word(
             tx_id.expr(),
-            external_address.expr(),
-            1.expr(),
-            is_warm.expr(),
+            external_address.to_word(),
+            Word::from_lo_unchecked(1.expr()),
+            Word::from_lo_unchecked(is_warm.expr()),
             Some(&mut reversion_info),
         );
 
-        let code_hash = cb.query_cell_phase2();
-        cb.account_read(
-            external_address.expr(),
+        let code_hash = cb.query_word32();
+        cb.account_read_word(
+            external_address.to_word(),
             AccountFieldTag::CodeHash,
-            code_hash.expr(),
+            code_hash.to_word(),
         );
-        let not_exists = IsZeroGadget::construct(cb, code_hash.expr());
+        let not_exists = IsZeroWordGadget::construct(cb, &code_hash.to_word());
         let exists = not::expr(not_exists.expr());
         cb.condition(exists.expr(), |cb| {
-            cb.bytecode_length(code_hash.expr(), code_size.expr());
+            cb.bytecode_length_word(code_hash.to_word(), code_size.expr());
         });
         cb.condition(not_exists.expr(), |cb| {
             cb.require_zero("code_size is zero when non_exists", code_size.expr());
@@ -114,9 +122,9 @@ impl<F: Field> ExecutionGadget<F> for ExtcodecopyGadget<F> {
             );
 
             cb.copy_table_lookup(
-                code_hash.expr(),
+                code_hash.to_word(),
                 CopyDataType::Bytecode.expr(),
-                cb.curr.state.call_id.expr(),
+                Word::from_lo_unchecked(cb.curr.state.call_id.expr()),
                 CopyDataType::Memory.expr(),
                 src_addr,
                 code_size.expr(),
@@ -175,7 +183,7 @@ impl<F: Field> ExecutionGadget<F> for ExtcodecopyGadget<F> {
         let [external_address, memory_offset, code_offset, memory_length] =
             [0, 1, 2, 3].map(|idx| block.get_rws(step, idx).stack_value());
         self.external_address_word
-            .assign(region, offset, Some(external_address.to_le_bytes()))?;
+            .assign_u256(region, offset, external_address)?;
         let memory_address =
             self.memory_address
                 .assign(region, offset, memory_offset, memory_length)?;
@@ -194,10 +202,8 @@ impl<F: Field> ExecutionGadget<F> for ExtcodecopyGadget<F> {
             .assign(region, offset, Value::known(F::from(is_warm as u64)))?;
 
         let code_hash = block.get_rws(step, 8).account_value_pair().0;
-        self.code_hash
-            .assign(region, offset, region.word_rlc(code_hash))?;
-        self.not_exists
-            .assign_value(region, offset, region.word_rlc(code_hash))?;
+        self.code_hash.assign_u256(region, offset, code_hash)?;
+        self.not_exists.assign_u256(region, offset, code_hash)?;
 
         let code_size = if code_hash.is_zero() {
             0

--- a/zkevm-circuits/src/evm_circuit/execution/extcodecopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodecopy.rs
@@ -75,7 +75,7 @@ impl<F: Field> ExecutionGadget<F> for ExtcodecopyGadget<F> {
         let tx_id = cb.call_context(None, CallContextFieldTag::TxId);
         let mut reversion_info = cb.reversion_info_read(None);
         let is_warm = cb.query_bool();
-        cb.account_access_list_write(
+        cb.account_access_list_write_unchecked(
             tx_id.expr(),
             external_address.to_word(),
             1.expr(),

--- a/zkevm-circuits/src/evm_circuit/execution/extcodecopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodecopy.rs
@@ -58,7 +58,6 @@ impl<F: Field> ExecutionGadget<F> for ExtcodecopyGadget<F> {
                 .to_vec()
                 .try_into()
                 .unwrap(),
-            256.expr(),
         );
 
         let code_size = cb.query_cell();

--- a/zkevm-circuits/src/evm_circuit/execution/extcodehash.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodehash.rs
@@ -44,7 +44,6 @@ impl<F: Field> ExecutionGadget<F> for ExtcodehashGadget<F> {
                 .to_vec()
                 .try_into()
                 .unwrap(),
-            256.expr(),
         );
 
         let tx_id = cb.call_context(None, CallContextFieldTag::TxId);

--- a/zkevm-circuits/src/evm_circuit/execution/extcodehash.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodehash.rs
@@ -8,24 +8,27 @@ use crate::{
             constraint_builder::{
                 EVMConstraintBuilder, ReversionInfo, StepStateTransition, Transition::Delta,
             },
-            from_bytes, select, CachedRegion, Cell, Word,
+            select, AccountAddress, CachedRegion, Cell,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
     table::{AccountFieldTag, CallContextFieldTag},
-    util::Expr,
+    util::{
+        word::{Word, Word32Cell, WordCell, WordExpr},
+        Expr,
+    },
 };
-use eth_types::{evm_types::GasCost, Field, ToLittleEndian};
+use eth_types::{evm_types::GasCost, Field};
 use halo2_proofs::{circuit::Value, plonk::Error};
 
 #[derive(Clone, Debug)]
 pub(crate) struct ExtcodehashGadget<F> {
     same_context: SameContextGadget<F>,
-    address_word: Word<F>,
+    address_word: Word32Cell<F>,
     tx_id: Cell<F>,
     reversion_info: ReversionInfo<F>,
     is_warm: Cell<F>,
-    code_hash: Cell<F>,
+    code_hash: WordCell<F>,
 }
 
 impl<F: Field> ExecutionGadget<F> for ExtcodehashGadget<F> {
@@ -34,26 +37,37 @@ impl<F: Field> ExecutionGadget<F> for ExtcodehashGadget<F> {
     const EXECUTION_STATE: ExecutionState = ExecutionState::EXTCODEHASH;
 
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
-        let address_word = cb.query_word_rlc();
-        let address = from_bytes::expr(&address_word.cells[..N_BYTES_ACCOUNT_ADDRESS]);
-        cb.stack_pop(address_word.expr());
+        let address_word = cb.query_word32();
+        // let address = cb.query_account_address();
+        let address = AccountAddress::new(
+            address_word.limbs[..N_BYTES_ACCOUNT_ADDRESS]
+                .to_vec()
+                .try_into()
+                .unwrap(),
+            256.expr(),
+        );
 
         let tx_id = cb.call_context(None, CallContextFieldTag::TxId);
         let mut reversion_info = cb.reversion_info_read(None);
 
         let is_warm = cb.query_bool();
-        cb.account_access_list_write(
+        cb.account_access_list_write_word(
             tx_id.expr(),
-            address.expr(),
-            1.expr(),
-            is_warm.expr(),
+            address.to_word(),
+            Word::from_lo_unchecked(1.expr()),
+            Word::from_lo_unchecked(is_warm.expr()),
             Some(&mut reversion_info),
         );
 
-        let code_hash = cb.query_cell_phase2();
+        // range check will be cover by account code_hash lookup
+        let code_hash = cb.query_word_unchecked();
         // For non-existing accounts the code_hash must be 0 in the rw_table.
-        cb.account_read(address, AccountFieldTag::CodeHash, code_hash.expr());
-        cb.stack_push(code_hash.expr());
+        cb.account_read_word(
+            address.to_word(),
+            AccountFieldTag::CodeHash,
+            code_hash.to_word(),
+        );
+        cb.stack_push_word(code_hash.to_word());
 
         let gas_cost = select::expr(
             is_warm.expr(),
@@ -94,8 +108,7 @@ impl<F: Field> ExecutionGadget<F> for ExtcodehashGadget<F> {
         self.same_context.assign_exec_step(region, offset, step)?;
 
         let address = block.get_rws(step, 0).stack_value();
-        self.address_word
-            .assign(region, offset, Some(address.to_le_bytes()))?;
+        self.address_word.assign_u256(region, offset, address)?;
 
         self.tx_id
             .assign(region, offset, Value::known(F::from(tx.id as u64)))?;
@@ -111,8 +124,7 @@ impl<F: Field> ExecutionGadget<F> for ExtcodehashGadget<F> {
             .assign(region, offset, Value::known(F::from(is_warm as u64)))?;
 
         let code_hash = block.get_rws(step, 5).account_value_pair().0;
-        self.code_hash
-            .assign(region, offset, region.word_rlc(code_hash))?;
+        self.code_hash.assign_u256(region, offset, code_hash)?;
 
         Ok(())
     }

--- a/zkevm-circuits/src/evm_circuit/execution/extcodehash.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodehash.rs
@@ -38,13 +38,13 @@ impl<F: Field> ExecutionGadget<F> for ExtcodehashGadget<F> {
 
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
         let address_word = cb.query_word32();
-        // let address = cb.query_account_address();
         let address = AccountAddress::new(
             address_word.limbs[..N_BYTES_ACCOUNT_ADDRESS]
                 .to_vec()
                 .try_into()
                 .unwrap(),
         );
+        cb.stack_pop_word(address_word.to_word());
 
         let tx_id = cb.call_context(None, CallContextFieldTag::TxId);
         let mut reversion_info = cb.reversion_info_read(None);

--- a/zkevm-circuits/src/evm_circuit/execution/extcodehash.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodehash.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     table::{AccountFieldTag, CallContextFieldTag},
     util::{
-        word::{Word, Word32Cell, WordCell, WordExpr},
+        word::{Word32Cell, WordCell, WordExpr},
         Expr,
     },
 };
@@ -51,11 +51,11 @@ impl<F: Field> ExecutionGadget<F> for ExtcodehashGadget<F> {
         let mut reversion_info = cb.reversion_info_read(None);
 
         let is_warm = cb.query_bool();
-        cb.account_access_list_write_word(
+        cb.account_access_list_write(
             tx_id.expr(),
             address.to_word(),
-            Word::from_lo_unchecked(1.expr()),
-            Word::from_lo_unchecked(is_warm.expr()),
+            1.expr(),
+            is_warm.expr(),
             Some(&mut reversion_info),
         );
 

--- a/zkevm-circuits/src/evm_circuit/execution/extcodehash.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodehash.rs
@@ -51,7 +51,7 @@ impl<F: Field> ExecutionGadget<F> for ExtcodehashGadget<F> {
         let mut reversion_info = cb.reversion_info_read(None);
 
         let is_warm = cb.query_bool();
-        cb.account_access_list_write(
+        cb.account_access_list_write_unchecked(
             tx_id.expr(),
             address.to_word(),
             1.expr(),

--- a/zkevm-circuits/src/evm_circuit/execution/extcodesize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodesize.rs
@@ -47,7 +47,6 @@ impl<F: Field> ExecutionGadget<F> for ExtcodesizeGadget<F> {
                 .to_vec()
                 .try_into()
                 .unwrap(),
-            256.expr(),
         );
         cb.stack_pop_word(address_word.to_word());
 

--- a/zkevm-circuits/src/evm_circuit/execution/extcodesize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodesize.rs
@@ -54,7 +54,7 @@ impl<F: Field> ExecutionGadget<F> for ExtcodesizeGadget<F> {
         let tx_id = cb.call_context(None, CallContextFieldTag::TxId);
         let mut reversion_info = cb.reversion_info_read(None);
         let is_warm = cb.query_bool();
-        cb.account_access_list_write(
+        cb.account_access_list_write_unchecked(
             tx_id.expr(),
             address.to_word(),
             1.expr(),

--- a/zkevm-circuits/src/evm_circuit/execution/extcodesize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodesize.rs
@@ -1,7 +1,7 @@
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
-        param::{N_BYTES_ACCOUNT_ADDRESS, N_BYTES_U64},
+        param::N_BYTES_ACCOUNT_ADDRESS,
         step::ExecutionState,
         util::{
             common_gadget::SameContextGadget,
@@ -9,28 +9,30 @@ use crate::{
                 ConstrainBuilderCommon, EVMConstraintBuilder, ReversionInfo, StepStateTransition,
                 Transition::Delta,
             },
-            from_bytes,
-            math_gadget::IsZeroGadget,
-            not, select, CachedRegion, Cell, RandomLinearCombination, Word,
+            math_gadget::IsZeroWordGadget,
+            not, select, AccountAddress, CachedRegion, Cell, U64Cell,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
     table::{AccountFieldTag, CallContextFieldTag},
-    util::Expr,
+    util::{
+        word::{Word, Word32Cell, WordCell, WordExpr},
+        Expr,
+    },
 };
-use eth_types::{evm_types::GasCost, Field, ToLittleEndian};
+use eth_types::{evm_types::GasCost, Field};
 use halo2_proofs::{circuit::Value, plonk::Error};
 
 #[derive(Clone, Debug)]
 pub(crate) struct ExtcodesizeGadget<F> {
     same_context: SameContextGadget<F>,
-    address_word: Word<F>,
+    address_word: Word32Cell<F>,
     reversion_info: ReversionInfo<F>,
     tx_id: Cell<F>,
     is_warm: Cell<F>,
-    code_hash: Cell<F>,
-    not_exists: IsZeroGadget<F>,
-    code_size: RandomLinearCombination<F, N_BYTES_U64>,
+    code_hash: WordCell<F>,
+    not_exists: IsZeroWordGadget<F, WordCell<F>>,
+    code_size: U64Cell<F>,
 }
 
 impl<F: Field> ExecutionGadget<F> for ExtcodesizeGadget<F> {
@@ -39,36 +41,47 @@ impl<F: Field> ExecutionGadget<F> for ExtcodesizeGadget<F> {
     const EXECUTION_STATE: ExecutionState = ExecutionState::EXTCODESIZE;
 
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
-        let address_word = cb.query_word_rlc();
-        let address = from_bytes::expr(&address_word.cells[..N_BYTES_ACCOUNT_ADDRESS]);
-        cb.stack_pop(address_word.expr());
+        let address_word = cb.query_word32();
+        let address = AccountAddress::new(
+            address_word.limbs[..N_BYTES_ACCOUNT_ADDRESS]
+                .to_vec()
+                .try_into()
+                .unwrap(),
+            256.expr(),
+        );
+        cb.stack_pop_word(address_word.to_word());
 
         let tx_id = cb.call_context(None, CallContextFieldTag::TxId);
         let mut reversion_info = cb.reversion_info_read(None);
         let is_warm = cb.query_bool();
-        cb.account_access_list_write(
+        cb.account_access_list_write_word(
             tx_id.expr(),
-            address.expr(),
-            1.expr(),
-            is_warm.expr(),
+            address.to_word(),
+            Word::from_lo_unchecked(1.expr()),
+            Word::from_lo_unchecked(is_warm.expr()),
             Some(&mut reversion_info),
         );
 
-        let code_hash = cb.query_cell_phase2();
+        // range check will be cover by account code_hash lookup
+        let code_hash = cb.query_word_unchecked();
         // For non-existing accounts the code_hash must be 0 in the rw_table.
-        cb.account_read(address.expr(), AccountFieldTag::CodeHash, code_hash.expr());
-        let not_exists = IsZeroGadget::construct(cb, code_hash.expr());
+        cb.account_read_word(
+            address.to_word(),
+            AccountFieldTag::CodeHash,
+            code_hash.to_word(),
+        );
+        let not_exists = IsZeroWordGadget::construct(cb, &code_hash);
         let exists = not::expr(not_exists.expr());
 
-        let code_size = cb.query_word_rlc();
+        let code_size = cb.query_u64();
         cb.condition(exists.expr(), |cb| {
-            cb.bytecode_length(code_hash.expr(), from_bytes::expr(&code_size.cells));
+            cb.bytecode_length_word(code_hash.to_word(), code_size.expr());
         });
         cb.condition(not_exists.expr(), |cb| {
             cb.require_zero("code_size is zero when non_exists", code_size.expr());
         });
 
-        cb.stack_push(code_size.expr());
+        cb.stack_push_word(code_size.to_word());
 
         let gas_cost = select::expr(
             is_warm.expr(),
@@ -112,8 +125,7 @@ impl<F: Field> ExecutionGadget<F> for ExtcodesizeGadget<F> {
         self.same_context.assign_exec_step(region, offset, step)?;
 
         let address = block.get_rws(step, 0).stack_value();
-        self.address_word
-            .assign(region, offset, Some(address.to_le_bytes()))?;
+        self.address_word.assign_u256(region, offset, address)?;
 
         self.tx_id
             .assign(region, offset, Value::known(F::from(tx.id as u64)))?;
@@ -130,10 +142,9 @@ impl<F: Field> ExecutionGadget<F> for ExtcodesizeGadget<F> {
             .assign(region, offset, Value::known(F::from(is_warm as u64)))?;
 
         let code_hash = block.get_rws(step, 5).account_value_pair().0;
-        self.code_hash
-            .assign(region, offset, region.word_rlc(code_hash))?;
+        self.code_hash.assign_u256(region, offset, code_hash)?;
         self.not_exists
-            .assign_value(region, offset, region.word_rlc(code_hash))?;
+            .assign(region, offset, Word::from(code_hash))?;
 
         let code_size = block.get_rws(step, 6).stack_value().as_u64();
         self.code_size

--- a/zkevm-circuits/src/evm_circuit/execution/extcodesize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodesize.rs
@@ -54,11 +54,11 @@ impl<F: Field> ExecutionGadget<F> for ExtcodesizeGadget<F> {
         let tx_id = cb.call_context(None, CallContextFieldTag::TxId);
         let mut reversion_info = cb.reversion_info_read(None);
         let is_warm = cb.query_bool();
-        cb.account_access_list_write_word(
+        cb.account_access_list_write(
             tx_id.expr(),
             address.to_word(),
-            Word::from_lo_unchecked(1.expr()),
-            Word::from_lo_unchecked(is_warm.expr()),
+            1.expr(),
+            is_warm.expr(),
             Some(&mut reversion_info),
         );
 

--- a/zkevm-circuits/src/evm_circuit/execution/gas.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/gas.rs
@@ -1,7 +1,6 @@
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
-        param::N_BYTES_GAS,
         step::ExecutionState,
         util::{
             common_gadget::SameContextGadget,
@@ -9,11 +8,11 @@ use crate::{
                 ConstrainBuilderCommon, EVMConstraintBuilder, StepStateTransition,
                 Transition::Delta,
             },
-            from_bytes, CachedRegion, RandomLinearCombination,
+            CachedRegion, U64Cell,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
-    util::Expr,
+    util::{word::WordExpr, Expr},
 };
 use eth_types::{evm_types::OpcodeId, Field};
 use halo2_proofs::plonk::Error;
@@ -21,7 +20,7 @@ use halo2_proofs::plonk::Error;
 #[derive(Clone, Debug)]
 pub(crate) struct GasGadget<F> {
     same_context: SameContextGadget<F>,
-    gas_left: RandomLinearCombination<F, N_BYTES_GAS>,
+    gas_left: U64Cell<F>,
 }
 
 impl<F: Field> ExecutionGadget<F> for GasGadget<F> {
@@ -31,18 +30,18 @@ impl<F: Field> ExecutionGadget<F> for GasGadget<F> {
 
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
         // The gas passed to a transaction is a 64-bit number.
-        let gas_left = cb.query_word_rlc();
+        let gas_left = cb.query_u64();
 
         // The `gas_left` in the current state has to be deducted by the gas
         // used by the `GAS` opcode itself.
         cb.require_equal(
             "Constraint: gas left equal to stack value",
-            from_bytes::expr(&gas_left.cells),
+            gas_left.expr(),
             cb.curr.state.gas_left.expr() - OpcodeId::GAS.constant_gas_cost().expr(),
         );
 
         // Construct the value and push it to stack.
-        cb.stack_push(gas_left.expr());
+        cb.stack_push_word(gas_left.to_word());
 
         let step_state_transition = StepStateTransition {
             rw_counter: Delta(1.expr()),

--- a/zkevm-circuits/src/evm_circuit/execution/gasprice.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/gasprice.rs
@@ -10,7 +10,10 @@ use crate::{
         witness::{Block, Call, ExecStep, Transaction},
     },
     table::{CallContextFieldTag, TxContextFieldTag},
-    util::Expr,
+    util::{
+        word::{WordCell, WordExpr},
+        Expr,
+    },
 };
 use bus_mapping::evm::OpcodeId;
 use eth_types::Field;
@@ -19,7 +22,7 @@ use halo2_proofs::{circuit::Value, plonk::Error};
 #[derive(Clone, Debug)]
 pub(crate) struct GasPriceGadget<F> {
     tx_id: Cell<F>,
-    gas_price: Cell<F>,
+    gas_price: WordCell<F>,
     same_context: SameContextGadget<F>,
 }
 
@@ -30,20 +33,20 @@ impl<F: Field> ExecutionGadget<F> for GasPriceGadget<F> {
 
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
         // Query gasprice value
-        let gas_price = cb.query_cell_phase2();
+        let gas_price = cb.query_word_unchecked();
 
         // Lookup in call_ctx the TxId
         let tx_id = cb.call_context(None, CallContextFieldTag::TxId);
         // Lookup the gas_price in tx table
-        cb.tx_context_lookup(
+        cb.tx_context_lookup_word(
             tx_id.expr(),
             TxContextFieldTag::GasPrice,
             None,
-            gas_price.expr(),
+            gas_price.to_word(),
         );
 
         // Push the value to the stack
-        cb.stack_push(gas_price.expr());
+        cb.stack_push_word(gas_price.to_word());
 
         // State transition
         let opcode = cb.query_cell();
@@ -77,8 +80,7 @@ impl<F: Field> ExecutionGadget<F> for GasPriceGadget<F> {
         self.tx_id
             .assign(region, offset, Value::known(F::from(tx.id as u64)))?;
 
-        self.gas_price
-            .assign(region, offset, region.word_rlc(gas_price))?;
+        self.gas_price.assign_u256(region, offset, gas_price)?;
 
         self.same_context.assign_exec_step(region, offset, step)?;
 

--- a/zkevm-circuits/src/evm_circuit/execution/is_zero.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/is_zero.rs
@@ -5,21 +5,24 @@ use crate::{
         util::{
             common_gadget::SameContextGadget,
             constraint_builder::{EVMConstraintBuilder, StepStateTransition, Transition::Delta},
-            math_gadget, CachedRegion, Cell,
+            math_gadget, CachedRegion,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
-    util::Expr,
+    util::{
+        word::{Word, WordCell, WordExpr},
+        Expr,
+    },
 };
 use bus_mapping::evm::OpcodeId;
 use eth_types::Field;
-use halo2_proofs::plonk::Error;
+use halo2_proofs::{circuit::Value, plonk::Error};
 
 #[derive(Clone, Debug)]
 pub(crate) struct IsZeroGadget<F> {
     same_context: SameContextGadget<F>,
-    value: Cell<F>,
-    is_zero: math_gadget::IsZeroGadget<F>,
+    value: WordCell<F>,
+    is_zero_word: math_gadget::IsZeroWordGadget<F, WordCell<F>>,
 }
 
 impl<F: Field> ExecutionGadget<F> for IsZeroGadget<F> {
@@ -30,11 +33,11 @@ impl<F: Field> ExecutionGadget<F> for IsZeroGadget<F> {
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
         let opcode = cb.query_cell();
 
-        let value = cb.query_cell_phase2();
-        let is_zero = math_gadget::IsZeroGadget::construct(cb, value.expr());
+        let value = cb.query_word_unchecked();
+        let is_zero_word = math_gadget::IsZeroWordGadget::construct(cb, &value);
 
-        cb.stack_pop(value.expr());
-        cb.stack_push(is_zero.expr());
+        cb.stack_pop_word(value.to_word());
+        cb.stack_push_word(Word::from_lo_unchecked(is_zero_word.expr()));
 
         // State transition
         let step_state_transition = StepStateTransition {
@@ -49,7 +52,7 @@ impl<F: Field> ExecutionGadget<F> for IsZeroGadget<F> {
         Self {
             same_context,
             value,
-            is_zero,
+            is_zero_word,
         }
     }
 
@@ -65,9 +68,9 @@ impl<F: Field> ExecutionGadget<F> for IsZeroGadget<F> {
         self.same_context.assign_exec_step(region, offset, step)?;
 
         let value = block.get_rws(step, 0).stack_value();
-        let value = region.word_rlc(value);
-        self.value.assign(region, offset, value)?;
-        self.is_zero.assign_value(region, offset, value)?;
+        self.value.assign_u256(region, offset, value)?;
+        self.is_zero_word
+            .assign_value(region, offset, Value::known(Word::from(value)))?;
 
         Ok(())
     }

--- a/zkevm-circuits/src/evm_circuit/execution/jump.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/jump.rs
@@ -1,7 +1,6 @@
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
-        param::N_BYTES_PROGRAM_COUNTER,
         step::ExecutionState,
         util::{
             common_gadget::SameContextGadget,
@@ -15,7 +14,7 @@ use crate::{
     },
     util::{word::WordExpr, Expr},
 };
-use eth_types::{evm_types::OpcodeId, Field, ToLittleEndian};
+use eth_types::{evm_types::OpcodeId, Field};
 use halo2_proofs::plonk::Error;
 
 #[derive(Clone, Debug)]
@@ -67,15 +66,7 @@ impl<F: Field> ExecutionGadget<F> for JumpGadget<F> {
         self.same_context.assign_exec_step(region, offset, step)?;
 
         let destination = block.get_rws(step, 0).stack_value();
-        self.destination.assign(
-            region,
-            offset,
-            Some(
-                destination.to_le_bytes()[..N_BYTES_PROGRAM_COUNTER]
-                    .try_into()
-                    .unwrap(),
-            ),
-        )?;
+        self.destination.assign_u256(region, offset, destination)?;
 
         Ok(())
     }

--- a/zkevm-circuits/src/evm_circuit/execution/jump.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/jump.rs
@@ -9,11 +9,11 @@ use crate::{
                 EVMConstraintBuilder, StepStateTransition,
                 Transition::{Delta, To},
             },
-            from_bytes, CachedRegion, RandomLinearCombination,
+            CachedRegion, U64Cell,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
-    util::Expr,
+    util::{word::WordExpr, Expr},
 };
 use eth_types::{evm_types::OpcodeId, Field, ToLittleEndian};
 use halo2_proofs::plonk::Error;
@@ -21,7 +21,7 @@ use halo2_proofs::plonk::Error;
 #[derive(Clone, Debug)]
 pub(crate) struct JumpGadget<F> {
     same_context: SameContextGadget<F>,
-    destination: RandomLinearCombination<F, N_BYTES_PROGRAM_COUNTER>,
+    destination: U64Cell<F>,
 }
 
 impl<F: Field> ExecutionGadget<F> for JumpGadget<F> {
@@ -30,23 +30,19 @@ impl<F: Field> ExecutionGadget<F> for JumpGadget<F> {
     const EXECUTION_STATE: ExecutionState = ExecutionState::JUMP;
 
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
-        let destination = cb.query_word_rlc();
+        let destination = cb.query_u64();
 
         // Pop the value from the stack
-        cb.stack_pop(destination.expr());
+        cb.stack_pop_word(destination.to_word());
 
         // Lookup opcode at destination
-        cb.opcode_lookup_at(
-            from_bytes::expr(&destination.cells),
-            OpcodeId::JUMPDEST.expr(),
-            1.expr(),
-        );
+        cb.opcode_lookup_at(destination.expr(), OpcodeId::JUMPDEST.expr(), 1.expr());
 
         // State transition
         let opcode = cb.query_cell();
         let step_state_transition = StepStateTransition {
             rw_counter: Delta(1.expr()),
-            program_counter: To(from_bytes::expr(&destination.cells)),
+            program_counter: To(destination.expr()),
             stack_pointer: Delta(1.expr()),
             gas_left: Delta(-OpcodeId::JUMP.constant_gas_cost().expr()),
             ..Default::default()

--- a/zkevm-circuits/src/evm_circuit/execution/jumpi.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/jumpi.rs
@@ -9,22 +9,25 @@ use crate::{
                 ConstrainBuilderCommon, EVMConstraintBuilder, StepStateTransition,
                 Transition::{Delta, To},
             },
-            math_gadget::IsZeroGadget,
-            select, CachedRegion, Cell,
+            math_gadget::IsZeroWordGadget,
+            select, CachedRegion,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
-    util::Expr,
+    util::{
+        word::{Word, WordCell, WordExpr},
+        Expr,
+    },
 };
 use eth_types::{evm_types::OpcodeId, Field};
-use halo2_proofs::plonk::Error;
+use halo2_proofs::{circuit::Value, plonk::Error};
 
 #[derive(Clone, Debug)]
 pub(crate) struct JumpiGadget<F> {
     same_context: SameContextGadget<F>,
     dest: WordByteRangeGadget<F, N_BYTES_PROGRAM_COUNTER>,
-    phase2_condition: Cell<F>,
-    is_condition_zero: IsZeroGadget<F>,
+    condition: WordCell<F>,
+    is_condition_zero: IsZeroWordGadget<F, WordCell<F>>,
 }
 
 impl<F: Field> ExecutionGadget<F> for JumpiGadget<F> {
@@ -34,14 +37,14 @@ impl<F: Field> ExecutionGadget<F> for JumpiGadget<F> {
 
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
         let dest = WordByteRangeGadget::construct(cb);
-        let phase2_condition = cb.query_cell_phase2();
+        let condition = cb.query_word_unchecked();
 
         // Pop the value from the stack
-        cb.stack_pop(dest.original_word());
-        cb.stack_pop(phase2_condition.expr());
+        cb.stack_pop_word(dest.original());
+        cb.stack_pop_word(condition.to_word());
 
         // Determine if the jump condition is met
-        let is_condition_zero = IsZeroGadget::construct(cb, phase2_condition.expr());
+        let is_condition_zero = IsZeroWordGadget::construct(cb, &condition);
         let should_jump = 1.expr() - is_condition_zero.expr();
 
         // Lookup opcode at destination when should_jump
@@ -77,7 +80,7 @@ impl<F: Field> ExecutionGadget<F> for JumpiGadget<F> {
         Self {
             same_context,
             dest,
-            phase2_condition,
+            condition,
             is_condition_zero,
         }
     }
@@ -94,12 +97,11 @@ impl<F: Field> ExecutionGadget<F> for JumpiGadget<F> {
         self.same_context.assign_exec_step(region, offset, step)?;
 
         let [destination, condition] = [0, 1].map(|index| block.get_rws(step, index).stack_value());
-        let condition = region.word_rlc(condition);
 
         self.dest.assign(region, offset, destination)?;
-        self.phase2_condition.assign(region, offset, condition)?;
+        self.condition.assign_u256(region, offset, condition)?;
         self.is_condition_zero
-            .assign_value(region, offset, condition)?;
+            .assign_value(region, offset, Value::known(Word::from(condition)))?;
 
         Ok(())
     }

--- a/zkevm-circuits/src/evm_circuit/execution/logs.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/logs.rs
@@ -10,12 +10,16 @@ use crate::{
                 Transition::{Delta, To},
             },
             memory_gadget::{MemoryAddressGadget, MemoryExpansionGadget},
-            not, sum, CachedRegion, Cell,
+            not, sum, CachedRegion, Cell, Word,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
     table::{CallContextFieldTag, TxLogFieldTag},
-    util::{build_tx_log_expression, word::Word, Expr},
+    util::{
+        build_tx_log_expression,
+        word::{Word32Cell, WordCell, WordExpr},
+        Expr,
+    },
 };
 use array_init::array_init;
 use bus_mapping::circuit_input_builder::CopyDataType;
@@ -30,10 +34,10 @@ pub(crate) struct LogGadget<F> {
     same_context: SameContextGadget<F>,
     // memory address
     memory_address: MemoryAddressGadget<F>,
-    phase2_topics: [Cell<F>; 4],
+    topics: [Word32Cell<F>; 4],
     topic_selectors: [Cell<F>; 4],
 
-    contract_address: Cell<F>,
+    contract_address: WordCell<F>,
     is_static_call: Cell<F>,
     is_persistent: Cell<F>,
     tx_id: Cell<F>,
@@ -47,12 +51,12 @@ impl<F: Field> ExecutionGadget<F> for LogGadget<F> {
     const EXECUTION_STATE: ExecutionState = ExecutionState::LOG;
 
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
-        let mstart = cb.query_cell_phase2();
-        let msize = cb.query_word_rlc();
+        let mstart = cb.query_word_unchecked();
+        let msize = cb.query_memory_address();
 
         // Pop mstart_address, msize from stack
-        cb.stack_pop(mstart.expr());
-        cb.stack_pop(msize.expr());
+        cb.stack_pop_word(mstart.to_word());
+        cb.stack_pop_word(msize.to_word());
         // read tx id
         let tx_id = cb.call_context(None, CallContextFieldTag::TxId);
         // constrain not in static call
@@ -61,34 +65,35 @@ impl<F: Field> ExecutionGadget<F> for LogGadget<F> {
 
         // check contract_address in CallContext & TxLog
         // use call context's  callee address as contract address
-        let contract_address = cb.call_context(None, CallContextFieldTag::CalleeAddress);
+        let contract_address =
+            cb.call_context_read_as_word(None, CallContextFieldTag::CalleeAddress);
         let is_persistent = cb.call_context(None, CallContextFieldTag::IsPersistent);
         cb.require_boolean("is_persistent is bool", is_persistent.expr());
 
         cb.condition(is_persistent.expr(), |cb| {
-            cb.tx_log_lookup(
+            cb.tx_log_lookup_word(
                 tx_id.expr(),
                 cb.curr.state.log_id.expr() + 1.expr(),
                 TxLogFieldTag::Address,
                 0.expr(),
-                contract_address.expr(),
+                contract_address.to_word(),
             );
         });
 
         // constrain topics in logs
-        let phase2_topics = array_init(|_| cb.query_cell_phase2());
+        let topics = array_init(|_| cb.query_word32());
         let topic_selectors: [Cell<F>; 4] = array_init(|_| cb.query_cell());
-        for (idx, topic) in phase2_topics.iter().enumerate() {
+        for (idx, topic) in topics.iter().enumerate() {
             cb.condition(topic_selectors[idx].expr(), |cb| {
-                cb.stack_pop_word(Word::from_lo_unchecked(topic.expr()));
+                cb.stack_pop_word(topic.to_word());
             });
             cb.condition(topic_selectors[idx].expr() * is_persistent.expr(), |cb| {
-                cb.tx_log_lookup(
+                cb.tx_log_lookup_word(
                     tx_id.expr(),
                     cb.curr.state.log_id.expr() + 1.expr(),
                     TxLogFieldTag::Topic,
                     idx.expr(),
-                    topic.expr(),
+                    topic.to_word(),
                 );
             });
         }
@@ -132,9 +137,9 @@ impl<F: Field> ExecutionGadget<F> for LogGadget<F> {
         let cond = memory_address.has_length() * is_persistent.expr();
         cb.condition(cond.clone(), |cb| {
             cb.copy_table_lookup(
-                cb.curr.state.call_id.expr(),
+                Word::from_lo_unchecked(cb.curr.state.call_id.expr()),
                 CopyDataType::Memory.expr(),
-                tx_id.expr(),
+                Word::from_lo_unchecked(tx_id.expr()),
                 CopyDataType::TxLog.expr(),
                 memory_address.offset(),
                 memory_address.address(),
@@ -172,7 +177,7 @@ impl<F: Field> ExecutionGadget<F> for LogGadget<F> {
         Self {
             same_context,
             memory_address,
-            phase2_topics,
+            topics,
             topic_selectors,
             contract_address,
             is_static_call,
@@ -225,22 +230,11 @@ impl<F: Field> ExecutionGadget<F> for LogGadget<F> {
                 offset,
                 Value::known(F::from(topic.is_some().into())),
             )?;
-            self.phase2_topics[i].assign(
-                region,
-                offset,
-                region.word_rlc(topic.unwrap_or_default()),
-            )?;
+            self.topics[i].assign_u256(region, offset, topic.unwrap_or_default())?;
         }
 
-        self.contract_address.assign(
-            region,
-            offset,
-            Value::known(
-                call.address
-                    .to_scalar()
-                    .expect("unexpected Address -> Scalar conversion failure"),
-            ),
-        )?;
+        self.contract_address
+            .assign_h160(region, offset, call.address)?;
         let is_persistent = call.is_persistent as u64;
         self.is_static_call
             .assign(region, offset, Value::known(F::from(call.is_static as u64)))?;

--- a/zkevm-circuits/src/evm_circuit/execution/logs.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/logs.rs
@@ -10,14 +10,14 @@ use crate::{
                 Transition::{Delta, To},
             },
             memory_gadget::{MemoryAddressGadget, MemoryExpansionGadget},
-            not, sum, CachedRegion, Cell, Word,
+            not, sum, CachedRegion, Cell,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
     table::{CallContextFieldTag, TxLogFieldTag},
     util::{
         build_tx_log_expression,
-        word::{Word32Cell, WordCell, WordExpr},
+        word::{Word, Word32Cell, WordCell, WordExpr},
         Expr,
     },
 };

--- a/zkevm-circuits/src/evm_circuit/execution/memory.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/memory.rs
@@ -1,7 +1,7 @@
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
-        param::{N_BYTES_MEMORY_ADDRESS, N_BYTES_MEMORY_WORD_SIZE},
+        param::N_BYTES_MEMORY_WORD_SIZE,
         step::ExecutionState,
         util::{
             common_gadget::SameContextGadget,
@@ -20,7 +20,7 @@ use crate::{
         Expr,
     },
 };
-use eth_types::{evm_types::OpcodeId, Field, ToLittleEndian};
+use eth_types::{evm_types::OpcodeId, Field};
 use halo2_proofs::plonk::Error;
 
 #[derive(Clone, Debug)]
@@ -129,13 +129,7 @@ impl<F: Field> ExecutionGadget<F> for MemoryGadget<F> {
 
         // Inputs/Outputs
         let [address, value] = [0, 1].map(|index| block.get_rws(step, index).stack_value());
-        self.address.assign(
-            region,
-            offset,
-            address.to_le_bytes()[0..N_BYTES_MEMORY_ADDRESS]
-                .try_into()
-                .ok(),
-        )?;
+        self.address.assign_u256(region, offset, address)?;
         self.value.assign_u256(region, offset, value)?;
 
         // Check if this is an MLOAD

--- a/zkevm-circuits/src/evm_circuit/execution/memory.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/memory.rs
@@ -1,7 +1,7 @@
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
-        param::N_BYTES_MEMORY_WORD_SIZE,
+        param::{N_BYTES_MEMORY_ADDRESS, N_BYTES_MEMORY_WORD_SIZE},
         step::ExecutionState,
         util::{
             common_gadget::SameContextGadget,
@@ -58,7 +58,7 @@ impl<F: Field> ExecutionGadget<F> for MemoryGadget<F> {
         // access
         let memory_expansion = MemoryExpansionGadget::construct(
             cb,
-            [address.to_word().lo() + 1.expr() + (is_not_mstore8.clone() * 31.expr())],
+            [address.expr() + 1.expr() + (is_not_mstore8.clone() * 31.expr())],
         );
 
         // Stack operations
@@ -73,19 +73,14 @@ impl<F: Field> ExecutionGadget<F> for MemoryGadget<F> {
         );
 
         cb.condition(is_mstore8.expr(), |cb| {
-            cb.memory_lookup(
-                1.expr(),
-                address.to_word().lo(),
-                value.limbs[0].expr(),
-                None,
-            );
+            cb.memory_lookup(1.expr(), address.expr(), value.limbs[0].expr(), None);
         });
 
         cb.condition(is_not_mstore8, |cb| {
             for idx in 0..32 {
                 cb.memory_lookup(
                     is_store.clone(),
-                    address.to_word().lo().clone() + idx.expr(),
+                    address.expr() + idx.expr(),
                     value.limbs[31 - idx].expr(),
                     None,
                 );
@@ -137,10 +132,11 @@ impl<F: Field> ExecutionGadget<F> for MemoryGadget<F> {
         self.address.assign(
             region,
             offset,
-            Some(address.to_le_bytes()[..5].try_into().unwrap()),
+            address.to_le_bytes()[0..N_BYTES_MEMORY_ADDRESS]
+                .try_into()
+                .ok(),
         )?;
-        self.value
-            .assign(region, offset, Some(value.to_le_bytes()))?;
+        self.value.assign_u256(region, offset, value)?;
 
         // Check if this is an MLOAD
         self.is_mload.assign(

--- a/zkevm-circuits/src/evm_circuit/execution/msize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/msize.rs
@@ -9,20 +9,20 @@ use crate::{
                 ConstrainBuilderCommon, EVMConstraintBuilder, StepStateTransition,
                 Transition::Delta,
             },
-            from_bytes, CachedRegion, RandomLinearCombination,
+            CachedRegion, Cell,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
-    util::Expr,
+    util::{word::Word, Expr},
 };
 use bus_mapping::evm::OpcodeId;
 use eth_types::Field;
-use halo2_proofs::plonk::Error;
+use halo2_proofs::{circuit::Value, plonk::Error};
 
 #[derive(Clone, Debug)]
 pub(crate) struct MsizeGadget<F> {
     same_context: SameContextGadget<F>,
-    value: RandomLinearCombination<F, 8>,
+    value: Cell<F>,
 }
 
 impl<F: Field> ExecutionGadget<F> for MsizeGadget<F> {
@@ -31,17 +31,18 @@ impl<F: Field> ExecutionGadget<F> for MsizeGadget<F> {
     const EXECUTION_STATE: ExecutionState = ExecutionState::MSIZE;
 
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
-        let value = cb.query_word_rlc();
+        let value = cb.query_cell();
 
-        // memory_size is limited to 64 bits so we only consider 8 bytes
+        // memory_size is limited to 64 bits
+        // constrain equality with step state therefore only use single cell
         cb.require_equal(
             "Constrain memory_size equal to stack value",
-            from_bytes::expr(&value.cells),
+            value.expr(),
             cb.curr.state.memory_word_size.expr() * N_BYTES_WORD.expr(),
         );
 
         // Push the value on the stack
-        cb.stack_push(value.expr());
+        cb.stack_push_word(Word::from_lo_unchecked(value.expr()));
 
         // State transition
         let step_state_transition = StepStateTransition {
@@ -70,8 +71,11 @@ impl<F: Field> ExecutionGadget<F> for MsizeGadget<F> {
         step: &ExecStep,
     ) -> Result<(), Error> {
         self.same_context.assign_exec_step(region, offset, step)?;
-        self.value
-            .assign(region, offset, Some((step.memory_size).to_le_bytes()))?;
+        self.value.assign(
+            region,
+            offset,
+            Value::known(F::from(step.memory_size as u64)),
+        )?;
 
         Ok(())
     }

--- a/zkevm-circuits/src/evm_circuit/execution/mul_div_mod.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/mul_div_mod.rs
@@ -3,21 +3,23 @@ use crate::{
         execution::ExecutionGadget,
         step::ExecutionState,
         util::{
-            self,
             common_gadget::SameContextGadget,
             constraint_builder::{
                 ConstrainBuilderCommon, EVMConstraintBuilder, StepStateTransition,
                 Transition::Delta,
             },
-            math_gadget::{IsZeroGadget, LtWordGadget, MulAddWordsGadget},
-            select, sum, CachedRegion,
+            math_gadget::{IsZeroWordGadget, LtWordGadget, MulAddWordsGadget},
+            CachedRegion,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
-    util::Expr,
+    util::{
+        word::{Word, Word32Cell, WordExpr},
+        Expr,
+    },
 };
 use bus_mapping::evm::OpcodeId;
-use eth_types::{Field, ToLittleEndian, U256};
+use eth_types::{Field, U256};
 use halo2_proofs::plonk::Error;
 
 /// MulGadget verifies opcode MUL, DIV, and MOD.
@@ -29,11 +31,11 @@ use halo2_proofs::plonk::Error;
 pub(crate) struct MulDivModGadget<F> {
     same_context: SameContextGadget<F>,
     /// Words a, b, c, d
-    pub words: [util::Word<F>; 4],
+    pub words: [Word32Cell<F>; 4],
     /// Gadget that verifies a * b + c = d
     mul_add_words: MulAddWordsGadget<F>,
     /// Check if divisor is zero for DIV and MOD
-    divisor_is_zero: IsZeroGadget<F>,
+    divisor_is_zero: IsZeroWordGadget<F, Word32Cell<F>>,
     /// Check if residue < divisor when divisor != 0 for DIV and MOD
     lt_word: LtWordGadget<F>,
 }
@@ -55,32 +57,39 @@ impl<F: Field> ExecutionGadget<F> for MulDivModGadget<F> {
         let is_mod = (opcode.expr() - OpcodeId::MUL.expr())
             * (opcode.expr() - OpcodeId::DIV.expr())
             * F::from(8).invert().unwrap();
-        let a = cb.query_word_rlc();
-        let b = cb.query_word_rlc();
-        let c = cb.query_word_rlc();
-        let d = cb.query_word_rlc();
+        let a = cb.query_word32();
+        let b = cb.query_word32();
+        let c = cb.query_word32();
+        let d = cb.query_word32();
 
         let mul_add_words = MulAddWordsGadget::construct(cb, [&a, &b, &c, &d]);
-        let divisor_is_zero = IsZeroGadget::construct(cb, sum::expr(&b.cells));
-        let lt_word = LtWordGadget::construct(cb, &c, &b);
+        let divisor_is_zero = IsZeroWordGadget::construct(cb, &b);
+        let lt_word = LtWordGadget::construct(cb, &c.to_word(), &b.to_word());
 
         // Pop a and b from the stack, push result on the stack
         // The first pop is multiplier for MUL and dividend for DIV/MOD
         // The second pop is multiplicand for MUL and divisor for DIV/MOD
         // The push is product for MUL, quotient for DIV, and residue for MOD
         // Note that for DIV/MOD, when divisor == 0, the push value is also 0.
-        cb.stack_pop(select::expr(is_mul.clone(), a.expr(), d.expr()));
-        cb.stack_pop(b.expr());
-        cb.stack_push(
-            is_mul.clone() * d.expr()
-                + is_div * a.expr() * (1.expr() - divisor_is_zero.expr())
-                + is_mod * c.expr() * (1.expr() - divisor_is_zero.expr()),
+        cb.stack_pop_word(Word::select(is_mul.clone(), a.to_word(), d.to_word()));
+        cb.stack_pop_word(b.to_word());
+        cb.stack_push_word(
+            d.to_word()
+                .mul_selector(is_mul.clone())
+                .add_unchecked(
+                    a.to_word()
+                        .mul_selector(is_div * (1.expr() - divisor_is_zero.expr())),
+                )
+                .add_unchecked(
+                    c.to_word()
+                        .mul_selector(is_mod * (1.expr() - divisor_is_zero.expr())),
+                ),
         );
 
         // Constraint for MUL case
-        cb.add_constraint(
+        cb.require_zero_word(
             "c == 0 for opcode MUL",
-            is_mul.clone() * sum::expr(&c.cells),
+            c.to_word().mul_selector(is_mul.clone()),
         );
 
         // Constraints for DIV and MOD cases
@@ -137,15 +146,13 @@ impl<F: Field> ExecutionGadget<F> for MulDivModGadget<F> {
             ),
             _ => unreachable!(),
         };
-        self.words[0].assign(region, offset, Some(a.to_le_bytes()))?;
-        self.words[1].assign(region, offset, Some(b.to_le_bytes()))?;
-        self.words[2].assign(region, offset, Some(c.to_le_bytes()))?;
-        self.words[3].assign(region, offset, Some(d.to_le_bytes()))?;
+        self.words[0].assign_u256(region, offset, a)?;
+        self.words[1].assign_u256(region, offset, b)?;
+        self.words[2].assign_u256(region, offset, c)?;
+        self.words[3].assign_u256(region, offset, d)?;
         self.mul_add_words.assign(region, offset, [a, b, c, d])?;
         self.lt_word.assign(region, offset, c, b)?;
-        let b_sum = (0..32).fold(0, |acc, idx| acc + b.byte(idx) as u64);
-        self.divisor_is_zero
-            .assign(region, offset, F::from(b_sum))?;
+        self.divisor_is_zero.assign(region, offset, Word::from(b))?;
         Ok(())
     }
 }

--- a/zkevm-circuits/src/evm_circuit/execution/mulmod.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/mulmod.rs
@@ -8,15 +8,18 @@ use crate::{
                 ConstrainBuilderCommon, EVMConstraintBuilder, StepStateTransition,
                 Transition::Delta,
             },
-            math_gadget::{IsZeroGadget, LtWordGadget, ModGadget, MulAddWords512Gadget},
-            sum, CachedRegion, Word,
+            math_gadget::{IsZeroWordGadget, LtWordGadget, ModGadget, MulAddWords512Gadget},
+            CachedRegion,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
-    util::Expr,
+    util::{
+        word::{Word, Word32Cell, WordExpr},
+        Expr,
+    },
 };
 use bus_mapping::evm::OpcodeId;
-use eth_types::{Field, ToLittleEndian, U256};
+use eth_types::{Field, U256};
 use halo2_proofs::plonk::Error;
 
 /// MulModGadget verifies opcode MULMOD
@@ -26,15 +29,15 @@ use halo2_proofs::plonk::Error;
 pub(crate) struct MulModGadget<F> {
     same_context: SameContextGadget<F>,
     // a, b, n, r
-    pub words: [Word<F>; 4],
-    k: Word<F>,
-    a_reduced: Word<F>,
-    d: Word<F>,
-    e: Word<F>,
+    pub words: [Word32Cell<F>; 4],
+    k: Word32Cell<F>,
+    a_reduced: Word32Cell<F>,
+    d: Word32Cell<F>,
+    e: Word32Cell<F>,
     modword: ModGadget<F>,
     mul512_left: MulAddWords512Gadget<F>,
     mul512_right: MulAddWords512Gadget<F>,
-    n_is_zero: IsZeroGadget<F>,
+    n_is_zero: IsZeroWordGadget<F, Word32Cell<F>>,
     lt: LtWordGadget<F>,
 }
 
@@ -46,39 +49,38 @@ impl<F: Field> ExecutionGadget<F> for MulModGadget<F> {
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
         let opcode = cb.query_cell();
 
-        let a = cb.query_word_rlc();
-        let b = cb.query_word_rlc();
-        let n = cb.query_word_rlc();
-        let r = cb.query_word_rlc();
+        let a = cb.query_word32();
+        let b = cb.query_word32();
+        let n = cb.query_word32();
+        let r = cb.query_word32();
 
-        let k = cb.query_word_rlc();
+        let k = cb.query_word32();
 
-        let a_reduced = cb.query_word_rlc();
-        let d = cb.query_word_rlc();
-        let e = cb.query_word_rlc();
+        let a_reduced = cb.query_word32();
+        let d = cb.query_word32();
+        let e = cb.query_word32();
 
         // 1.  k1 * n + a_reduced  == a
         let modword = ModGadget::construct(cb, [&a, &n, &a_reduced]);
 
         // 2.  a_reduced * b + 0 == d * 2^256 + e
-        let mul512_left =
-            MulAddWords512Gadget::legacy_construct(cb, [&a_reduced, &b, &d, &e], None);
+        let mul512_left = MulAddWords512Gadget::construct(cb, [&a_reduced, &b, &d, &e], None);
 
         // 3.  k2 * n + r == d * 2^256 + e
-        let mul512_right = MulAddWords512Gadget::legacy_construct(cb, [&k, &n, &d, &e], Some(&r));
+        let mul512_right = MulAddWords512Gadget::construct(cb, [&k, &n, &d, &e], Some(&r));
 
         // (r < n ) or n == 0
-        let n_is_zero = IsZeroGadget::construct(cb, sum::expr(&n.cells));
-        let lt = LtWordGadget::construct(cb, &r, &n);
+        let n_is_zero = IsZeroWordGadget::construct(cb, &n);
+        let lt = LtWordGadget::construct(cb, &r.to_word(), &n.to_word());
         cb.add_constraint(
             " (1 - (r < n) - (n==0)) ",
             1.expr() - lt.expr() - n_is_zero.expr(),
         );
 
-        cb.stack_pop(a.expr());
-        cb.stack_pop(b.expr());
-        cb.stack_pop(n.expr());
-        cb.stack_push(r.expr());
+        cb.stack_pop_word(a.to_word());
+        cb.stack_pop_word(b.to_word());
+        cb.stack_pop_word(n.to_word());
+        cb.stack_push_word(r.to_word());
 
         // State transition
         let step_state_transition = StepStateTransition {
@@ -117,10 +119,10 @@ impl<F: Field> ExecutionGadget<F> for MulModGadget<F> {
         self.same_context.assign_exec_step(region, offset, step)?;
 
         let [r, n, b, a] = [3, 2, 1, 0].map(|index| block.get_rws(step, index).stack_value());
-        self.words[0].assign(region, offset, Some(a.to_le_bytes()))?;
-        self.words[1].assign(region, offset, Some(b.to_le_bytes()))?;
-        self.words[2].assign(region, offset, Some(n.to_le_bytes()))?;
-        self.words[3].assign(region, offset, Some(r.to_le_bytes()))?;
+        self.words[0].assign_u256(region, offset, a)?;
+        self.words[1].assign_u256(region, offset, b)?;
+        self.words[2].assign_u256(region, offset, n)?;
+        self.words[3].assign_u256(region, offset, r)?;
         // 1. quotient and reduction of a mod n
         let (k1, a_reduced) = if n.is_zero() {
             (U256::zero(), U256::zero())
@@ -142,11 +144,10 @@ impl<F: Field> ExecutionGadget<F> for MulModGadget<F> {
             (r, U256::try_from(prod / n).unwrap())
         };
 
-        self.k.assign(region, offset, Some(k2.to_le_bytes()))?;
-        self.a_reduced
-            .assign(region, offset, Some(a_reduced.to_le_bytes()))?;
-        self.d.assign(region, offset, Some(d.to_le_bytes()))?;
-        self.e.assign(region, offset, Some(e.to_le_bytes()))?;
+        self.k.assign_u256(region, offset, k2)?;
+        self.a_reduced.assign_u256(region, offset, a_reduced)?;
+        self.d.assign_u256(region, offset, d)?;
+        self.e.assign_u256(region, offset, e)?;
 
         self.modword.assign(region, offset, a, n, a_reduced, k1)?;
         self.mul512_left
@@ -156,8 +157,7 @@ impl<F: Field> ExecutionGadget<F> for MulModGadget<F> {
 
         self.lt.assign(region, offset, r, n)?;
 
-        let n_sum = (0..32).fold(0, |acc, idx| acc + n.byte(idx) as u64);
-        self.n_is_zero.assign(region, offset, F::from(n_sum))?;
+        self.n_is_zero.assign(region, offset, Word::from(n))?;
         Ok(())
     }
 }

--- a/zkevm-circuits/src/evm_circuit/execution/not.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/not.rs
@@ -6,20 +6,23 @@ use crate::{
         util::{
             common_gadget::SameContextGadget,
             constraint_builder::{EVMConstraintBuilder, StepStateTransition, Transition::Delta},
-            CachedRegion, Word,
+            CachedRegion,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
-    util::Expr,
+    util::{
+        word::{Word32Cell, WordExpr},
+        Expr,
+    },
 };
-use eth_types::{evm_types::OpcodeId, Field, ToLittleEndian};
+use eth_types::{evm_types::OpcodeId, Field};
 use halo2_proofs::plonk::Error;
 
 #[derive(Clone, Debug)]
 pub(crate) struct NotGadget<F> {
     same_context: SameContextGadget<F>,
-    input: Word<F>,
-    output: Word<F>,
+    input: Word32Cell<F>,
+    output: Word32Cell<F>,
 }
 
 impl<F: Field> ExecutionGadget<F> for NotGadget<F> {
@@ -30,13 +33,13 @@ impl<F: Field> ExecutionGadget<F> for NotGadget<F> {
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
         let opcode = cb.query_cell();
 
-        let input = cb.query_word_rlc();
-        let output = cb.query_word_rlc();
+        let input = cb.query_word32();
+        let output = cb.query_word32();
 
-        cb.stack_pop(input.expr());
-        cb.stack_push(output.expr());
+        cb.stack_pop_word(input.to_word());
+        cb.stack_push_word(output.to_word());
 
-        for (i, o) in input.cells.iter().zip(output.cells.iter()) {
+        for (i, o) in input.limbs.iter().zip(output.limbs.iter()) {
             cb.add_lookup(
                 "input XOR output is all 1's",
                 Lookup::Fixed {
@@ -75,10 +78,8 @@ impl<F: Field> ExecutionGadget<F> for NotGadget<F> {
         self.same_context.assign_exec_step(region, offset, step)?;
 
         let [input, output] = [0, 1].map(|index| block.get_rws(step, index).stack_value());
-        self.input
-            .assign(region, offset, Some(input.to_le_bytes()))?;
-        self.output
-            .assign(region, offset, Some(output.to_le_bytes()))?;
+        self.input.assign_u256(region, offset, input)?;
+        self.output.assign_u256(region, offset, output)?;
 
         Ok(())
     }

--- a/zkevm-circuits/src/evm_circuit/execution/origin.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/origin.rs
@@ -1,7 +1,6 @@
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
-        param::N_BYTES_ACCOUNT_ADDRESS,
         step::ExecutionState,
         util::{
             common_gadget::SameContextGadget,
@@ -14,7 +13,7 @@ use crate::{
     util::{word::WordExpr, Expr},
 };
 use bus_mapping::evm::OpcodeId;
-use eth_types::{Field, ToLittleEndian};
+use eth_types::Field;
 use halo2_proofs::{circuit::Value, plonk::Error};
 
 #[derive(Clone, Debug)]
@@ -79,13 +78,7 @@ impl<F: Field> ExecutionGadget<F> for OriginGadget<F> {
             .assign(region, offset, Value::known(F::from(tx.id as u64)))?;
 
         // Assign Origin addr.
-        self.origin.assign(
-            region,
-            offset,
-            origin.to_le_bytes()[..N_BYTES_ACCOUNT_ADDRESS]
-                .try_into()
-                .ok(),
-        )?;
+        self.origin.assign_u256(region, offset, origin)?;
 
         // Assign SameContextGadget witnesses.
         self.same_context.assign_exec_step(region, offset, step)?;

--- a/zkevm-circuits/src/evm_circuit/execution/pc.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/pc.rs
@@ -1,7 +1,6 @@
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
-        param::N_BYTES_PROGRAM_COUNTER,
         step::ExecutionState,
         util::{
             common_gadget::SameContextGadget,
@@ -9,11 +8,11 @@ use crate::{
                 ConstrainBuilderCommon, EVMConstraintBuilder, StepStateTransition,
                 Transition::Delta,
             },
-            from_bytes, CachedRegion, RandomLinearCombination,
+            CachedRegion, U64Cell,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
-    util::Expr,
+    util::{word::WordExpr, Expr},
 };
 use bus_mapping::evm::OpcodeId;
 use eth_types::Field;
@@ -22,7 +21,7 @@ use halo2_proofs::plonk::Error;
 #[derive(Clone, Debug)]
 pub(crate) struct PcGadget<F> {
     same_context: SameContextGadget<F>,
-    value: RandomLinearCombination<F, N_BYTES_PROGRAM_COUNTER>,
+    value: U64Cell<F>,
 }
 
 impl<F: Field> ExecutionGadget<F> for PcGadget<F> {
@@ -31,17 +30,17 @@ impl<F: Field> ExecutionGadget<F> for PcGadget<F> {
     const EXECUTION_STATE: ExecutionState = ExecutionState::PC;
 
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
-        let value = cb.query_word_rlc();
+        let value = cb.query_u64();
 
         // program_counter is limited to 64 bits so we only consider 8 bytes
         cb.require_equal(
             "Constrain program_counter equal to stack value",
-            from_bytes::expr(&value.cells),
+            value.to_word().lo(),
             cb.curr.state.program_counter.expr(),
         );
 
         // Push the value on the stack
-        cb.stack_push(value.expr());
+        cb.stack_push_word(value.to_word());
 
         // State transition
         let step_state_transition = StepStateTransition {

--- a/zkevm-circuits/src/evm_circuit/execution/pc.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/pc.rs
@@ -35,7 +35,7 @@ impl<F: Field> ExecutionGadget<F> for PcGadget<F> {
         // program_counter is limited to 64 bits so we only consider 8 bytes
         cb.require_equal(
             "Constrain program_counter equal to stack value",
-            value.to_word().lo(),
+            value.expr(),
             cb.curr.state.program_counter.expr(),
         );
 

--- a/zkevm-circuits/src/evm_circuit/execution/pop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/pop.rs
@@ -5,11 +5,14 @@ use crate::{
         util::{
             common_gadget::SameContextGadget,
             constraint_builder::{EVMConstraintBuilder, StepStateTransition, Transition::Delta},
-            CachedRegion, Cell,
+            CachedRegion,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
-    util::Expr,
+    util::{
+        word::{WordCell, WordExpr},
+        Expr,
+    },
 };
 use bus_mapping::evm::OpcodeId;
 use eth_types::Field;
@@ -18,7 +21,7 @@ use halo2_proofs::plonk::Error;
 #[derive(Clone, Debug)]
 pub(crate) struct PopGadget<F> {
     same_context: SameContextGadget<F>,
-    phase2_value: Cell<F>,
+    value: WordCell<F>,
 }
 
 impl<F: Field> ExecutionGadget<F> for PopGadget<F> {
@@ -27,10 +30,10 @@ impl<F: Field> ExecutionGadget<F> for PopGadget<F> {
     const EXECUTION_STATE: ExecutionState = ExecutionState::POP;
 
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
-        let phase2_value = cb.query_cell_phase2();
+        let value = cb.query_word_unchecked();
 
         // Pop the value from the stack
-        cb.stack_pop(phase2_value.expr());
+        cb.stack_pop_word(value.to_word());
 
         // State transition
         let step_state_transition = StepStateTransition {
@@ -45,7 +48,7 @@ impl<F: Field> ExecutionGadget<F> for PopGadget<F> {
 
         Self {
             same_context,
-            phase2_value,
+            value,
         }
     }
 
@@ -61,8 +64,7 @@ impl<F: Field> ExecutionGadget<F> for PopGadget<F> {
         self.same_context.assign_exec_step(region, offset, step)?;
 
         let value = block.get_rws(step, 0).stack_value();
-        self.phase2_value
-            .assign(region, offset, region.word_rlc(value))?;
+        self.value.assign_u256(region, offset, value)?;
 
         Ok(())
     }

--- a/zkevm-circuits/src/evm_circuit/execution/push.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/push.rs
@@ -18,7 +18,7 @@ use crate::{
     },
 };
 use array_init::array_init;
-use eth_types::{evm_types::OpcodeId, Field, ToLittleEndian};
+use eth_types::{evm_types::OpcodeId, Field};
 use halo2_proofs::{circuit::Value, plonk::Error};
 
 #[derive(Clone, Debug)]
@@ -132,8 +132,7 @@ impl<F: Field> ExecutionGadget<F> for PushGadget<F> {
         let opcode = step.opcode().unwrap();
 
         let value = block.get_rws(step, 0).stack_value();
-        self.value
-            .assign(region, offset, Some(value.to_le_bytes()))?;
+        self.value.assign_u256(region, offset, value)?;
 
         let num_additional_pushed = opcode.postfix().expect("opcode with postfix") - 1;
         for (idx, selector) in self.selectors.iter().enumerate() {

--- a/zkevm-circuits/src/evm_circuit/execution/return_revert.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/return_revert.rs
@@ -16,7 +16,10 @@ use crate::{
         witness::{Block, Call, ExecStep, Transaction},
     },
     table::{AccountFieldTag, CallContextFieldTag},
-    util::Expr,
+    util::{
+        word::{Word, Word32Cell, WordCell, WordExpr},
+        Expr,
+    },
 };
 use bus_mapping::{circuit_input_builder::CopyDataType, evm::OpcodeId, state_db::CodeDB};
 use eth_types::{evm_types::GasCost, Field, ToScalar, U256};
@@ -40,10 +43,10 @@ pub(crate) struct ReturnRevertGadget<F> {
     return_data_length: Cell<F>,
 
     memory_expansion: MemoryExpansionGadget<F, 1, N_BYTES_MEMORY_WORD_SIZE>,
-    code_hash: Cell<F>,
+    code_hash: Word32Cell<F>,
 
     caller_id: Cell<F>,
-    address: Cell<F>,
+    address: WordCell<F>,
     reversion_info: ReversionInfo<F>,
 }
 
@@ -56,10 +59,10 @@ impl<F: Field> ExecutionGadget<F> for ReturnRevertGadget<F> {
         let opcode = cb.query_cell();
         cb.opcode_lookup(opcode.expr(), 1.expr());
 
-        let offset = cb.query_cell_phase2();
-        let length = cb.query_word_rlc();
-        cb.stack_pop(offset.expr());
-        cb.stack_pop(length.expr());
+        let offset = cb.query_word_unchecked();
+        let length = cb.query_memory_address();
+        cb.stack_pop_word(offset.to_word());
+        cb.stack_pop_word(length.to_word());
         let range = MemoryAddressGadget::construct(cb, offset, length);
 
         let is_success = cb.call_context(None, CallContextFieldTag::IsSuccess);
@@ -102,12 +105,12 @@ impl<F: Field> ExecutionGadget<F> for ReturnRevertGadget<F> {
             cb.condition(is_contract_deployment.clone(), |cb| {
                 // We don't need to place any additional constraints on code_hash because the
                 // copy circuit enforces that it is the hash of the bytes in the copy lookup.
-                let code_hash = cb.query_cell_phase2();
+                let code_hash = cb.query_word32();
                 let deployed_code_rlc = cb.query_cell_phase2();
                 cb.copy_table_lookup(
-                    cb.curr.state.call_id.expr(),
+                    Word::from_lo_unchecked(cb.curr.state.call_id.expr()),
                     CopyDataType::Memory.expr(),
-                    code_hash.expr(),
+                    code_hash.to_word(),
                     CopyDataType::Bytecode.expr(),
                     range.offset(),
                     range.address(),
@@ -117,18 +120,17 @@ impl<F: Field> ExecutionGadget<F> for ReturnRevertGadget<F> {
                     copy_rw_increase.expr(),
                 );
 
-                let [caller_id, address] = [
-                    CallContextFieldTag::CallerId,
-                    CallContextFieldTag::CalleeAddress,
-                ]
-                .map(|tag| cb.call_context(None, tag));
+                let caller_id = cb.call_context(None, CallContextFieldTag::CallerId);
+                let address =
+                    cb.call_context_read_as_word(None, CallContextFieldTag::CalleeAddress);
+
                 let mut reversion_info = cb.reversion_info_read(None);
 
-                cb.account_write(
-                    address.expr(),
+                cb.account_write_word(
+                    address.to_word(),
                     AccountFieldTag::CodeHash,
-                    code_hash.expr(),
-                    cb.empty_code_hash_rlc(),
+                    code_hash.to_word(),
+                    cb.empty_code_hash_word(),
                     Some(&mut reversion_info),
                 );
 
@@ -144,11 +146,10 @@ impl<F: Field> ExecutionGadget<F> for ReturnRevertGadget<F> {
         // Case B in the specs.
         cb.condition(is_root.expr(), |cb| {
             cb.require_next_state(ExecutionState::EndTx);
-            cb.call_context_lookup(
-                false.expr(),
+            cb.call_context_lookup_read(
                 None,
                 CallContextFieldTag::IsPersistent,
-                is_success.expr(),
+                Word::from_lo_unchecked(is_success.expr()),
             );
             cb.require_step_state_transition(StepStateTransition {
                 program_counter: To(0.expr()),
@@ -203,9 +204,9 @@ impl<F: Field> ExecutionGadget<F> for ReturnRevertGadget<F> {
                 * not::expr(copy_rw_increase_is_zero.expr()),
             |cb| {
                 cb.copy_table_lookup(
-                    cb.curr.state.call_id.expr(),
+                    Word::from_lo_unchecked(cb.curr.state.call_id.expr()),
                     CopyDataType::Memory.expr(),
-                    cb.next.state.call_id.expr(),
+                    Word::from_lo_unchecked(cb.next.state.call_id.expr()),
                     CopyDataType::Memory.expr(),
                     range.offset(),
                     range.address(),
@@ -298,11 +299,8 @@ impl<F: Field> ExecutionGadget<F> for ReturnRevertGadget<F> {
             )?;
             let mut code_hash = CodeDB::hash(&values).to_fixed_bytes();
             code_hash.reverse();
-            self.code_hash.assign(
-                region,
-                offset,
-                region.word_rlc(U256::from_little_endian(&code_hash)),
-            )?;
+            self.code_hash
+                .assign_u256(region, offset, U256::from_little_endian(&code_hash))?;
         }
 
         let copy_rw_increase = if call.is_create() && call.is_success {
@@ -340,11 +338,7 @@ impl<F: Field> ExecutionGadget<F> for ReturnRevertGadget<F> {
             Value::known(call.caller_id.to_scalar().unwrap()),
         )?;
 
-        self.address.assign(
-            region,
-            offset,
-            Value::known(call.address.to_scalar().unwrap()),
-        )?;
+        self.address.assign_h160(region, offset, call.address)?;
 
         self.reversion_info.assign(
             region,

--- a/zkevm-circuits/src/evm_circuit/execution/returndatacopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/returndatacopy.rs
@@ -1,7 +1,7 @@
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
-        param::{N_BYTES_MEMORY_ADDRESS, N_BYTES_MEMORY_WORD_SIZE},
+        param::N_BYTES_MEMORY_WORD_SIZE,
         step::ExecutionState,
         util::{
             common_gadget::SameContextGadget,
@@ -22,7 +22,7 @@ use crate::{
     },
 };
 use bus_mapping::{circuit_input_builder::CopyDataType, evm::OpcodeId};
-use eth_types::{evm_types::GasCost, Field, ToLittleEndian, ToScalar};
+use eth_types::{evm_types::GasCost, Field, ToScalar};
 use gadgets::util::not;
 use halo2_proofs::{circuit::Value, plonk::Error};
 
@@ -176,15 +176,7 @@ impl<F: Field> ExecutionGadget<F> for ReturnDataCopyGadget<F> {
         let [dest_offset, data_offset, size] =
             [0, 1, 2].map(|index| block.get_rws(step, index).stack_value());
 
-        self.data_offset.assign(
-            region,
-            offset,
-            Some(
-                data_offset.to_le_bytes()[..N_BYTES_MEMORY_ADDRESS]
-                    .try_into()
-                    .unwrap(),
-            ),
-        )?;
+        self.data_offset.assign_u256(region, offset, data_offset)?;
 
         let [last_callee_id, return_data_offset, return_data_size] = [
             (3, CallContextFieldTag::LastCalleeId),

--- a/zkevm-circuits/src/evm_circuit/execution/returndatacopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/returndatacopy.rs
@@ -9,7 +9,6 @@ use crate::{
                 ConstrainBuilderCommon, EVMConstraintBuilder, StepStateTransition,
                 Transition::{Delta, To},
             },
-            from_bytes,
             math_gadget::RangeCheckGadget,
             memory_gadget::{MemoryAddressGadget, MemoryCopierGasGadget, MemoryExpansionGadget},
             CachedRegion, Cell, MemoryAddress,
@@ -17,7 +16,10 @@ use crate::{
         witness::{Block, Call, ExecStep, Transaction},
     },
     table::CallContextFieldTag,
-    util::Expr,
+    util::{
+        word::{Word, WordExpr},
+        Expr,
+    },
 };
 use bus_mapping::{circuit_input_builder::CopyDataType, evm::OpcodeId};
 use eth_types::{evm_types::GasCost, Field, ToLittleEndian, ToScalar};
@@ -60,44 +62,40 @@ impl<F: Field> ExecutionGadget<F> for ReturnDataCopyGadget<F> {
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
         let opcode = cb.query_cell();
 
-        let dest_offset = cb.query_cell_phase2();
-        let data_offset = cb.query_word_rlc();
-        let size = cb.query_word_rlc();
+        let dest_offset = cb.query_word_unchecked();
+        let data_offset = cb.query_memory_address();
+        let size = cb.query_memory_address();
 
         // 1. Pop dest_offset, offset, length from stack
-        cb.stack_pop(dest_offset.expr());
-        cb.stack_pop(data_offset.expr());
-        cb.stack_pop(size.expr());
+        cb.stack_pop_word(dest_offset.to_word());
+        cb.stack_pop_word(Word::from_lo_unchecked(data_offset.expr()));
+        cb.stack_pop_word(Word::from_lo_unchecked(size.expr()));
 
         // 2. Add lookup constraint in the call context for the returndatacopy field.
         let last_callee_id = cb.query_cell();
         let return_data_offset = cb.query_cell();
         let return_data_size = cb.query_cell();
-        cb.call_context_lookup(
-            false.expr(),
+        cb.call_context_lookup_read(
             None,
             CallContextFieldTag::LastCalleeId,
-            last_callee_id.expr(),
+            Word::from_lo_unchecked(last_callee_id.expr()),
         );
-        cb.call_context_lookup(
-            false.expr(),
+        cb.call_context_lookup_read(
             None,
             CallContextFieldTag::LastCalleeReturnDataOffset,
-            return_data_offset.expr(),
+            Word::from_lo_unchecked(return_data_offset.expr()),
         );
-        cb.call_context_lookup(
-            false.expr(),
+        cb.call_context_lookup_read(
             None,
             CallContextFieldTag::LastCalleeReturnDataLength,
-            return_data_size.expr(),
+            Word::from_lo_unchecked(return_data_size.expr()),
         );
 
         // 3. contraints for copy: copy overflow check
         // i.e., offset + size <= return_data_size
         let in_bound_check = RangeCheckGadget::construct(
             cb,
-            return_data_size.expr()
-                - (from_bytes::expr(&data_offset.cells) + from_bytes::expr(&size.cells)),
+            return_data_size.expr() - (data_offset.expr() + size.expr()),
         );
 
         // 4. memory copy
@@ -117,11 +115,11 @@ impl<F: Field> ExecutionGadget<F> for ReturnDataCopyGadget<F> {
         let copy_rwc_inc = cb.query_cell();
         cb.condition(dst_memory_addr.has_length(), |cb| {
             cb.copy_table_lookup(
-                last_callee_id.expr(),
+                Word::from_lo_unchecked(last_callee_id.expr()),
                 CopyDataType::Memory.expr(),
-                cb.curr.state.call_id.expr(),
+                Word::from_lo_unchecked(cb.curr.state.call_id.expr()),
                 CopyDataType::Memory.expr(),
-                return_data_offset.expr() + from_bytes::expr(&data_offset.cells),
+                return_data_offset.expr() + data_offset.expr(),
                 return_data_offset.expr() + return_data_size.expr(),
                 dst_memory_addr.offset(),
                 dst_memory_addr.length(),

--- a/zkevm-circuits/src/evm_circuit/execution/returndatasize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/returndatasize.rs
@@ -6,21 +6,24 @@ use crate::{
         util::{
             common_gadget::SameContextGadget,
             constraint_builder::{EVMConstraintBuilder, StepStateTransition, Transition::Delta},
-            from_bytes, CachedRegion, RandomLinearCombination,
+            from_bytes, CachedRegion,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
     table::CallContextFieldTag,
-    util::Expr,
+    util::{
+        word::{WordCell, WordExpr},
+        Expr,
+    },
 };
 use bus_mapping::evm::OpcodeId;
 use eth_types::{Field, ToLittleEndian};
-use halo2_proofs::plonk::Error;
+use halo2_proofs::{circuit::Value, plonk::Error};
 
 #[derive(Clone, Debug)]
 pub(crate) struct ReturnDataSizeGadget<F> {
     same_context: SameContextGadget<F>,
-    return_data_size: RandomLinearCombination<F, N_BYTES_U64>,
+    return_data_size: WordCell<F>,
 }
 
 impl<F: Field> ExecutionGadget<F> for ReturnDataSizeGadget<F> {
@@ -32,16 +35,15 @@ impl<F: Field> ExecutionGadget<F> for ReturnDataSizeGadget<F> {
         let opcode = cb.query_cell();
 
         // Add lookup constraint in the call context for the returndatasize field.
-        let return_data_size = cb.query_word_rlc();
-        cb.call_context_lookup(
-            false.expr(),
+        let return_data_size = cb.query_word_unchecked();
+        cb.call_context_lookup_read(
             None,
             CallContextFieldTag::LastCalleeReturnDataLength,
-            from_bytes::expr(&return_data_size.cells),
+            return_data_size.to_word(),
         );
 
         // The returndatasize should be pushed to the top of the stack.
-        cb.stack_push(return_data_size.expr());
+        cb.stack_push_word(return_data_size.to_word());
 
         let step_state_transition = StepStateTransition {
             rw_counter: Delta(2.expr()),
@@ -70,14 +72,12 @@ impl<F: Field> ExecutionGadget<F> for ReturnDataSizeGadget<F> {
     ) -> Result<(), Error> {
         self.same_context.assign_exec_step(region, offset, step)?;
         let return_data_size = block.get_rws(step, 1).stack_value();
-        self.return_data_size.assign(
+        self.return_data_size.assign_lo(
             region,
             offset,
-            Some(
-                return_data_size.to_le_bytes()[..N_BYTES_U64]
-                    .try_into()
-                    .expect("could not encode return_data_size as byte array in little endian"),
-            ),
+            Value::known(from_bytes::value(
+                &return_data_size.to_le_bytes()[..N_BYTES_U64],
+            )),
         )?;
 
         Ok(())

--- a/zkevm-circuits/src/evm_circuit/execution/returndatasize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/returndatasize.rs
@@ -1,12 +1,11 @@
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
-        param::N_BYTES_U64,
         step::ExecutionState,
         util::{
             common_gadget::SameContextGadget,
             constraint_builder::{EVMConstraintBuilder, StepStateTransition, Transition::Delta},
-            from_bytes, CachedRegion,
+            CachedRegion,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
@@ -17,8 +16,8 @@ use crate::{
     },
 };
 use bus_mapping::evm::OpcodeId;
-use eth_types::{Field, ToLittleEndian};
-use halo2_proofs::{circuit::Value, plonk::Error};
+use eth_types::Field;
+use halo2_proofs::plonk::Error;
 
 #[derive(Clone, Debug)]
 pub(crate) struct ReturnDataSizeGadget<F> {
@@ -72,13 +71,8 @@ impl<F: Field> ExecutionGadget<F> for ReturnDataSizeGadget<F> {
     ) -> Result<(), Error> {
         self.same_context.assign_exec_step(region, offset, step)?;
         let return_data_size = block.get_rws(step, 1).stack_value();
-        self.return_data_size.assign_lo(
-            region,
-            offset,
-            Value::known(from_bytes::value(
-                &return_data_size.to_le_bytes()[..N_BYTES_U64],
-            )),
-        )?;
+        self.return_data_size
+            .assign_u64(region, offset, return_data_size.as_u64())?;
 
         Ok(())
     }

--- a/zkevm-circuits/src/evm_circuit/execution/sar.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sar.rs
@@ -105,7 +105,7 @@ impl<F: Field> ExecutionGadget<F> for SarGadget<F> {
         for idx in 0..4 {
             cb.require_equal(
                 "a64s[idx] == a64s_lo[idx] + a64s_hi[idx] * p_lo",
-                a64s.limbs[0].clone(),
+                a64s.limbs[idx].clone(),
                 a64s_lo[idx].expr() + a64s_hi[idx].expr() * p_lo.expr(),
             );
         }

--- a/zkevm-circuits/src/evm_circuit/execution/sar.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sar.rs
@@ -105,7 +105,7 @@ impl<F: Field> ExecutionGadget<F> for SarGadget<F> {
         for idx in 0..4 {
             cb.require_equal(
                 "a64s[idx] == a64s_lo[idx] + a64s_hi[idx] * p_lo",
-                a64s.get(idx).clone(),
+                a64s.limbs[0].clone(),
                 a64s_lo[idx].expr() + a64s_hi[idx].expr() * p_lo.expr(),
             );
         }

--- a/zkevm-circuits/src/evm_circuit/execution/sar.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sar.rs
@@ -1,7 +1,6 @@
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
-        param::N_BYTES_U64,
         step::ExecutionState,
         table::{FixedTableTag, Lookup},
         util::{
@@ -10,18 +9,23 @@ use crate::{
                 ConstrainBuilderCommon, EVMConstraintBuilder, StepStateTransition,
                 Transition::Delta,
             },
-            from_bytes,
             math_gadget::{IsEqualGadget, IsZeroGadget, LtGadget},
-            select, sum, CachedRegion, Cell, Word,
+            select, sum, CachedRegion, Cell,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
-    util::Expr,
+    util::{
+        word::{Word32Cell, Word4, WordExpr},
+        Expr,
+    },
 };
 use array_init::array_init;
 use bus_mapping::evm::OpcodeId;
 use eth_types::{Field, ToLittleEndian};
-use halo2_proofs::{circuit::Value, plonk::Error};
+use halo2_proofs::{
+    circuit::Value,
+    plonk::{Error, Expression},
+};
 
 /// SarGadget verifies SAR opcode.
 /// Verify signed word shift right as `signed(a) >> shift == signed(b)`;
@@ -29,9 +33,9 @@ use halo2_proofs::{circuit::Value, plonk::Error};
 #[derive(Clone, Debug)]
 pub(crate) struct SarGadget<F> {
     same_context: SameContextGadget<F>,
-    shift: Word<F>,
-    a: Word<F>,
-    b: Word<F>,
+    shift: Word32Cell<F>,
+    a: Word32Cell<F>,
+    b: Word32Cell<F>,
     // Each of the four `a64s` limbs is split into two parts (`a64s_lo` and `a64s_hi`) at position
     // `shf_mod64`, `a64s_lo` is the lower `shf_mod64` bits.
     a64s_lo: [Cell<F>; 4],
@@ -77,13 +81,16 @@ impl<F: Field> ExecutionGadget<F> for SarGadget<F> {
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
         let opcode = cb.query_cell();
 
-        let shift = cb.query_word_rlc();
-        let a = cb.query_word_rlc();
-        let b = cb.query_word_rlc();
+        let shift = cb.query_word32();
+        let a = cb.query_word32();
+        let b = cb.query_word32();
 
-        cb.stack_pop(shift.expr());
-        cb.stack_pop(a.expr());
-        cb.stack_push(b.expr());
+        cb.stack_pop_word(shift.to_word());
+        cb.stack_pop_word(a.to_word());
+        cb.stack_push_word(b.to_word());
+
+        let a64s: Word4<Expression<F>> = a.to_word_n();
+        let b64s: Word4<Expression<F>> = b.to_word_n();
 
         let a64s_lo = array_init(|_| cb.query_cell());
         let a64s_hi = array_init(|_| cb.query_cell());
@@ -92,13 +99,13 @@ impl<F: Field> ExecutionGadget<F> for SarGadget<F> {
         let p_lo = cb.query_cell();
         let p_hi = cb.query_cell();
         let p_top = cb.query_cell();
-        let is_neg = LtGadget::construct(cb, 127.expr(), a.cells[31].expr());
-        let shf_lt256 = IsZeroGadget::construct(cb, sum::expr(&shift.cells[1..32]));
+        let is_neg = LtGadget::construct(cb, 127.expr(), a.limbs[31].expr());
+        let shf_lt256 = IsZeroGadget::construct(cb, sum::expr(&shift.limbs[1..32]));
 
         for idx in 0..4 {
             cb.require_equal(
                 "a64s[idx] == a64s_lo[idx] + a64s_hi[idx] * p_lo",
-                from_bytes::expr(&a.cells[N_BYTES_U64 * idx..N_BYTES_U64 * (idx + 1)]),
+                a64s.get(idx).clone(),
                 a64s_lo[idx].expr() + a64s_hi[idx].expr() * p_lo.expr(),
             );
         }
@@ -129,7 +136,7 @@ impl<F: Field> ExecutionGadget<F> for SarGadget<F> {
 
         cb.require_equal(
             "Constrain merged b64s[0] value",
-            from_bytes::expr(&b.cells[0..N_BYTES_U64]),
+            b64s.limbs[0].expr(),
             (a64s_hi[0].expr() + a64s_lo[1].expr() * p_hi.expr()) * shf_div64_eq0.expr()
                 + (a64s_hi[1].expr() + a64s_lo[2].expr() * p_hi.expr()) * shf_div64_eq1.expr()
                 + (a64s_hi[2].expr() + a64s_lo[3].expr() * p_hi.expr()) * shf_div64_eq2.expr()
@@ -144,7 +151,7 @@ impl<F: Field> ExecutionGadget<F> for SarGadget<F> {
         );
         cb.require_equal(
             "Constrain merged b64s[1] value",
-            from_bytes::expr(&b.cells[N_BYTES_U64..N_BYTES_U64 * 2]),
+            b64s.limbs[1].expr(),
             (a64s_hi[1].expr() + a64s_lo[2].expr() * p_hi.expr()) * shf_div64_eq0.expr()
                 + (a64s_hi[2].expr() + a64s_lo[3].expr() * p_hi.expr()) * shf_div64_eq1.expr()
                 + (a64s_hi[3].expr() + p_top.expr()) * shf_div64_eq2.expr()
@@ -157,7 +164,7 @@ impl<F: Field> ExecutionGadget<F> for SarGadget<F> {
         );
         cb.require_equal(
             "Constrain merged b64s[2] value",
-            from_bytes::expr(&b.cells[N_BYTES_U64 * 2..N_BYTES_U64 * 3]),
+            b64s.limbs[2].expr(),
             (a64s_hi[2].expr() + a64s_lo[3].expr() * p_hi.expr()) * shf_div64_eq0.expr()
                 + (a64s_hi[3].expr() + p_top.expr()) * shf_div64_eq1.expr()
                 + is_neg.expr()
@@ -166,7 +173,7 @@ impl<F: Field> ExecutionGadget<F> for SarGadget<F> {
         );
         cb.require_equal(
             "Constrain merged b64s[3] value",
-            from_bytes::expr(&b.cells[N_BYTES_U64 * 3..]),
+            b64s.limbs[3].expr(),
             (a64s_hi[3].expr() + p_top.expr()) * shf_div64_eq0.expr()
                 + is_neg.expr() * u64::MAX.expr() * (1.expr() - shf_div64_eq0.expr()),
         );
@@ -178,7 +185,7 @@ impl<F: Field> ExecutionGadget<F> for SarGadget<F> {
         cb.require_equal("shf_mod64 < 64", shf_mod64_lt_64.expr(), 1.expr());
         cb.require_equal(
             "shift[0] == shf_mod64 + shf_div64 * 64",
-            shift.cells[0].expr(),
+            shift.limbs[0].expr(),
             shf_mod64.expr() + shf_div64.expr() * 64.expr(),
         );
 
@@ -189,7 +196,7 @@ impl<F: Field> ExecutionGadget<F> for SarGadget<F> {
             Lookup::Fixed {
                 tag: FixedTableTag::SignByte.expr(),
                 values: [
-                    a.cells[31].expr(),
+                    a.limbs[31].expr(),
                     select::expr(is_neg.expr(), 255.expr(), 0.expr()),
                     0.expr(),
                 ],
@@ -268,10 +275,9 @@ impl<F: Field> ExecutionGadget<F> for SarGadget<F> {
         self.same_context.assign_exec_step(region, offset, step)?;
         let [shift, a, b] = [0, 1, 2].map(|idx| block.get_rws(step, idx).stack_value());
 
-        self.shift
-            .assign(region, offset, Some(shift.to_le_bytes()))?;
-        self.a.assign(region, offset, Some(a.to_le_bytes()))?;
-        self.b.assign(region, offset, Some(b.to_le_bytes()))?;
+        self.shift.assign_u256(region, offset, shift)?;
+        self.a.assign_u256(region, offset, a)?;
+        self.b.assign_u256(region, offset, b)?;
 
         let is_neg = 127 < a.to_le_bytes()[31];
         let shf0 = u128::from(shift.to_le_bytes()[0]);

--- a/zkevm-circuits/src/evm_circuit/execution/sdiv_smod.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sdiv_smod.rs
@@ -8,12 +8,17 @@ use crate::{
                 ConstrainBuilderCommon, EVMConstraintBuilder, StepStateTransition,
                 Transition::Delta,
             },
-            math_gadget::{AbsWordGadget, IsZeroGadget, LtGadget, LtWordGadget, MulAddWordsGadget},
-            select, sum, CachedRegion,
+            math_gadget::{
+                AbsWordGadget, IsZeroWordGadget, LtGadget, LtWordGadget, MulAddWordsGadget,
+            },
+            CachedRegion,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
-    util::Expr,
+    util::{
+        word::{Word, Word32Cell, WordExpr},
+        Expr,
+    },
 };
 use bus_mapping::evm::OpcodeId;
 use eth_types::{Field, ToLittleEndian, U256};
@@ -29,9 +34,9 @@ pub(crate) struct SignedDivModGadget<F> {
     mul_add_words: MulAddWordsGadget<F>,
     remainder_abs_lt_divisor_abs: LtWordGadget<F>,
     dividend_is_signed_overflow: LtGadget<F, 1>,
-    quotient_is_zero: IsZeroGadget<F>,
-    divisor_is_zero: IsZeroGadget<F>,
-    remainder_is_zero: IsZeroGadget<F>,
+    quotient_is_zero: IsZeroWordGadget<F, Word32Cell<F>>,
+    divisor_is_zero: IsZeroWordGadget<F, Word32Cell<F>>,
+    remainder_is_zero: IsZeroWordGadget<F, Word32Cell<F>>,
 }
 
 impl<F: Field> ExecutionGadget<F> for SignedDivModGadget<F> {
@@ -47,33 +52,41 @@ impl<F: Field> ExecutionGadget<F> for SignedDivModGadget<F> {
         let divisor_abs_word = AbsWordGadget::construct(cb);
         let remainder_abs_word = AbsWordGadget::construct(cb);
         let dividend_abs_word = AbsWordGadget::construct(cb);
-        let quotient_is_zero = IsZeroGadget::construct(cb, sum::expr(&quotient_abs_word.x().cells));
-        let divisor_is_zero = IsZeroGadget::construct(cb, sum::expr(&divisor_abs_word.x().cells));
-        let remainder_is_zero =
-            IsZeroGadget::construct(cb, sum::expr(&remainder_abs_word.x().cells));
+        let quotient_is_zero = IsZeroWordGadget::construct(cb, quotient_abs_word.x_word());
+        let divisor_is_zero = IsZeroWordGadget::construct(cb, divisor_abs_word.x_word());
+        let remainder_is_zero = IsZeroWordGadget::construct(cb, remainder_abs_word.x_word());
 
-        cb.stack_pop(dividend_abs_word.x().expr());
-        cb.stack_pop(divisor_abs_word.x().expr());
-        cb.stack_push(select::expr(
+        cb.stack_pop_word(dividend_abs_word.x_word().to_word());
+        cb.stack_pop_word(divisor_abs_word.x_word().to_word());
+        cb.stack_push_word(Word::select(
             is_sdiv,
-            quotient_abs_word.x().expr() * (1.expr() - divisor_is_zero.expr()),
-            remainder_abs_word.x().expr() * (1.expr() - divisor_is_zero.expr()),
+            quotient_abs_word
+                .x_word()
+                .to_word()
+                .mul_selector(1.expr() - divisor_is_zero.expr()),
+            remainder_abs_word
+                .x_word()
+                .to_word()
+                .mul_selector(1.expr() - divisor_is_zero.expr()),
         ));
 
         // Constrain `|quotient| * |divisor| + |remainder| = |dividend|`.
         let mul_add_words = MulAddWordsGadget::construct(
             cb,
             [
-                quotient_abs_word.x_abs(),
-                divisor_abs_word.x_abs(),
-                remainder_abs_word.x_abs(),
-                dividend_abs_word.x_abs(),
+                quotient_abs_word.x_abs_word(),
+                divisor_abs_word.x_abs_word(),
+                remainder_abs_word.x_abs_word(),
+                dividend_abs_word.x_abs_word(),
             ],
         );
         cb.add_constraint("overflow == 0", mul_add_words.overflow());
 
-        let remainder_abs_lt_divisor_abs =
-            LtWordGadget::construct(cb, remainder_abs_word.x_abs(), divisor_abs_word.x_abs());
+        let remainder_abs_lt_divisor_abs = LtWordGadget::construct(
+            cb,
+            &remainder_abs_word.x_abs_word().to_word(),
+            &divisor_abs_word.x_abs_word().to_word(),
+        );
         cb.add_constraint(
             "abs(remainder) < abs(divisor) when divisor != 0",
             (1.expr() - remainder_abs_lt_divisor_abs.expr()) * (1.expr() - divisor_is_zero.expr()),
@@ -95,8 +108,11 @@ impl<F: Field> ExecutionGadget<F> for SignedDivModGadget<F> {
         // `(1 << 255) - 1`. So constraint
         // `sign(dividend) == sign(divisor) ^ sign(quotient)` cannot be applied
         // for this case.
-        let dividend_is_signed_overflow =
-            LtGadget::construct(cb, 127.expr(), dividend_abs_word.x_abs().cells[31].expr());
+        let dividend_is_signed_overflow = LtGadget::construct(
+            cb,
+            127.expr(),
+            dividend_abs_word.x_abs_word().limbs[31].expr(),
+        );
 
         // Constrain sign(dividend) == sign(divisor) ^ sign(quotient) when both
         // quotient and divisor are non-zero and dividend is not signed overflow.
@@ -206,15 +222,12 @@ impl<F: Field> ExecutionGadget<F> for SignedDivModGadget<F> {
             127.into(),
             u64::from(dividend_abs.to_le_bytes()[31]).into(),
         )?;
-        let quotient_sum = (0..32).fold(0, |acc, idx| acc + quotient.byte(idx) as u64);
-        let divisor_sum = (0..32).fold(0, |acc, idx| acc + divisor.byte(idx) as u64);
-        let remainder_sum = (0..32).fold(0, |acc, idx| acc + remainder.byte(idx) as u64);
         self.quotient_is_zero
-            .assign(region, offset, F::from(quotient_sum))?;
+            .assign(region, offset, Word::from(quotient))?;
         self.divisor_is_zero
-            .assign(region, offset, F::from(divisor_sum))?;
+            .assign(region, offset, Word::from(divisor))?;
         self.remainder_is_zero
-            .assign(region, offset, F::from(remainder_sum))?;
+            .assign(region, offset, Word::from(remainder))?;
         Ok(())
     }
 }

--- a/zkevm-circuits/src/evm_circuit/execution/selfbalance.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/selfbalance.rs
@@ -5,22 +5,25 @@ use crate::{
         util::{
             common_gadget::SameContextGadget,
             constraint_builder::{EVMConstraintBuilder, StepStateTransition, Transition::Delta},
-            CachedRegion, Cell,
+            CachedRegion,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
     table::{AccountFieldTag, CallContextFieldTag},
-    util::Expr,
+    util::{
+        word::{WordCell, WordExpr},
+        Expr,
+    },
 };
 use bus_mapping::evm::OpcodeId;
-use eth_types::{Field, ToScalar};
-use halo2_proofs::{circuit::Value, plonk::Error};
+use eth_types::Field;
+use halo2_proofs::plonk::Error;
 
 #[derive(Clone, Debug)]
 pub(crate) struct SelfbalanceGadget<F> {
     same_context: SameContextGadget<F>,
-    callee_address: Cell<F>,
-    phase2_self_balance: Cell<F>,
+    callee_address: WordCell<F>,
+    self_balance: WordCell<F>,
 }
 
 impl<F: Field> ExecutionGadget<F> for SelfbalanceGadget<F> {
@@ -29,16 +32,16 @@ impl<F: Field> ExecutionGadget<F> for SelfbalanceGadget<F> {
     const EXECUTION_STATE: ExecutionState = ExecutionState::SELFBALANCE;
 
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
-        let callee_address = cb.call_context(None, CallContextFieldTag::CalleeAddress);
+        let callee_address = cb.call_context_read_as_word(None, CallContextFieldTag::CalleeAddress);
 
-        let phase2_self_balance = cb.query_cell_phase2();
-        cb.account_read(
-            callee_address.expr(),
+        let self_balance = cb.query_word_unchecked();
+        cb.account_read_word(
+            callee_address.to_word(),
             AccountFieldTag::Balance,
-            phase2_self_balance.expr(),
+            self_balance.to_word(),
         );
 
-        cb.stack_push(phase2_self_balance.expr());
+        cb.stack_push_word(self_balance.to_word());
 
         let opcode = cb.query_cell();
         let step_state_transition = StepStateTransition {
@@ -52,8 +55,8 @@ impl<F: Field> ExecutionGadget<F> for SelfbalanceGadget<F> {
 
         Self {
             same_context,
-            phase2_self_balance,
             callee_address,
+            self_balance,
         }
     }
 
@@ -68,19 +71,12 @@ impl<F: Field> ExecutionGadget<F> for SelfbalanceGadget<F> {
     ) -> Result<(), Error> {
         self.same_context.assign_exec_step(region, offset, step)?;
 
-        self.callee_address.assign(
-            region,
-            offset,
-            Value::known(
-                call.address
-                    .to_scalar()
-                    .expect("unexpected Address -> Scalar conversion failure"),
-            ),
-        )?;
+        self.callee_address
+            .assign_h160(region, offset, call.address)?;
 
         let self_balance = block.get_rws(step, 2).stack_value();
-        self.phase2_self_balance
-            .assign(region, offset, region.word_rlc(self_balance))?;
+        self.self_balance
+            .assign_u256(region, offset, self_balance)?;
 
         Ok(())
     }

--- a/zkevm-circuits/src/evm_circuit/execution/sha3.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sha3.rs
@@ -13,11 +13,11 @@ use crate::{
                 ConstrainBuilderCommon, EVMConstraintBuilder, StepStateTransition, Transition,
             },
             memory_gadget::{MemoryAddressGadget, MemoryCopierGasGadget, MemoryExpansionGadget},
-            rlc, CachedRegion, Cell, Word,
+            rlc, CachedRegion, Cell,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
-    util::word::{WordCell, WordExpr},
+    util::word::{Word, WordCell, WordExpr},
 };
 
 use super::ExecutionGadget;

--- a/zkevm-circuits/src/evm_circuit/execution/sha3.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sha3.rs
@@ -1,20 +1,23 @@
 use bus_mapping::{circuit_input_builder::CopyDataType, evm::OpcodeId};
-use eth_types::{evm_types::GasCost, Field, ToLittleEndian, ToScalar};
+use eth_types::{evm_types::GasCost, Field, ToScalar};
 use gadgets::util::{not, Expr};
 use halo2_proofs::{circuit::Value, plonk::Error};
 
-use crate::evm_circuit::{
-    param::N_BYTES_MEMORY_WORD_SIZE,
-    step::ExecutionState,
-    util::{
-        common_gadget::SameContextGadget,
-        constraint_builder::{
-            ConstrainBuilderCommon, EVMConstraintBuilder, StepStateTransition, Transition,
+use crate::{
+    evm_circuit::{
+        param::N_BYTES_MEMORY_WORD_SIZE,
+        step::ExecutionState,
+        util::{
+            common_gadget::SameContextGadget,
+            constraint_builder::{
+                ConstrainBuilderCommon, EVMConstraintBuilder, StepStateTransition, Transition,
+            },
+            memory_gadget::{MemoryAddressGadget, MemoryCopierGasGadget, MemoryExpansionGadget},
+            rlc, CachedRegion, Cell, Word,
         },
-        memory_gadget::{MemoryAddressGadget, MemoryCopierGasGadget, MemoryExpansionGadget},
-        rlc, CachedRegion, Cell, Word,
+        witness::{Block, Call, ExecStep, Transaction},
     },
-    witness::{Block, Call, ExecStep, Transaction},
+    util::word::{WordCell, WordExpr},
 };
 
 use super::ExecutionGadget;
@@ -23,7 +26,7 @@ use super::ExecutionGadget;
 pub(crate) struct Sha3Gadget<F> {
     same_context: SameContextGadget<F>,
     memory_address: MemoryAddressGadget<F>,
-    sha3_rlc: Word<F>,
+    sha3_digest: WordCell<F>,
     copy_rwc_inc: Cell<F>,
     rlc_acc: Cell<F>,
     memory_expansion: MemoryExpansionGadget<F, 1, N_BYTES_MEMORY_WORD_SIZE>,
@@ -38,13 +41,13 @@ impl<F: Field> ExecutionGadget<F> for Sha3Gadget<F> {
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
         let opcode = cb.query_cell();
 
-        let offset = cb.query_cell_phase2();
-        let size = cb.query_word_rlc();
-        let sha3_rlc = cb.query_word_rlc();
+        let offset = cb.query_word_unchecked();
+        let size = cb.query_memory_address();
+        let sha3_digest = cb.query_word_unchecked();
 
-        cb.stack_pop(offset.expr());
-        cb.stack_pop(size.expr());
-        cb.stack_push(sha3_rlc.expr());
+        cb.stack_pop_word(offset.to_word());
+        cb.stack_pop_word(size.to_word());
+        cb.stack_push_word(sha3_digest.to_word());
 
         let memory_address = MemoryAddressGadget::construct(cb, offset, size);
 
@@ -53,9 +56,9 @@ impl<F: Field> ExecutionGadget<F> for Sha3Gadget<F> {
 
         cb.condition(memory_address.has_length(), |cb| {
             cb.copy_table_lookup(
-                cb.curr.state.call_id.expr(),
+                Word::from_lo_unchecked(cb.curr.state.call_id.expr()),
                 CopyDataType::Memory.expr(),
-                cb.curr.state.call_id.expr(),
+                Word::from_lo_unchecked(cb.curr.state.call_id.expr()),
                 CopyDataType::RlcAcc.expr(),
                 memory_address.offset(),
                 memory_address.address(),
@@ -70,7 +73,11 @@ impl<F: Field> ExecutionGadget<F> for Sha3Gadget<F> {
             cb.require_zero("copy_rwc_inc == 0 for size = 0", copy_rwc_inc.expr());
             cb.require_zero("rlc_acc == 0 for size = 0", rlc_acc.expr());
         });
-        cb.keccak_table_lookup(rlc_acc.expr(), memory_address.length(), sha3_rlc.expr());
+        cb.keccak_table_lookup_word(
+            rlc_acc.expr(),
+            memory_address.length(),
+            sha3_digest.to_word(),
+        );
 
         let memory_expansion = MemoryExpansionGadget::construct(cb, [memory_address.address()]);
         let memory_copier_gas = MemoryCopierGasGadget::construct(
@@ -94,7 +101,7 @@ impl<F: Field> ExecutionGadget<F> for Sha3Gadget<F> {
         Self {
             same_context,
             memory_address,
-            sha3_rlc,
+            sha3_digest,
             copy_rwc_inc,
             rlc_acc,
             memory_expansion,
@@ -118,8 +125,7 @@ impl<F: Field> ExecutionGadget<F> for Sha3Gadget<F> {
         let memory_address = self
             .memory_address
             .assign(region, offset, memory_offset, size)?;
-        self.sha3_rlc
-            .assign(region, offset, Some(sha3_output.to_le_bytes()))?;
+        self.sha3_digest.assign_u256(region, offset, sha3_output)?;
 
         self.copy_rwc_inc.assign(
             region,

--- a/zkevm-circuits/src/evm_circuit/execution/signextend.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/signextend.rs
@@ -11,11 +11,14 @@ use crate::{
                 Transition::Delta,
             },
             math_gadget::{IsEqualGadget, IsZeroGadget},
-            rlc, select, sum, CachedRegion, Cell, Word,
+            select, sum, CachedRegion, Cell,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
-    util::Expr,
+    util::{
+        word::{Word32, Word32Cell, WordExpr},
+        Expr,
+    },
 };
 use array_init::array_init;
 use bus_mapping::evm::OpcodeId;
@@ -25,8 +28,8 @@ use halo2_proofs::{circuit::Value, plonk::Error};
 #[derive(Clone, Debug)]
 pub(crate) struct SignextendGadget<F> {
     same_context: SameContextGadget<F>,
-    index: Word<F>,
-    value: Word<F>,
+    index: Word32Cell<F>,
+    value: Word32Cell<F>,
     sign_byte: Cell<F>,
     is_msb_sum_zero: IsZeroGadget<F>,
     is_byte_selected: [IsEqualGadget<F>; 31],
@@ -39,8 +42,8 @@ impl<F: Field> ExecutionGadget<F> for SignextendGadget<F> {
     const EXECUTION_STATE: ExecutionState = ExecutionState::SIGNEXTEND;
 
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
-        let index = cb.query_word_rlc();
-        let value = cb.query_word_rlc();
+        let index = cb.query_word32();
+        let value = cb.query_word32();
         let sign_byte = cb.query_cell();
         let selectors = array_init(|_| cb.query_bool());
 
@@ -49,12 +52,12 @@ impl<F: Field> ExecutionGadget<F> for SignextendGadget<F> {
         // need to do any changes. So just sum all the non-LSB byte
         // values here and then check if it's non-zero so we can use
         // that as an additional condition to enable the selector.
-        let is_msb_sum_zero = IsZeroGadget::construct(cb, sum::expr(&index.cells[1..32]));
+        let is_msb_sum_zero = IsZeroGadget::construct(cb, sum::expr(&index.limbs[1..32]));
 
         // Check if this byte is selected looking only at the LSB of the index
         // word
         let is_byte_selected =
-            array_init(|idx| IsEqualGadget::construct(cb, index.cells[0].expr(), idx.expr()));
+            array_init(|idx| IsEqualGadget::construct(cb, index.limbs[0].expr(), idx.expr()));
 
         // We need to find the byte we have to get the sign from so we can
         // extend correctly. We go byte by byte and check if `idx ==
@@ -72,7 +75,7 @@ impl<F: Field> ExecutionGadget<F> for SignextendGadget<F> {
             let is_selected = and::expr(&[is_byte_selected[idx].expr(), is_msb_sum_zero.expr()]);
 
             // Add the byte to the sum when this byte is selected
-            selected_byte = selected_byte + (is_selected.clone() * value.cells[idx].expr());
+            selected_byte = selected_byte + (is_selected.clone() * value.limbs[idx].expr());
 
             // Verify the selector.
             // Cells are used here to store intermediate results, otherwise
@@ -111,26 +114,23 @@ impl<F: Field> ExecutionGadget<F> for SignextendGadget<F> {
         // enabled need to be changed to the sign byte.
         // When a byte was selected all the **following** bytes need to be
         // replaced (hence the `selectors[idx - 1]`).
-        let result = rlc::expr(
-            &array_init::<_, _, 32>(|idx| {
-                if idx == 0 {
-                    value.cells[idx].expr()
-                } else {
-                    select::expr(
-                        selectors[idx - 1].expr(),
-                        sign_byte.expr(),
-                        value.cells[idx].expr(),
-                    )
-                }
-            }),
-            cb.challenges().evm_word(),
-        );
+        let result = Word32::new(array_init::<_, _, 32>(|idx| {
+            if idx == 0 {
+                value.limbs[idx].expr()
+            } else {
+                select::expr(
+                    selectors[idx - 1].expr(),
+                    sign_byte.expr(),
+                    value.limbs[idx].expr(),
+                )
+            }
+        }));
 
         // Pop the byte index and the value from the stack, push the result on
         // the stack
-        cb.stack_pop(index.expr());
-        cb.stack_pop(value.expr());
-        cb.stack_push(result);
+        cb.stack_pop_word(index.to_word());
+        cb.stack_pop_word(value.to_word());
+        cb.stack_push_word(result.to_word());
 
         // State transition
         let step_state_transition = StepStateTransition {
@@ -166,22 +166,24 @@ impl<F: Field> ExecutionGadget<F> for SignextendGadget<F> {
         self.same_context.assign_exec_step(region, offset, step)?;
 
         // Inputs/Outputs
-        let index = block.get_rws(step, 0).stack_value().to_le_bytes();
-        let value = block.get_rws(step, 1).stack_value().to_le_bytes();
-        self.index.assign(region, offset, Some(index))?;
-        self.value.assign(region, offset, Some(value))?;
+        let index = block.get_rws(step, 0).stack_value();
+        let index_bytes = index.to_le_bytes();
+        let value = block.get_rws(step, 1).stack_value();
+        let value_bytes = value.to_le_bytes();
+        self.index.assign_u256(region, offset, index)?;
+        self.value.assign_u256(region, offset, value)?;
 
         // Generate the selectors
         let msb_sum_zero =
             self.is_msb_sum_zero
-                .assign(region, offset, sum::value(&index[1..32]))?;
+                .assign(region, offset, sum::value(&index_bytes[1..32]))?;
         let mut previous_selector_value: F = 0.into();
         for i in 0..31 {
             let selected = and::value(vec![
                 self.is_byte_selected[i].assign(
                     region,
                     offset,
-                    F::from(index[0] as u64),
+                    F::from(index_bytes[0] as u64),
                     F::from(i as u64),
                 )?,
                 msb_sum_zero,
@@ -195,8 +197,8 @@ impl<F: Field> ExecutionGadget<F> for SignextendGadget<F> {
 
         // Set the sign byte
         let mut sign = 0u64;
-        if index[0] < 31 && msb_sum_zero == F::ONE {
-            sign = (value[index[0] as usize] >> 7) as u64;
+        if index_bytes[0] < 31 && msb_sum_zero == F::ONE {
+            sign = (value_bytes[index_bytes[0] as usize] >> 7) as u64;
         }
         self.sign_byte
             .assign(region, offset, Value::known(F::from(sign * 0xFF)))

--- a/zkevm-circuits/src/evm_circuit/execution/sload.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sload.rs
@@ -12,9 +12,12 @@ use crate::{
         witness::{Block, Call, ExecStep, Transaction},
     },
     table::CallContextFieldTag,
-    util::Expr,
+    util::{
+        word::{Word, WordCell, WordExpr},
+        Expr,
+    },
 };
-use eth_types::{Field, ToScalar};
+use eth_types::Field;
 use halo2_proofs::{circuit::Value, plonk::Error};
 
 #[derive(Clone, Debug)]
@@ -22,10 +25,10 @@ pub(crate) struct SloadGadget<F> {
     same_context: SameContextGadget<F>,
     tx_id: Cell<F>,
     reversion_info: ReversionInfo<F>,
-    callee_address: Cell<F>,
-    phase2_key: Cell<F>,
-    phase2_value: Cell<F>,
-    phase2_committed_value: Cell<F>,
+    callee_address: WordCell<F>,
+    key: WordCell<F>,
+    value: WordCell<F>,
+    committed_value: WordCell<F>,
     is_warm: Cell<F>,
 }
 
@@ -39,31 +42,31 @@ impl<F: Field> ExecutionGadget<F> for SloadGadget<F> {
 
         let tx_id = cb.call_context(None, CallContextFieldTag::TxId);
         let mut reversion_info = cb.reversion_info_read(None);
-        let callee_address = cb.call_context(None, CallContextFieldTag::CalleeAddress);
+        let callee_address = cb.call_context_read_as_word(None, CallContextFieldTag::CalleeAddress);
 
-        let phase2_key = cb.query_cell_phase2();
+        let key = cb.query_word_unchecked();
         // Pop the key from the stack
-        cb.stack_pop(phase2_key.expr());
+        cb.stack_pop_word(key.to_word());
 
-        let phase2_value = cb.query_cell_phase2();
-        let phase2_committed_value = cb.query_cell_phase2();
-        cb.account_storage_read(
-            callee_address.expr(),
-            phase2_key.expr(),
-            phase2_value.expr(),
+        let value = cb.query_word_unchecked();
+        let committed_value = cb.query_word_unchecked();
+        cb.account_storage_read_word(
+            callee_address.to_word(),
+            key.to_word(),
+            value.to_word(),
             tx_id.expr(),
-            phase2_committed_value.expr(),
+            committed_value.to_word(),
         );
 
-        cb.stack_push(phase2_value.expr());
+        cb.stack_push_word(value.to_word());
 
         let is_warm = cb.query_bool();
-        cb.account_storage_access_list_write(
+        cb.account_storage_access_list_write_word(
             tx_id.expr(),
-            callee_address.expr(),
-            phase2_key.expr(),
-            true.expr(),
-            is_warm.expr(),
+            callee_address.to_word(),
+            key.to_word(),
+            Word::from_lo_unchecked(true.expr()),
+            Word::from_lo_unchecked(is_warm.expr()),
             Some(&mut reversion_info),
         );
 
@@ -82,9 +85,9 @@ impl<F: Field> ExecutionGadget<F> for SloadGadget<F> {
             tx_id,
             reversion_info,
             callee_address,
-            phase2_key,
-            phase2_value,
-            phase2_committed_value,
+            key,
+            value,
+            committed_value,
             is_warm,
         }
     }
@@ -108,25 +111,17 @@ impl<F: Field> ExecutionGadget<F> for SloadGadget<F> {
             call.rw_counter_end_of_reversion,
             call.is_persistent,
         )?;
-        self.callee_address.assign(
-            region,
-            offset,
-            Value::known(
-                call.address
-                    .to_scalar()
-                    .expect("unexpected Address -> Scalar conversion failure"),
-            ),
-        )?;
+        self.callee_address
+            .assign_h160(region, offset, call.address)?;
+
         let key = block.get_rws(step, 4).stack_value();
         let value = block.get_rws(step, 6).stack_value();
-        self.phase2_key
-            .assign(region, offset, region.word_rlc(key))?;
-        self.phase2_value
-            .assign(region, offset, region.word_rlc(value))?;
+        self.key.assign_u256(region, offset, key)?;
+        self.value.assign_u256(region, offset, value)?;
 
         let (_, committed_value) = block.get_rws(step, 5).aux_pair();
-        self.phase2_committed_value
-            .assign(region, offset, region.word_rlc(committed_value))?;
+        self.committed_value
+            .assign_u256(region, offset, committed_value)?;
 
         let (_, is_warm) = block.get_rws(step, 7).tx_access_list_value_pair();
         self.is_warm

--- a/zkevm-circuits/src/evm_circuit/execution/sstore.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sstore.rs
@@ -9,16 +9,19 @@ use crate::{
                 ConstrainBuilderCommon, EVMConstraintBuilder, ReversionInfo, StepStateTransition,
                 Transition::Delta,
             },
-            math_gadget::{IsEqualGadget, IsZeroGadget, LtGadget},
-            not, CachedRegion, Cell,
+            math_gadget::{IsEqualWordGadget, IsZeroWordGadget, LtGadget},
+            not, CachedRegion, Cell, U64Cell,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
     table::CallContextFieldTag,
-    util::Expr,
+    util::{
+        word::{Word, Word32Cell, WordCell, WordExpr},
+        Expr,
+    },
 };
 
-use eth_types::{evm_types::GasCost, Field, ToScalar};
+use eth_types::{evm_types::GasCost, Field};
 use halo2_proofs::{
     circuit::Value,
     plonk::{Error, Expression},
@@ -30,16 +33,16 @@ pub(crate) struct SstoreGadget<F> {
     tx_id: Cell<F>,
     is_static: Cell<F>,
     reversion_info: ReversionInfo<F>,
-    callee_address: Cell<F>,
-    phase2_key: Cell<F>,
-    phase2_value: Cell<F>,
-    phase2_value_prev: Cell<F>,
-    phase2_original_value: Cell<F>,
+    callee_address: WordCell<F>,
+    key: Word32Cell<F>,
+    value: Word32Cell<F>,
+    value_prev: Word32Cell<F>,
+    original_value: Word32Cell<F>,
     is_warm: Cell<F>,
-    tx_refund_prev: Cell<F>,
+    tx_refund_prev: U64Cell<F>,
     // Constrain for SSTORE reentrancy sentry.
     sufficient_gas_sentry: LtGadget<F, N_BYTES_GAS>,
-    gas_cost: SstoreGasGadget<F>,
+    gas_cost: SstoreGasGadget<F, Word32Cell<F>>,
     tx_refund: SstoreTxRefundGadget<F>,
 }
 
@@ -58,35 +61,35 @@ impl<F: Field> ExecutionGadget<F> for SstoreGadget<F> {
         cb.require_zero("is_static is false", is_static.expr());
 
         let mut reversion_info = cb.reversion_info_read(None);
-        let callee_address = cb.call_context(None, CallContextFieldTag::CalleeAddress);
+        let callee_address = cb.call_context_read_as_word(None, CallContextFieldTag::CalleeAddress);
 
-        let phase2_key = cb.query_cell_phase2();
+        let key = cb.query_word32();
         // Pop the key from the stack
-        cb.stack_pop(phase2_key.expr());
+        cb.stack_pop_word(key.to_word());
 
-        let phase2_value = cb.query_cell_phase2();
+        let value = cb.query_word32();
         // Pop the value from the stack
-        cb.stack_pop(phase2_value.expr());
+        cb.stack_pop_word(value.to_word());
 
-        let phase2_value_prev = cb.query_cell_phase2();
-        let phase2_original_value = cb.query_cell_phase2();
-        cb.account_storage_write(
-            callee_address.expr(),
-            phase2_key.expr(),
-            phase2_value.expr(),
-            phase2_value_prev.expr(),
+        let value_prev = cb.query_word32();
+        let original_value = cb.query_word32();
+        cb.account_storage_write_word(
+            callee_address.to_word(),
+            key.to_word(),
+            value.to_word(),
+            value_prev.to_word(),
             tx_id.expr(),
-            phase2_original_value.expr(),
+            original_value.to_word(),
             Some(&mut reversion_info),
         );
 
         let is_warm = cb.query_bool();
-        cb.account_storage_access_list_write(
+        cb.account_storage_access_list_write_word(
             tx_id.expr(),
-            callee_address.expr(),
-            phase2_key.expr(),
-            true.expr(),
-            is_warm.expr(),
+            callee_address.to_word(),
+            key.to_word(),
+            Word::from_lo_unchecked(true.expr()),
+            Word::from_lo_unchecked(is_warm.expr()),
             Some(&mut reversion_info),
         );
 
@@ -104,24 +107,24 @@ impl<F: Field> ExecutionGadget<F> for SstoreGadget<F> {
 
         let gas_cost = SstoreGasGadget::construct(
             cb,
-            phase2_value.clone(),
-            phase2_value_prev.clone(),
-            phase2_original_value.clone(),
             is_warm.clone(),
+            value.clone(),
+            value_prev.clone(),
+            original_value.clone(),
         );
 
-        let tx_refund_prev = cb.query_cell();
+        let tx_refund_prev = cb.query_u64();
         let tx_refund = SstoreTxRefundGadget::construct(
             cb,
             tx_refund_prev.clone(),
-            phase2_value.clone(),
-            phase2_value_prev.clone(),
-            phase2_original_value.clone(),
+            value.clone(),
+            value_prev.clone(),
+            original_value.clone(),
         );
-        cb.tx_refund_write(
+        cb.tx_refund_write_word(
             tx_id.expr(),
-            tx_refund.expr(),
-            tx_refund_prev.expr(),
+            Word::from_lo_unchecked(tx_refund.expr()),
+            tx_refund_prev.to_word(),
             Some(&mut reversion_info),
         );
 
@@ -141,10 +144,10 @@ impl<F: Field> ExecutionGadget<F> for SstoreGadget<F> {
             is_static,
             reversion_info,
             callee_address,
-            phase2_key,
-            phase2_value,
-            phase2_value_prev,
-            phase2_original_value,
+            key,
+            value,
+            value_prev,
+            original_value,
             is_warm,
             tx_refund_prev,
             sufficient_gas_sentry,
@@ -174,28 +177,18 @@ impl<F: Field> ExecutionGadget<F> for SstoreGadget<F> {
             call.rw_counter_end_of_reversion,
             call.is_persistent,
         )?;
-        self.callee_address.assign(
-            region,
-            offset,
-            Value::known(
-                call.address
-                    .to_scalar()
-                    .expect("unexpected Address -> Scalar conversion failure"),
-            ),
-        )?;
+        self.callee_address
+            .assign_h160(region, offset, call.address)?;
 
         let key = block.get_rws(step, 5).stack_value();
         let value = block.get_rws(step, 6).stack_value();
-        self.phase2_key
-            .assign(region, offset, region.word_rlc(key))?;
-        self.phase2_value
-            .assign(region, offset, region.word_rlc(value))?;
+        self.key.assign_u256(region, offset, key)?;
+        self.value.assign_u256(region, offset, value)?;
 
         let (_, value_prev, _, original_value) = block.get_rws(step, 7).storage_value_aux();
-        self.phase2_value_prev
-            .assign(region, offset, region.word_rlc(value_prev))?;
-        self.phase2_original_value
-            .assign(region, offset, region.word_rlc(original_value))?;
+        self.value_prev.assign_u256(region, offset, value_prev)?;
+        self.original_value
+            .assign_u256(region, offset, original_value)?;
 
         let (_, is_warm) = block.get_rws(step, 8).tx_access_list_value_pair();
         self.is_warm
@@ -203,7 +196,7 @@ impl<F: Field> ExecutionGadget<F> for SstoreGadget<F> {
 
         let (tx_refund, tx_refund_prev) = block.get_rws(step, 9).tx_refund_value_pair();
         self.tx_refund_prev
-            .assign(region, offset, Value::known(F::from(tx_refund_prev)))?;
+            .assign(region, offset, Some(tx_refund_prev.to_le_bytes()))?;
 
         self.sufficient_gas_sentry.assign_value(
             region,
@@ -230,36 +223,34 @@ impl<F: Field> ExecutionGadget<F> for SstoreGadget<F> {
 
 #[derive(Clone, Debug)]
 pub(crate) struct SstoreTxRefundGadget<F> {
-    tx_refund_old: Cell<F>,
+    tx_refund_old: U64Cell<F>,
     tx_refund_new: Expression<F>,
-    value: Cell<F>,
-    value_prev: Cell<F>,
-    original_value: Cell<F>,
-    value_prev_is_zero_gadget: IsZeroGadget<F>,
-    value_is_zero_gadget: IsZeroGadget<F>,
-    original_is_zero_gadget: IsZeroGadget<F>,
-    original_eq_value_gadget: IsEqualGadget<F>,
-    prev_eq_value_gadget: IsEqualGadget<F>,
-    original_eq_prev_gadget: IsEqualGadget<F>,
+    value_prev_is_zero_gadget: IsZeroWordGadget<F, Word<Expression<F>>>,
+    value_is_zero_gadget: IsZeroWordGadget<F, Word<Expression<F>>>,
+    original_is_zero_gadget: IsZeroWordGadget<F, Word<Expression<F>>>,
+    original_eq_value_gadget: IsEqualWordGadget<F, Word<Expression<F>>, Word<Expression<F>>>,
+    prev_eq_value_gadget: IsEqualWordGadget<F, Word<Expression<F>>, Word<Expression<F>>>,
+    original_eq_prev_gadget: IsEqualWordGadget<F, Word<Expression<F>>, Word<Expression<F>>>,
 }
 
 impl<F: Field> SstoreTxRefundGadget<F> {
-    pub(crate) fn construct(
+    pub(crate) fn construct<T: WordExpr<F>>(
         cb: &mut EVMConstraintBuilder<F>,
-        tx_refund_old: Cell<F>,
-        value: Cell<F>,
-        value_prev: Cell<F>,
-        original_value: Cell<F>,
+        tx_refund_old: U64Cell<F>,
+        value: T,
+        value_prev: T,
+        original_value: T,
     ) -> Self {
-        let value_prev_is_zero_gadget = IsZeroGadget::construct(cb, value_prev.expr());
-        let value_is_zero_gadget = IsZeroGadget::construct(cb, value.expr());
-        let original_is_zero_gadget = IsZeroGadget::construct(cb, original_value.expr());
+        let value_prev_is_zero_gadget = IsZeroWordGadget::construct(cb, &value_prev.to_word());
+        let value_is_zero_gadget = IsZeroWordGadget::construct(cb, &value.to_word());
+        let original_is_zero_gadget = IsZeroWordGadget::construct(cb, &original_value.to_word());
 
         let original_eq_value_gadget =
-            IsEqualGadget::construct(cb, original_value.expr(), value.expr());
-        let prev_eq_value_gadget = IsEqualGadget::construct(cb, value_prev.expr(), value.expr());
+            IsEqualWordGadget::construct(cb, &original_value.to_word(), &value.to_word());
+        let prev_eq_value_gadget =
+            IsEqualWordGadget::construct(cb, &value_prev.to_word(), &value.to_word());
         let original_eq_prev_gadget =
-            IsEqualGadget::construct(cb, original_value.expr(), value_prev.expr());
+            IsEqualWordGadget::construct(cb, &original_value.to_word(), &value_prev.to_word());
 
         let value_prev_is_zero = value_prev_is_zero_gadget.expr();
         let value_is_zero = value_is_zero_gadget.expr();
@@ -294,9 +285,6 @@ impl<F: Field> SstoreTxRefundGadget<F> {
             - recreate_slot * (GasCost::SSTORE_CLEARS_SCHEDULE.expr());
 
         Self {
-            value,
-            value_prev,
-            original_value,
             tx_refund_old,
             tx_refund_new,
             value_prev_is_zero_gadget,
@@ -325,38 +313,30 @@ impl<F: Field> SstoreTxRefundGadget<F> {
         original_value: eth_types::Word,
     ) -> Result<(), Error> {
         self.tx_refund_old
-            .assign(region, offset, Value::known(F::from(tx_refund_old)))?;
-        self.value.assign(region, offset, region.word_rlc(value))?;
-        self.value_prev
-            .assign(region, offset, region.word_rlc(value_prev))?;
-        self.original_value
-            .assign(region, offset, region.word_rlc(original_value))?;
+            .assign(region, offset, Some(tx_refund_old.to_le_bytes()))?;
         self.value_prev_is_zero_gadget
-            .assign_value(region, offset, region.word_rlc(value_prev))?;
+            .assign(region, offset, Word::from(value_prev))?;
         self.value_is_zero_gadget
-            .assign_value(region, offset, region.word_rlc(value))?;
-        self.original_is_zero_gadget.assign_value(
+            .assign(region, offset, Word::from(value))?;
+        self.original_is_zero_gadget
+            .assign(region, offset, Word::from(original_value))?;
+        self.original_eq_value_gadget.assign(
             region,
             offset,
-            region.word_rlc(original_value),
+            Word::from(original_value),
+            Word::from(value),
         )?;
-        self.original_eq_value_gadget.assign_value(
+        self.prev_eq_value_gadget.assign(
             region,
             offset,
-            region.word_rlc(original_value),
-            region.word_rlc(value),
+            Word::from(value_prev),
+            Word::from(value),
         )?;
-        self.prev_eq_value_gadget.assign_value(
+        self.original_eq_prev_gadget.assign(
             region,
             offset,
-            region.word_rlc(value_prev),
-            region.word_rlc(value),
-        )?;
-        self.original_eq_prev_gadget.assign_value(
-            region,
-            offset,
-            region.word_rlc(original_value),
-            region.word_rlc(value_prev),
+            Word::from(original_value),
+            Word::from(value_prev),
         )?;
         debug_assert_eq!(
             calc_expected_tx_refund(tx_refund_old, value, value_prev, original_value),

--- a/zkevm-circuits/src/evm_circuit/execution/stop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/stop.rs
@@ -14,7 +14,10 @@ use crate::{
         witness::{Block, Call, ExecStep, Transaction},
     },
     table::CallContextFieldTag,
-    util::Expr,
+    util::{
+        word::{Word, WordExpr},
+        Expr,
+    },
 };
 use bus_mapping::evm::OpcodeId;
 use eth_types::{Field, ToWord};
@@ -35,7 +38,7 @@ impl<F: Field> ExecutionGadget<F> for StopGadget<F> {
 
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
         let code_length = cb.query_cell();
-        cb.bytecode_length(cb.curr.state.code_hash.expr(), code_length.expr());
+        cb.bytecode_length_word(cb.curr.state.code_hash.to_word(), code_length.expr());
         let is_out_of_range = IsZeroGadget::construct(
             cb,
             code_length.expr() - cb.curr.state.program_counter.expr(),
@@ -54,7 +57,11 @@ impl<F: Field> ExecutionGadget<F> for StopGadget<F> {
         );
 
         // Call ends with STOP must be successful
-        cb.call_context_lookup(false.expr(), None, CallContextFieldTag::IsSuccess, 1.expr());
+        cb.call_context_lookup_read(
+            None,
+            CallContextFieldTag::IsSuccess,
+            Word::from_lo_unchecked(1.expr()),
+        );
 
         let is_to_end_tx = cb.next.execution_state_selector([ExecutionState::EndTx]);
         cb.require_equal(

--- a/zkevm-circuits/src/evm_circuit/execution/stop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/stop.rs
@@ -57,11 +57,7 @@ impl<F: Field> ExecutionGadget<F> for StopGadget<F> {
         );
 
         // Call ends with STOP must be successful
-        cb.call_context_lookup_read(
-            None,
-            CallContextFieldTag::IsSuccess,
-            Word::from_lo_unchecked(1.expr()),
-        );
+        cb.call_context_lookup_read(None, CallContextFieldTag::IsSuccess, Word::one());
 
         let is_to_end_tx = cb.next.execution_state_selector([ExecutionState::EndTx]);
         cb.require_equal(

--- a/zkevm-circuits/src/evm_circuit/param.rs
+++ b/zkevm-circuits/src/evm_circuit/param.rs
@@ -80,6 +80,9 @@ pub(crate) const MAX_N_BYTES_INTEGER: usize = 31;
 // Number of bytes an EVM word has.
 pub(crate) const N_BYTES_WORD: usize = 32;
 
+// Number of bytes an half EVM word has.
+pub(crate) const N_BYTES_HALF_WORD: usize = N_BYTES_WORD / 2;
+
 // Number of bytes an u64 has.
 pub(crate) const N_BYTES_U64: usize = 8;
 

--- a/zkevm-circuits/src/evm_circuit/step.rs
+++ b/zkevm-circuits/src/evm_circuit/step.rs
@@ -66,9 +66,7 @@ pub enum ExecutionState {
     RETURNDATACOPY,
     EXTCODEHASH,
     BLOCKHASH,
-    BLOCKCTXU64,  // TIMESTAMP, NUMBER, GASLIMIT
-    BLOCKCTXU160, // COINBASE
-    BLOCKCTXU256, // DIFFICULTY, BASEFEE
+    BLOCKCTX, // TIMESTAMP, NUMBER, GASLIMIT, COINBASE, DIFFICULTY, BASEFEE
     CHAINID,
     SELFBALANCE,
     POP,
@@ -239,11 +237,12 @@ impl From<&ExecStep> for ExecutionState {
                     OpcodeId::EXTCODEHASH => ExecutionState::EXTCODEHASH,
                     OpcodeId::EXTCODESIZE => ExecutionState::EXTCODESIZE,
                     OpcodeId::BLOCKHASH => ExecutionState::BLOCKHASH,
-                    OpcodeId::TIMESTAMP | OpcodeId::NUMBER | OpcodeId::GASLIMIT => {
-                        ExecutionState::BLOCKCTXU64
-                    }
-                    OpcodeId::COINBASE => ExecutionState::BLOCKCTXU160,
-                    OpcodeId::DIFFICULTY | OpcodeId::BASEFEE => ExecutionState::BLOCKCTXU256,
+                    OpcodeId::TIMESTAMP
+                    | OpcodeId::NUMBER
+                    | OpcodeId::GASLIMIT
+                    | OpcodeId::COINBASE
+                    | OpcodeId::DIFFICULTY
+                    | OpcodeId::BASEFEE => ExecutionState::BLOCKCTX,
                     OpcodeId::GAS => ExecutionState::GAS,
                     OpcodeId::SAR => ExecutionState::SAR,
                     OpcodeId::SELFBALANCE => ExecutionState::SELFBALANCE,
@@ -379,9 +378,14 @@ impl ExecutionState {
             Self::RETURNDATACOPY => vec![OpcodeId::RETURNDATACOPY],
             Self::EXTCODEHASH => vec![OpcodeId::EXTCODEHASH],
             Self::BLOCKHASH => vec![OpcodeId::BLOCKHASH],
-            Self::BLOCKCTXU64 => vec![OpcodeId::TIMESTAMP, OpcodeId::NUMBER, OpcodeId::GASLIMIT],
-            Self::BLOCKCTXU160 => vec![OpcodeId::COINBASE],
-            Self::BLOCKCTXU256 => vec![OpcodeId::DIFFICULTY, OpcodeId::BASEFEE],
+            Self::BLOCKCTX => vec![
+                OpcodeId::TIMESTAMP,
+                OpcodeId::NUMBER,
+                OpcodeId::GASLIMIT,
+                OpcodeId::COINBASE,
+                OpcodeId::DIFFICULTY,
+                OpcodeId::BASEFEE,
+            ],
             Self::CHAINID => vec![OpcodeId::CHAINID],
             Self::SELFBALANCE => vec![OpcodeId::SELFBALANCE],
             Self::POP => vec![OpcodeId::POP],

--- a/zkevm-circuits/src/evm_circuit/step.rs
+++ b/zkevm-circuits/src/evm_circuit/step.rs
@@ -15,7 +15,7 @@ use bus_mapping::{
     error::{DepthError, ExecError, InsufficientBalanceError, NonceUintOverflowError, OogError},
     evm::OpcodeId,
 };
-use eth_types::{evm_unimplemented, Field};
+use eth_types::{evm_unimplemented, Field, ToWord};
 use halo2_proofs::{
     circuit::Value,
     plonk::{Advice, Column, ConstraintSystem, Error, Expression},
@@ -738,7 +738,7 @@ impl<F: Field> Step<F> {
         )?;
         self.state
             .code_hash
-            .assign(region, offset, Some(call.code_hash.to_fixed_bytes()))?;
+            .assign_u256(region, offset, call.code_hash.to_word())?;
         self.state
             .program_counter
             .assign(region, offset, Value::known(F::from(step.pc)))?;

--- a/zkevm-circuits/src/evm_circuit/table.rs
+++ b/zkevm-circuits/src/evm_circuit/table.rs
@@ -141,8 +141,7 @@ pub struct RwValues<F> {
     pub storage_key: Word<Expression<F>>,
     pub value: Word<Expression<F>>,
     pub value_prev: Word<Expression<F>>,
-    pub aux1: Expression<F>,
-    pub aux2: Expression<F>,
+    pub init_val: Word<Expression<F>>,
 }
 
 impl<F: Field> RwValues<F> {
@@ -154,8 +153,7 @@ impl<F: Field> RwValues<F> {
         storage_key: Word<Expression<F>>,
         value: Word<Expression<F>>,
         value_prev: Word<Expression<F>>,
-        aux1: Expression<F>,
-        aux2: Expression<F>,
+        init_val: Word<Expression<F>>,
     ) -> Self {
         Self {
             id,
@@ -164,8 +162,7 @@ impl<F: Field> RwValues<F> {
             storage_key,
             value,
             value_prev,
-            aux1,
-            aux2,
+            init_val,
         }
     }
 }
@@ -237,11 +234,11 @@ pub(crate) enum Lookup<F> {
         /// Whether the row is the first row of the copy event.
         is_first: Expression<F>,
         /// The source ID for the copy event.
-        src_id: Expression<F>,
+        src_id: Word<Expression<F>>,
         /// The source tag for the copy event.
         src_tag: Expression<F>,
         /// The destination ID for the copy event.
-        dst_id: Expression<F>,
+        dst_id: Word<Expression<F>>,
         /// The destination tag for the copy event.
         dst_tag: Expression<F>,
         /// The source address where bytes are copied from.
@@ -336,8 +333,8 @@ impl<F: Field> Lookup<F> {
                 values.value.hi(),
                 values.value_prev.lo(),
                 values.value_prev.hi(),
-                values.aux1.clone(),
-                values.aux2.clone(),
+                values.init_val.lo(),
+                values.init_val.hi(),
             ],
             Self::Bytecode {
                 hash,
@@ -373,9 +370,11 @@ impl<F: Field> Lookup<F> {
                 rwc_inc,
             } => vec![
                 is_first.clone(),
-                src_id.clone(),
+                src_id.lo(),
+                src_id.hi(),
                 src_tag.clone(),
-                dst_id.clone(),
+                dst_id.lo(),
+                dst_id.hi(),
                 dst_tag.clone(),
                 src_addr.clone(),
                 src_addr_end.clone(),

--- a/zkevm-circuits/src/evm_circuit/util.rs
+++ b/zkevm-circuits/src/evm_circuit/util.rs
@@ -10,6 +10,7 @@ use crate::{
         },
         table::Table,
     },
+    util::int_decomposition::IntDecomposition,
     witness::{Block, ExecStep, Rw, RwMap},
 };
 use bus_mapping::state_db::CodeDB;
@@ -36,7 +37,7 @@ pub use gadgets::util::{and, not, or, select, sum};
 use super::param::{N_BYTES_ACCOUNT_ADDRESS, N_BYTES_U64};
 
 #[derive(Clone, Debug)]
-pub(crate) struct Cell<F> {
+pub struct Cell<F> {
     // expression for constraint
     expression: Expression<F>,
     column: Column<Advice>,
@@ -490,6 +491,7 @@ pub struct RandomLinearCombination<F, const N: usize> {
 impl<F: Field, const N: usize> RandomLinearCombination<F, N> {
     const N_BYTES: usize = N;
 
+    /// XXX for randomness 256.expr(), consider using IntDecomposition instead
     pub(crate) fn new(cells: [Cell<F>; N], randomness: Expression<F>) -> Self {
         Self {
             expression: rlc::expr(&cells.clone().map(|cell| cell.expr()), randomness),
@@ -521,44 +523,11 @@ impl<F: Field, const N: usize> Expr<F> for RandomLinearCombination<F, N> {
     }
 }
 
-pub(crate) type MemoryAddress<F> = RandomLinearCombination<F, N_BYTES_MEMORY_ADDRESS>;
+pub(crate) type MemoryAddress<F> = IntDecomposition<F, N_BYTES_MEMORY_ADDRESS>;
 
-impl<F: Field> WordExpr<F> for MemoryAddress<F> {
-    fn to_word(&self) -> Word<Expression<F>> {
-        Word::from_lo_unchecked(self.expr())
-    }
-}
+pub(crate) type AccountAddress<F> = IntDecomposition<F, N_BYTES_ACCOUNT_ADDRESS>;
 
-pub(crate) type AccountAddress<F> = RandomLinearCombination<F, N_BYTES_ACCOUNT_ADDRESS>;
-
-impl<F: Field> WordExpr<F> for AccountAddress<F> {
-    fn to_word(&self) -> Word<Expression<F>> {
-        Word::new([
-            rlc::expr(
-                &self.cells[0..16]
-                    .iter()
-                    .map(|cell| cell.expr())
-                    .collect_vec(),
-                256.expr(),
-            ),
-            rlc::expr(
-                &self.cells[16..]
-                    .iter()
-                    .map(|cell| cell.expr())
-                    .collect_vec(),
-                256.expr(),
-            ),
-        ])
-    }
-}
-
-pub(crate) type U64Cell<F> = RandomLinearCombination<F, N_BYTES_U64>;
-
-impl<F: Field> WordExpr<F> for U64Cell<F> {
-    fn to_word(&self) -> Word<Expression<F>> {
-        Word::from_lo_unchecked(self.expr())
-    }
-}
+pub(crate) type U64Cell<F> = IntDecomposition<F, N_BYTES_U64>;
 
 /// Decodes a field element from its byte representation in little endian order
 pub(crate) mod from_bytes {

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -1048,10 +1048,10 @@ impl<F: Field> CommonErrorGadget<F> {
         step: &ExecStep,
         rw_offset: usize,
     ) -> Result<u64, Error> {
-        self.rw_counter_end_of_reversion.assign_lo(
+        self.rw_counter_end_of_reversion.assign_u64(
             region,
             offset,
-            Value::known(F::from(call.rw_counter_end_of_reversion as u64)),
+            call.rw_counter_end_of_reversion as u64,
         )?;
         self.restore_context
             .assign(region, offset, block, call, step, rw_offset)?;

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -161,7 +161,7 @@ impl<F: Field> RestoreContextGadget<F> {
             ),
         ] {
             // TODO review and assure range check
-            cb.call_context_lookup_write_unchecked(
+            cb.call_context_lookup_write(
                 Some(caller_id.expr()),
                 field_tag,
                 Word::from_lo_unchecked(value),

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -7,7 +7,7 @@ use super::{
 };
 use crate::{
     evm_circuit::{
-        param::{N_BYTES_ACCOUNT_ADDRESS, N_BYTES_GAS, N_BYTES_MEMORY_WORD_SIZE},
+        param::{N_BYTES_GAS, N_BYTES_MEMORY_WORD_SIZE},
         step::ExecutionState,
         table::{FixedTableTag, Lookup},
         util::{
@@ -756,13 +756,8 @@ impl<F: Field, const IS_SUCCESS_CALL: bool> CommonCallGadget<F, IS_SUCCESS_CALL>
         callee_code_hash: U256,
     ) -> Result<u64, Error> {
         self.gas.assign_u256(region, offset, gas)?;
-        self.callee_address_word.assign(
-            region,
-            offset,
-            callee_address.to_le_bytes()[0..N_BYTES_ACCOUNT_ADDRESS]
-                .try_into()
-                .ok(),
-        )?;
+        self.callee_address_word
+            .assign_u256(region, offset, callee_address)?;
         self.value.assign_u256(region, offset, value)?;
         if IS_SUCCESS_CALL {
             self.is_success

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -21,7 +21,7 @@ use crate::{
     },
     table::{AccountFieldTag, CallContextFieldTag},
     util::{
-        word::{Word, Word32Cell, WordCell, WordExpr},
+        word::{Word, Word32, Word32Cell, WordCell, WordExpr},
         Expr,
     },
     witness::{Block, Call, ExecStep},
@@ -118,10 +118,15 @@ impl<F: Field> RestoreContextGadget<F> {
     ) -> Self {
         // Read caller's context for restore
         let caller_id = cb.call_context(None, CallContextFieldTag::CallerId);
-        let [caller_is_root, caller_is_create, caller_program_counter, caller_stack_pointer, caller_gas_left, caller_memory_word_size, caller_reversible_write_counter] =
+        let [caller_is_root, caller_is_create] =
+            [CallContextFieldTag::IsRoot, CallContextFieldTag::IsCreate]
+                .map(|field_tag| cb.call_context(Some(caller_id.expr()), field_tag));
+
+        let caller_code_hash =
+            cb.call_context_read_as_word(Some(caller_id.expr()), CallContextFieldTag::CodeHash);
+
+        let [caller_program_counter, caller_stack_pointer, caller_gas_left, caller_memory_word_size, caller_reversible_write_counter] =
             [
-                CallContextFieldTag::IsRoot,
-                CallContextFieldTag::IsCreate,
                 CallContextFieldTag::ProgramCounter,
                 CallContextFieldTag::StackPointer,
                 CallContextFieldTag::GasLeft,
@@ -129,9 +134,6 @@ impl<F: Field> RestoreContextGadget<F> {
                 CallContextFieldTag::ReversibleWriteCounter,
             ]
             .map(|field_tag| cb.call_context(Some(caller_id.expr()), field_tag));
-
-        let caller_code_hash =
-            cb.call_context_read_as_word(Some(caller_id.expr()), CallContextFieldTag::CodeHash);
 
         // Update caller's last callee information
         // EIP-211 CREATE/CREATE2 call successful case should set RETURNDATASIZE = 0
@@ -197,7 +199,7 @@ impl<F: Field> RestoreContextGadget<F> {
             call_id: To(caller_id.expr()),
             is_root: To(caller_is_root.expr()),
             is_create: To(caller_is_create.expr()),
-            code_hash: To(caller_code_hash.expr()),
+            code_hash: To(caller_code_hash.to_word()),
             program_counter: To(caller_program_counter.expr()),
             stack_pointer: To(caller_stack_pointer.expr()),
             gas_left: To(gas_left),
@@ -261,7 +263,7 @@ impl<F: Field> RestoreContextGadget<F> {
         }
 
         self.caller_code_hash
-            .assign(region, offset, Some(caller_code_hash.to_le_bytes()))?;
+            .assign_u256(region, offset, caller_code_hash)?;
 
         Ok(())
     }
@@ -277,7 +279,7 @@ impl<F: Field, const N_ADDENDS: usize, const INCREASE: bool>
 {
     pub(crate) fn construct(
         cb: &mut EVMConstraintBuilder<F>,
-        address: Expression<F>,
+        address: Word<Expression<F>>,
         updates: Vec<Word32Cell<F>>,
         reversion_info: Option<&mut ReversionInfo<F>>,
     ) -> Self {
@@ -286,13 +288,13 @@ impl<F: Field, const N_ADDENDS: usize, const INCREASE: bool>
         let balance_addend = cb.query_word32();
         let balance_sum = cb.query_word32();
 
-        let [value, value_prev] = if INCREASE {
-            [balance_sum.word_expr(), balance_addend.word_expr()]
+        let [value, value_prev]: [Word32<Expression<F>>; 2] = if INCREASE {
+            [balance_sum.to_word_n(), balance_addend.to_word_n()]
         } else {
-            [balance_addend.word_expr(), balance_sum.word_expr()]
+            [balance_addend.to_word_n(), balance_sum.to_word_n()]
         };
 
-        let add_words = AddWordsGadget::construct_new(
+        let add_words = AddWordsGadget::construct(
             cb,
             std::iter::once(balance_addend)
                 .chain(updates.to_vec())
@@ -371,23 +373,9 @@ pub(crate) struct TransferWithGasFeeGadget<F> {
 impl<F: Field> TransferWithGasFeeGadget<F> {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn construct(
-        _cb: &mut EVMConstraintBuilder<F>,
-        _sender_address: Expression<F>,
-        _receiver_address: Expression<F>,
-        _receiver_exists: Expression<F>,
-        _must_create: Expression<F>,
-        _value: Word<F>,
-        _gas_fee: Word<F>,
-        _reversion_info: &mut ReversionInfo<F>,
-    ) -> Self {
-        todo!()
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn construct_new(
         cb: &mut EVMConstraintBuilder<F>,
-        sender_address: Expression<F>,
-        receiver_address: Expression<F>,
+        sender_address: Word<Expression<F>>,
+        receiver_address: Word<Expression<F>>,
         receiver_exists: Expression<F>,
         must_create: Expression<F>,
         value: Word32Cell<F>,
@@ -395,8 +383,8 @@ impl<F: Field> TransferWithGasFeeGadget<F> {
         reversion_info: &mut ReversionInfo<F>,
     ) -> Self {
         let sender_sub_fee =
-            UpdateBalanceGadget::construct(cb, sender_address.expr(), vec![gas_fee], None);
-        let value_is_zero = IsZeroWordGadget::construct(cb, value.clone());
+            UpdateBalanceGadget::construct(cb, sender_address.to_word(), vec![gas_fee], None);
+        let value_is_zero = IsZeroWordGadget::construct(cb, &value);
         // If receiver doesn't exist, create it
         cb.condition(
             or::expr([
@@ -519,14 +507,14 @@ pub(crate) struct TransferGadget<F> {
 impl<F: Field> TransferGadget<F> {
     pub(crate) fn construct(
         cb: &mut EVMConstraintBuilder<F>,
-        sender_address: Expression<F>,
-        receiver_address: Expression<F>,
+        sender_address: Word<Expression<F>>,
+        receiver_address: Word<Expression<F>>,
         receiver_exists: Expression<F>,
         must_create: Expression<F>,
         value: Word32Cell<F>,
         reversion_info: &mut ReversionInfo<F>,
     ) -> Self {
-        let value_is_zero = IsZeroWordGadget::construct(cb, value.clone());
+        let value_is_zero = IsZeroWordGadget::construct(cb, &value);
         // If receiver doesn't exist, create it
         cb.condition(
             or::expr([
@@ -622,7 +610,7 @@ pub(crate) struct CommonCallGadget<F, const IS_SUCCESS_CALL: bool> {
 
     pub gas: Word32Cell<F>,
     pub gas_is_u64: IsZeroGadget<F>,
-    pub callee_address: AccountAddress<F>,
+    pub callee_address_word: AccountAddress<F>,
     pub value: Word32Cell<F>,
     pub cd_address: MemoryAddressGadget<F>,
     pub rd_address: MemoryAddressGadget<F>,
@@ -654,10 +642,10 @@ impl<F: Field, const IS_SUCCESS_CALL: bool> CommonCallGadget<F, IS_SUCCESS_CALL>
         let gas_word = cb.query_word32();
         let callee_address_word = cb.query_account_address();
         let value = cb.query_word32();
-        let cd_offset = cb.query_word32();
-        let cd_length = cb.query_word32();
-        let rd_offset = cb.query_word32();
-        let rd_length = cb.query_word32();
+        let cd_offset = cb.query_word_unchecked();
+        let cd_length = cb.query_memory_address();
+        let rd_offset = cb.query_word_unchecked();
+        let rd_length = cb.query_memory_address();
         let is_success = cb.query_bool();
 
         // Lookup values from stack
@@ -687,13 +675,13 @@ impl<F: Field, const IS_SUCCESS_CALL: bool> CommonCallGadget<F, IS_SUCCESS_CALL>
 
         // Recomposition of random linear combination to integer
         let gas_is_u64 = IsZeroGadget::construct(cb, sum::expr(&gas_word.limbs[N_BYTES_GAS..]));
-        let cd_address = MemoryAddressGadget::construct_new(cb, cd_offset, cd_length);
-        let rd_address = MemoryAddressGadget::construct_new(cb, rd_offset, rd_length);
+        let cd_address = MemoryAddressGadget::construct(cb, cd_offset, cd_length);
+        let rd_address = MemoryAddressGadget::construct(cb, rd_offset, rd_length);
         let memory_expansion =
             MemoryExpansionGadget::construct(cb, [cd_address.address(), rd_address.address()]);
 
         // construct common gadget
-        let value_is_zero = IsZeroWordGadget::construct(cb, value.clone());
+        let value_is_zero = IsZeroWordGadget::construct(cb, &value);
         let has_value = select::expr(
             is_delegatecall.expr() + is_staticcall.expr(),
             0.expr(),
@@ -702,17 +690,17 @@ impl<F: Field, const IS_SUCCESS_CALL: bool> CommonCallGadget<F, IS_SUCCESS_CALL>
 
         let callee_code_hash = cb.query_word_unchecked();
         cb.account_read_word(
-            callee_address_word.expr(),
+            callee_address_word.to_word(),
             AccountFieldTag::CodeHash,
             callee_code_hash.to_word(),
         );
         let is_empty_code_hash =
-            IsEqualWordGadget::construct(cb, callee_code_hash.clone(), cb.empty_code_hash_word());
-        let callee_not_exists = IsZeroWordGadget::construct(cb, callee_code_hash.clone());
+            IsEqualWordGadget::construct(cb, &callee_code_hash, &cb.empty_code_hash_word());
+        let callee_not_exists = IsZeroWordGadget::construct(cb, &callee_code_hash);
 
         Self {
             is_success,
-            callee_address: callee_address_word,
+            callee_address_word,
             gas: gas_word,
             gas_is_u64,
             value,
@@ -727,8 +715,8 @@ impl<F: Field, const IS_SUCCESS_CALL: bool> CommonCallGadget<F, IS_SUCCESS_CALL>
         }
     }
 
-    pub fn callee_address_expr(&self) -> Expression<F> {
-        self.callee_address.expr()
+    pub fn callee_address_word(&self) -> Word<Expression<F>> {
+        self.callee_address_word.to_word()
     }
 
     pub fn gas_expr(&self) -> Expression<F> {
@@ -767,16 +755,15 @@ impl<F: Field, const IS_SUCCESS_CALL: bool> CommonCallGadget<F, IS_SUCCESS_CALL>
         memory_word_size: u64,
         callee_code_hash: U256,
     ) -> Result<u64, Error> {
-        self.gas.assign(region, offset, Some(gas.to_le_bytes()))?;
-        self.callee_address.assign(
+        self.gas.assign_u256(region, offset, gas)?;
+        self.callee_address_word.assign(
             region,
             offset,
             callee_address.to_le_bytes()[0..N_BYTES_ACCOUNT_ADDRESS]
                 .try_into()
                 .ok(),
         )?;
-        self.value
-            .assign(region, offset, Some(value.to_le_bytes()))?;
+        self.value.assign_u256(region, offset, value)?;
         if IS_SUCCESS_CALL {
             self.is_success
                 .assign(region, offset, Value::known(F::from(is_success.low_u64())))?;
@@ -802,7 +789,7 @@ impl<F: Field, const IS_SUCCESS_CALL: bool> CommonCallGadget<F, IS_SUCCESS_CALL>
         self.value_is_zero
             .assign(region, offset, Word::from(value))?;
         self.callee_code_hash
-            .assign(region, offset, Some(callee_code_hash.to_le_bytes()))?;
+            .assign_u256(region, offset, callee_code_hash)?;
         self.is_empty_code_hash.assign_value(
             region,
             offset,
@@ -869,39 +856,25 @@ impl<F: Field> SloadGasGadget<F> {
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct SstoreGasGadget<F> {
-    value: WordCell<F>,
-    value_prev: WordCell<F>,
-    original_value: WordCell<F>,
+pub(crate) struct SstoreGasGadget<F, T> {
     is_warm: Cell<F>,
     gas_cost: Expression<F>,
-    value_eq_prev: IsEqualWordGadget<F, WordCell<F>, WordCell<F>>,
-    original_eq_prev: IsEqualWordGadget<F, WordCell<F>, WordCell<F>>,
-    original_is_zero: IsZeroWordGadget<F, WordCell<F>>,
+    value_eq_prev: IsEqualWordGadget<F, T, T>,
+    original_eq_prev: IsEqualWordGadget<F, T, T>,
+    original_is_zero: IsZeroWordGadget<F, T>,
 }
 
-impl<F: Field> SstoreGasGadget<F> {
+impl<F: Field, T: WordExpr<F> + Clone> SstoreGasGadget<F, T> {
     pub(crate) fn construct(
-        _cb: &mut EVMConstraintBuilder<F>,
-        _value: Cell<F>,
-        _value_prev: Cell<F>,
-        _original_value: Cell<F>,
-        _is_warm: Cell<F>,
-    ) -> Self {
-        todo!()
-    }
-
-    pub(crate) fn construct_new(
         cb: &mut EVMConstraintBuilder<F>,
-        value: WordCell<F>,
-        value_prev: WordCell<F>,
-        original_value: WordCell<F>,
         is_warm: Cell<F>,
+        value: T,
+        value_prev: T,
+        original_value: T,
     ) -> Self {
-        let value_eq_prev = IsEqualWordGadget::construct(cb, value.clone(), value_prev.clone());
-        let original_eq_prev =
-            IsEqualWordGadget::construct(cb, original_value.clone(), value_prev.clone());
-        let original_is_zero = IsZeroWordGadget::construct(cb, original_value.clone());
+        let value_eq_prev = IsEqualWordGadget::construct(cb, &value, &value_prev);
+        let original_eq_prev = IsEqualWordGadget::construct(cb, &original_value, &value_prev);
+        let original_is_zero = IsZeroWordGadget::construct(cb, &original_value);
         let warm_case_gas = select::expr(
             value_eq_prev.expr(),
             GasCost::WARM_ACCESS.expr(),
@@ -922,9 +895,6 @@ impl<F: Field> SstoreGasGadget<F> {
         );
 
         Self {
-            value,
-            value_prev,
-            original_value,
             is_warm,
             gas_cost,
             value_eq_prev,
@@ -946,12 +916,6 @@ impl<F: Field> SstoreGasGadget<F> {
         original_value: eth_types::Word,
         is_warm: bool,
     ) -> Result<(), Error> {
-        self.value
-            .assign(region, offset, Some(value.to_le_bytes()))?;
-        self.value_prev
-            .assign(region, offset, Some(value_prev.to_le_bytes()))?;
-        self.original_value
-            .assign(region, offset, Some(original_value.to_le_bytes()))?;
         self.is_warm
             .assign(region, offset, Value::known(F::from(is_warm as u64)))?;
         self.value_eq_prev.assign_value(
@@ -1147,11 +1111,6 @@ impl<F: Field, const VALID_BYTES: usize> WordByteCapGadget<F, VALID_BYTES> {
         self.lt_cap.expr()
     }
 
-    #[deprecated(note = "in fav of original_word_new")]
-    pub(crate) fn original_word(&self) -> Expression<F> {
-        self.word.original.limbs[0].expr()
-    }
-
     pub(crate) fn original_word_new(&self) -> Word32Cell<F> {
         self.word.original.clone()
     }
@@ -1196,8 +1155,7 @@ impl<F: Field, const VALID_BYTES: usize> WordByteRangeGadget<F, VALID_BYTES> {
         offset: usize,
         original: U256,
     ) -> Result<bool, Error> {
-        self.original
-            .assign(region, offset, Some(original.to_le_bytes()))?;
+        self.original.assign_u256(region, offset, original)?;
 
         let overflow_hi = original.to_le_bytes()[VALID_BYTES..]
             .iter()
@@ -1214,11 +1172,6 @@ impl<F: Field, const VALID_BYTES: usize> WordByteRangeGadget<F, VALID_BYTES> {
 
     pub(crate) fn original(&self) -> Word<Expression<F>> {
         self.original.to_word()
-    }
-
-    #[deprecated(note = "in fav of original")]
-    pub(crate) fn original_word(&self) -> Expression<F> {
-        todo!()
     }
 
     pub(crate) fn valid_value(&self) -> Expression<F> {

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -477,15 +477,15 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
     }
 
     pub(crate) fn query_u64(&mut self) -> U64Cell<F> {
-        U64Cell::new(self.query_bytes(), 256u64.expr())
+        U64Cell::new(self.query_bytes())
     }
 
     pub(crate) fn query_account_address(&mut self) -> AccountAddress<F> {
-        AccountAddress::<F>::new(self.query_bytes(), 256u64.expr())
+        AccountAddress::<F>::new(self.query_bytes())
     }
 
     pub(crate) fn query_memory_address(&mut self) -> MemoryAddress<F> {
-        MemoryAddress::<F>::new(self.query_bytes(), 256u64.expr())
+        MemoryAddress::<F>::new(self.query_bytes())
     }
 
     pub(crate) fn query_bytes<const N: usize>(&mut self) -> [Cell<F>; N] {
@@ -747,17 +747,6 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         index: Option<Expression<F>>,
     ) -> WordCell<F> {
         let word = self.query_word_unchecked();
-        self.tx_context_lookup_word(id, field_tag, index, word.to_word());
-        word
-    }
-
-    pub(crate) fn tx_context_as_account_address(
-        &mut self,
-        id: Expression<F>,
-        field_tag: TxContextFieldTag,
-        index: Option<Expression<F>>,
-    ) -> AccountAddress<F> {
-        let word = self.query_account_address();
         self.tx_context_lookup_word(id, field_tag, index, word.to_word());
         word
     }

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -887,7 +887,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
     }
 
     // Access list
-    pub(crate) fn account_access_list_write(
+    pub(crate) fn account_access_list_write_unchecked(
         &mut self,
         tx_id: Expression<F>,
         account_address: Word<Expression<F>>,
@@ -1173,7 +1173,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         );
     }
 
-    pub(crate) fn call_context_lookup_write_unchecked(
+    pub(crate) fn call_context_lookup_write(
         &mut self,
         call_id: Option<Expression<F>>,
         field_tag: CallContextFieldTag,
@@ -1207,10 +1207,9 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         .map(|field_tag| {
             let cell = self.query_cell();
             if is_write {
-                self.call_context_lookup_write_unchecked(
+                self.call_context_lookup_write(
                     call_id.clone(),
                     field_tag,
-                    // TODO assure range check since write=true also possible
                     Word::from_lo_unchecked(cell.expr()),
                 );
             } else {
@@ -1242,7 +1241,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         self.reversion_info(call_id, false)
     }
 
-    pub(crate) fn reversion_info_write(
+    pub(crate) fn reversion_info_write_unchecked(
         &mut self,
         call_id: Option<Expression<F>>,
     ) -> ReversionInfo<F> {

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -887,12 +887,12 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
     }
 
     // Access list
-    pub(crate) fn account_access_list_write_word(
+    pub(crate) fn account_access_list_write(
         &mut self,
         tx_id: Expression<F>,
         account_address: Word<Expression<F>>,
-        value: Word<Expression<F>>,
-        value_prev: Word<Expression<F>>,
+        value: Expression<F>,
+        value_prev: Expression<F>,
         reversion_info: Option<&mut ReversionInfo<F>>,
     ) {
         self.reversible_write(
@@ -903,19 +903,19 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 address_word_to_expr(account_address),
                 0.expr(),
                 Word::zero(),
-                value,
-                value_prev,
+                Word::from_lo_unchecked(value),
+                Word::from_lo_unchecked(value_prev),
                 Word::zero(),
             ),
             reversion_info,
         );
     }
 
-    pub(crate) fn account_access_list_read_word(
+    pub(crate) fn account_access_list_read(
         &mut self,
         tx_id: Expression<F>,
         account_address: Word<Expression<F>>,
-        value: Word<Expression<F>>,
+        value: Expression<F>,
     ) {
         self.rw_lookup(
             "account access list read",
@@ -926,8 +926,8 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 address_word_to_expr(account_address),
                 0.expr(),
                 Word::zero(),
-                value.clone(),
-                value,
+                Word::from_lo_unchecked(value.clone()),
+                Word::from_lo_unchecked(value),
                 Word::zero(),
             ),
         );

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -11,9 +11,7 @@ use crate::{
     },
     util::{
         build_tx_log_expression,
-        word::{
-            Word, Word16, Word32, Word32Cell, Word4, WordCell, WordExpr, WordLegacy, WordLimbs,
-        },
+        word::{Word, Word16, Word32, Word32Cell, Word4, WordCell, WordExpr, WordLimbs},
         Challenges, Expr,
     },
 };
@@ -29,7 +27,8 @@ use halo2_proofs::{
 };
 
 use super::{
-    rlc, AccountAddress, CachedRegion, CellType, MemoryAddress, StoredExpression, U64Cell,
+    address_word_to_expr, rlc, AccountAddress, CachedRegion, CellType, MemoryAddress,
+    StoredExpression, U64Cell,
 };
 
 // Max degree allowed in all expressions passing through the ConstraintBuilder.
@@ -58,7 +57,7 @@ pub(crate) struct StepStateTransition<F: Field> {
     pub(crate) call_id: Transition<Expression<F>>,
     pub(crate) is_root: Transition<Expression<F>>,
     pub(crate) is_create: Transition<Expression<F>>,
-    pub(crate) code_hash: Transition<Expression<F>>,
+    pub(crate) code_hash: Transition<Word<Expression<F>>>,
     pub(crate) program_counter: Transition<Expression<F>>,
     pub(crate) stack_pointer: Transition<Expression<F>>,
     pub(crate) gas_left: Transition<Expression<F>>,
@@ -421,11 +420,6 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         self.query_cell_with_type(CellType::LookupByte)
     }
 
-    #[deprecated(note = "query_word* are favored")]
-    pub(crate) fn query_word_rlc<const N: usize>(&mut self) -> RandomLinearCombination<F, N> {
-        RandomLinearCombination::<F, N>::new(self.query_bytes(), self.challenges.evm_word())
-    }
-
     // default query_word is 2 limbs. Each limb is not guaranteed to be 128 bits.
     pub fn query_word_unchecked(&mut self) -> WordCell<F> {
         Word::new(
@@ -601,7 +595,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                     Transition::To(to) => self.require_equal_word(
                         concat!("State transition (to) constraint of ", stringify!($name)),
                         self.next.state.$name.to_word(),
-                        Word::from_lo_unchecked(to),
+                        to,
                     ),
                     _ => {}
                 }
@@ -686,18 +680,6 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         );
     }
 
-    // Bytecode table
-    #[deprecated(note = "in fav of bytecode_lookup_word")]
-    pub(crate) fn bytecode_lookup(
-        &mut self,
-        code_hash: Expression<F>,
-        index: Expression<F>,
-        is_code: Expression<F>,
-        value: Expression<F>,
-    ) {
-        self.bytecode_lookup_word(Word::from_lo_unchecked(code_hash), index, is_code, value)
-    }
-
     pub(crate) fn bytecode_lookup_word(
         &mut self,
         code_hash: Word<Expression<F>>,
@@ -715,11 +697,6 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 value,
             },
         )
-    }
-
-    #[deprecated(note = "in fav of bytecode_length_word")]
-    pub(crate) fn bytecode_length(&mut self, code_hash: Expression<F>, value: Expression<F>) {
-        self.bytecode_length_word(Word::from_lo_unchecked(code_hash), value)
     }
 
     pub(crate) fn bytecode_length_word(
@@ -752,18 +729,6 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         self.tx_context_lookup_word(id, field_tag, index, Word::from_lo_unchecked(cell.expr()));
         cell
     }
-    #[deprecated(note = "tx_context_as_word32 is favored")]
-    pub(crate) fn tx_context_as_word(
-        &mut self,
-        id: Expression<F>,
-        field_tag: TxContextFieldTag,
-        index: Option<Expression<F>>,
-    ) -> WordLegacy<F> {
-        let word = self.query_word_rlc();
-        self.tx_context_lookup_word(id, field_tag, index, word.to_word());
-        word
-    }
-
     pub(crate) fn tx_context_as_word32(
         &mut self,
         id: Expression<F>,
@@ -775,16 +740,26 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         word
     }
 
-    #[deprecated(note = "tx_context_lookup_word is favored")]
-    pub(crate) fn tx_context_lookup(
+    pub(crate) fn tx_context_as_word(
         &mut self,
         id: Expression<F>,
         field_tag: TxContextFieldTag,
         index: Option<Expression<F>>,
-        value: Expression<F>,
-    ) {
-        let value = Word::from_lo_unchecked(value);
-        self.tx_context_lookup_word(id, field_tag, index, value)
+    ) -> WordCell<F> {
+        let word = self.query_word_unchecked();
+        self.tx_context_lookup_word(id, field_tag, index, word.to_word());
+        word
+    }
+
+    pub(crate) fn tx_context_as_account_address(
+        &mut self,
+        id: Expression<F>,
+        field_tag: TxContextFieldTag,
+        index: Option<Expression<F>>,
+    ) -> AccountAddress<F> {
+        let word = self.query_account_address();
+        self.tx_context_lookup_word(id, field_tag, index, word.to_word());
+        word
     }
 
     pub(crate) fn tx_context_lookup_word(
@@ -806,16 +781,6 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
     }
 
     // block
-    #[deprecated(note = "block_lookup_word is favored")]
-    pub(crate) fn block_lookup(
-        &mut self,
-        tag: Expression<F>,
-        number: Option<Expression<F>>,
-        val: Expression<F>,
-    ) {
-        self.block_lookup_word(tag, number, Word::from_lo_unchecked(val))
-    }
-
     pub(crate) fn block_lookup_word(
         &mut self,
         tag: Expression<F>,
@@ -922,29 +887,10 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
     }
 
     // Access list
-
-    #[deprecated(note = "account_access_list_write_word is favored")]
-    pub(crate) fn account_access_list_write(
-        &mut self,
-        tx_id: Expression<F>,
-        account_address: Expression<F>,
-        value: Expression<F>,
-        value_prev: Expression<F>,
-        reversion_info: Option<&mut ReversionInfo<F>>,
-    ) {
-        self.account_access_list_write_word(
-            tx_id,
-            account_address,
-            Word::from_lo_unchecked(value),
-            Word::from_lo_unchecked(value_prev),
-            reversion_info,
-        )
-    }
-
     pub(crate) fn account_access_list_write_word(
         &mut self,
         tx_id: Expression<F>,
-        account_address: Expression<F>,
+        account_address: Word<Expression<F>>,
         value: Word<Expression<F>>,
         value_prev: Word<Expression<F>>,
         reversion_info: Option<&mut ReversionInfo<F>>,
@@ -954,31 +900,21 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
             Target::TxAccessListAccount,
             RwValues::new(
                 tx_id,
-                account_address,
+                address_word_to_expr(account_address),
                 0.expr(),
                 Word::zero(),
                 value,
                 value_prev,
-                0.expr(),
-                0.expr(),
+                Word::zero(),
             ),
             reversion_info,
         );
-    }
-    #[deprecated(note = "account_access_list_read_word is favored")]
-    pub(crate) fn account_access_list_read(
-        &mut self,
-        tx_id: Expression<F>,
-        account_address: Expression<F>,
-        value: Expression<F>,
-    ) {
-        self.account_access_list_read_word(tx_id, account_address, Word::from_lo_unchecked(value));
     }
 
     pub(crate) fn account_access_list_read_word(
         &mut self,
         tx_id: Expression<F>,
-        account_address: Expression<F>,
+        account_address: Word<Expression<F>>,
         value: Word<Expression<F>>,
     ) {
         self.rw_lookup(
@@ -987,41 +923,19 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
             Target::TxAccessListAccount,
             RwValues::new(
                 tx_id,
-                account_address,
+                address_word_to_expr(account_address),
                 0.expr(),
                 Word::zero(),
                 value.clone(),
                 value,
-                0.expr(),
-                0.expr(),
+                Word::zero(),
             ),
         );
     }
-
-    #[deprecated(note = "account_storage_access_list_write_word is favored")]
-    pub(crate) fn account_storage_access_list_write(
-        &mut self,
-        tx_id: Expression<F>,
-        account_address: Expression<F>,
-        storage_key: Expression<F>,
-        value: Expression<F>,
-        value_prev: Expression<F>,
-        reversion_info: Option<&mut ReversionInfo<F>>,
-    ) {
-        self.account_storage_access_list_write_word(
-            tx_id,
-            account_address,
-            Word::from_lo_unchecked(storage_key),
-            Word::from_lo_unchecked(value),
-            Word::from_lo_unchecked(value_prev),
-            reversion_info,
-        )
-    }
-
     pub(crate) fn account_storage_access_list_write_word(
         &mut self,
         tx_id: Expression<F>,
-        account_address: Expression<F>,
+        account_address: Word<Expression<F>>,
         storage_key: Word<Expression<F>>,
         value: Word<Expression<F>>,
         value_prev: Word<Expression<F>>,
@@ -1032,37 +946,21 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
             Target::TxAccessListAccountStorage,
             RwValues::new(
                 tx_id,
-                account_address,
+                address_word_to_expr(account_address),
                 0.expr(),
                 storage_key,
                 value,
                 value_prev,
-                0.expr(),
-                0.expr(),
+                Word::zero(),
             ),
             reversion_info,
-        );
-    }
-    #[deprecated(note = "account_storage_access_list_read_word is favored")]
-    pub(crate) fn account_storage_access_list_read(
-        &mut self,
-        tx_id: Expression<F>,
-        account_address: Expression<F>,
-        storage_key: Expression<F>,
-        value: Expression<F>,
-    ) {
-        self.account_storage_access_list_read_word(
-            tx_id,
-            account_address,
-            Word::from_lo_unchecked(storage_key),
-            Word::from_lo_unchecked(value),
         );
     }
 
     pub(crate) fn account_storage_access_list_read_word(
         &mut self,
         tx_id: Expression<F>,
-        account_address: Expression<F>,
+        account_address: Word<Expression<F>>,
         storage_key: Word<Expression<F>>,
         value: Word<Expression<F>>,
     ) {
@@ -1072,13 +970,12 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
             Target::TxAccessListAccountStorage,
             RwValues::new(
                 tx_id,
-                account_address,
+                address_word_to_expr(account_address),
                 0.expr(),
                 storage_key,
                 value.clone(),
                 value,
-                0.expr(),
-                0.expr(),
+                Word::zero(),
             ),
         );
     }
@@ -1097,25 +994,9 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 Word::zero(),
                 value.clone(),
                 value,
-                0.expr(),
-                0.expr(),
+                Word::zero(),
             ),
         );
-    }
-    #[deprecated(note = "infav of tx_refund_write_word")]
-    pub(crate) fn tx_refund_write(
-        &mut self,
-        tx_id: Expression<F>,
-        value: Expression<F>,
-        value_prev: Expression<F>,
-        reversion_info: Option<&mut ReversionInfo<F>>,
-    ) {
-        self.tx_refund_write_word(
-            tx_id,
-            Word::from_lo_unchecked(value),
-            Word::from_lo_unchecked(value_prev),
-            reversion_info,
-        )
     }
 
     pub(crate) fn tx_refund_write_word(
@@ -1135,28 +1016,16 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 Word::zero(),
                 value,
                 value_prev,
-                0.expr(),
-                0.expr(),
+                Word::zero(),
             ),
             reversion_info,
         );
     }
 
     // Account
-
-    #[deprecated(note = "infav of account_read_word")]
-    pub(crate) fn account_read(
-        &mut self,
-        account_address: Expression<F>,
-        field_tag: AccountFieldTag,
-        value: Expression<F>,
-    ) {
-        self.account_read_word(account_address, field_tag, Word::from_lo_unchecked(value));
-    }
-
     pub(crate) fn account_read_word(
         &mut self,
-        account_address: Expression<F>,
+        account_address: Word<Expression<F>>,
         field_tag: AccountFieldTag,
         value: Word<Expression<F>>,
     ) {
@@ -1166,37 +1035,19 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
             Target::Account,
             RwValues::new(
                 0.expr(),
-                account_address,
+                address_word_to_expr(account_address),
                 field_tag.expr(),
                 Word::zero(),
                 value.clone(),
                 value,
-                0.expr(),
-                0.expr(),
+                Word::zero(),
             ),
         );
-    }
-    #[deprecated(note = "infav of account_write_word")]
-    pub(crate) fn account_write(
-        &mut self,
-        account_address: Expression<F>,
-        field_tag: AccountFieldTag,
-        value: Expression<F>,
-        value_prev: Expression<F>,
-        reversion_info: Option<&mut ReversionInfo<F>>,
-    ) {
-        self.account_write_word(
-            account_address,
-            field_tag,
-            Word::from_lo_unchecked(value),
-            Word::from_lo_unchecked(value_prev),
-            reversion_info,
-        )
     }
 
     pub(crate) fn account_write_word(
         &mut self,
-        account_address: Expression<F>,
+        account_address: Word<Expression<F>>,
         field_tag: AccountFieldTag,
         value: Word<Expression<F>>,
         value_prev: Word<Expression<F>>,
@@ -1207,45 +1058,25 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
             Target::Account,
             RwValues::new(
                 0.expr(),
-                account_address,
+                address_word_to_expr(account_address),
                 field_tag.expr(),
                 Word::zero(),
                 value,
                 value_prev,
-                0.expr(),
-                0.expr(),
+                Word::zero(),
             ),
             reversion_info,
         );
     }
 
     // Account Storage
-
-    #[deprecated(note = "account_storage_read_word is preferred")]
-    pub(crate) fn account_storage_read(
-        &mut self,
-        account_address: Expression<F>,
-        key: Expression<F>,
-        value: Expression<F>,
-        tx_id: Expression<F>,
-        committed_value: Expression<F>,
-    ) {
-        self.account_storage_read_word(
-            account_address,
-            Word::from_lo_unchecked(key),
-            Word::from_lo_unchecked(value),
-            tx_id,
-            committed_value,
-        );
-    }
-
     pub(crate) fn account_storage_read_word(
         &mut self,
-        account_address: Expression<F>,
+        account_address: Word<Expression<F>>,
         key: Word<Expression<F>>,
         value: Word<Expression<F>>,
         tx_id: Expression<F>,
-        committed_value: Expression<F>,
+        committed_value: Word<Expression<F>>,
     ) {
         self.rw_lookup(
             "account_storage_read",
@@ -1253,49 +1084,25 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
             Target::Storage,
             RwValues::new(
                 tx_id,
-                account_address,
+                address_word_to_expr(account_address),
                 0.expr(),
                 key,
                 value.clone(),
                 value,
-                0.expr(),
                 committed_value,
             ),
-        );
-    }
-
-    #[deprecated(note = "account_storage_write_word is preferred")]
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn account_storage_write(
-        &mut self,
-        account_address: Expression<F>,
-        key: Expression<F>,
-        value: Expression<F>,
-        value_prev: Expression<F>,
-        tx_id: Expression<F>,
-        committed_value: Expression<F>,
-        reversion_info: Option<&mut ReversionInfo<F>>,
-    ) {
-        self.account_storage_write_word(
-            account_address,
-            Word::from_lo_unchecked(key),
-            Word::from_lo_unchecked(value),
-            Word::from_lo_unchecked(value_prev),
-            tx_id,
-            committed_value,
-            reversion_info,
         );
     }
 
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn account_storage_write_word(
         &mut self,
-        account_address: Expression<F>,
+        account_address: Word<Expression<F>>,
         key: Word<Expression<F>>,
         value: Word<Expression<F>>,
         value_prev: Word<Expression<F>>,
         tx_id: Expression<F>,
-        committed_value: Expression<F>,
+        committed_value: Word<Expression<F>>,
         reversion_info: Option<&mut ReversionInfo<F>>,
     ) {
         self.reversible_write(
@@ -1303,12 +1110,11 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
             Target::Storage,
             RwValues::new(
                 tx_id,
-                account_address,
+                address_word_to_expr(account_address),
                 0.expr(),
                 key,
                 value,
                 value_prev,
-                0.expr(),
                 committed_value,
             ),
             reversion_info,
@@ -1335,16 +1141,6 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         cell
     }
 
-    pub(crate) fn call_context_read(
-        &mut self,
-        call_id: Option<Expression<F>>,
-        field_tag: CallContextFieldTag,
-    ) -> WordLegacy<F> {
-        let word = self.query_word_rlc();
-        self.call_context_lookup_read(call_id, field_tag, word.to_word());
-        word
-    }
-
     pub(crate) fn call_context_read_as_word(
         &mut self,
         call_id: Option<Expression<F>>,
@@ -1353,31 +1149,6 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         let word = self.query_word_unchecked();
         self.call_context_lookup_read(call_id, field_tag, word.to_word());
         word
-    }
-
-    #[deprecated(note = "call_context_lookup_read is favored")]
-    pub(crate) fn call_context_lookup(
-        &mut self,
-        is_write: Expression<F>,
-        call_id: Option<Expression<F>>,
-        field_tag: CallContextFieldTag,
-        value: Expression<F>,
-    ) {
-        self.rw_lookup(
-            "CallContext lookup",
-            is_write,
-            Target::CallContext,
-            RwValues::new(
-                call_id.unwrap_or_else(|| self.curr.state.call_id.expr()),
-                0.expr(),
-                field_tag.expr(),
-                Word::zero(),
-                Word::from_lo_unchecked(value),
-                Word::zero(),
-                0.expr(),
-                0.expr(),
-            ),
-        );
     }
 
     pub(crate) fn call_context_lookup_read(
@@ -1397,8 +1168,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 Word::zero(),
                 value,
                 Word::zero(),
-                0.expr(),
-                0.expr(),
+                Word::zero(),
             ),
         );
     }
@@ -1420,8 +1190,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 Word::zero(),
                 value,
                 Word::zero(),
-                0.expr(),
-                0.expr(),
+                Word::zero(),
             ),
         );
     }
@@ -1481,21 +1250,6 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
     }
 
     // Stack
-
-    #[deprecated(note = "stack_pop_word is favored")]
-    pub(crate) fn stack_pop(&mut self, value: Expression<F>) {
-        // This is definitely incorrct. The intention is to convert expression to word to fix build.
-        let value = Word::from_lo_unchecked(value);
-        self.stack_pop_word(value)
-    }
-
-    #[deprecated(note = "stack_push_word is favored")]
-    pub(crate) fn stack_push(&mut self, value: Expression<F>) {
-        // This is definitely incorrct. The intention is to convert expression to word to fix build.
-        let value = Word::from_lo_unchecked(value);
-        self.stack_push_word(value)
-    }
-
     pub(crate) fn stack_pop_word(&mut self, value: Word<Expression<F>>) {
         self.stack_lookup_word(false.expr(), self.stack_pointer_offset.clone(), value);
         self.stack_pointer_offset = self.stack_pointer_offset.clone() + self.condition_expr();
@@ -1504,19 +1258,6 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
     pub(crate) fn stack_push_word(&mut self, value: Word<Expression<F>>) {
         self.stack_pointer_offset = self.stack_pointer_offset.clone() - self.condition_expr();
         self.stack_lookup_word(true.expr(), self.stack_pointer_offset.expr(), value);
-    }
-    #[deprecated(note = "stack_lookup_word is favored")]
-    pub(crate) fn stack_lookup(
-        &mut self,
-        is_write: Expression<F>,
-        stack_pointer_offset: Expression<F>,
-        value: Expression<F>,
-    ) {
-        self.stack_lookup_word(
-            is_write,
-            stack_pointer_offset,
-            Word::from_lo_unchecked(value),
-        )
     }
 
     pub(crate) fn stack_lookup_word(
@@ -1536,8 +1277,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 Word::zero(),
                 value,
                 Word::zero(),
-                0.expr(),
-                0.expr(),
+                Word::zero(),
             ),
         );
     }
@@ -1563,19 +1303,18 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 // TODO assure range check since write=true also possible
                 Word::from_lo_unchecked(byte),
                 Word::zero(),
-                0.expr(),
-                0.expr(),
+                Word::zero(),
             ),
         );
     }
 
-    pub(crate) fn tx_log_lookup(
+    pub(crate) fn tx_log_lookup_word(
         &mut self,
         tx_id: Expression<F>,
         log_id: Expression<F>,
         field_tag: TxLogFieldTag,
         index: Expression<F>,
-        value: Expression<F>,
+        value: Word<Expression<F>>,
     ) {
         self.rw_lookup(
             "log data lookup",
@@ -1586,17 +1325,14 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 build_tx_log_expression(index, field_tag.expr(), log_id),
                 0.expr(),
                 Word::zero(),
-                // TODO assure range check since here is write
-                Word::from_lo_unchecked(value),
+                value,
                 Word::zero(),
-                0.expr(),
-                0.expr(),
+                Word::zero(),
             ),
         );
     }
 
     // Tx Receipt
-
     pub(crate) fn tx_receipt_lookup(
         &mut self,
         is_write: Expression<F>,
@@ -1616,8 +1352,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 // TODO assure range check since write=true also possible
                 Word::from_lo_unchecked(value),
                 Word::zero(),
-                0.expr(),
-                0.expr(),
+                Word::zero(),
             ),
         );
     }
@@ -1637,8 +1372,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 storage_key: Word::zero(),
                 value: Word::zero(),
                 value_prev: Word::zero(),
-                aux1: 0.expr(),
-                aux2: 0.expr(),
+                init_val: Word::zero(),
             },
         );
     }
@@ -1648,9 +1382,9 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn copy_table_lookup(
         &mut self,
-        src_id: Expression<F>,
+        src_id: Word<Expression<F>>,
         src_tag: Expression<F>,
-        dst_id: Expression<F>,
+        dst_id: Word<Expression<F>>,
         dst_tag: Expression<F>,
         src_addr: Expression<F>,
         src_addr_end: Expression<F>,
@@ -1703,17 +1437,6 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
     }
 
     // Keccak Table
-
-    #[deprecated(note = "keccak_table_lookup_word is fav")]
-    pub(crate) fn keccak_table_lookup(
-        &mut self,
-        input_rlc: Expression<F>,
-        input_len: Expression<F>,
-        output: Expression<F>,
-    ) {
-        self.keccak_table_lookup_word(input_rlc, input_len, Word::from_lo_unchecked(output))
-    }
-
     pub(crate) fn keccak_table_lookup_word(
         &mut self,
         input_rlc: Expression<F>,

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget.rs
@@ -39,7 +39,7 @@ pub(crate) use is_equal_word::IsEqualWordGadget;
 pub(crate) use is_zero::IsZeroGadget;
 pub(crate) use is_zero_word::IsZeroWordGadget;
 pub(crate) use lt::LtGadget;
-pub(crate) use lt_word::{LtWordGadget as LtWordGadgetNew, LtWordGadgetLegacy as LtWordGadget};
+pub(crate) use lt_word::LtWordGadget;
 pub(crate) use min_max::MinMaxGadget;
 pub(crate) use modulo::ModGadget;
 pub(crate) use mul_add_words::MulAddWordsGadget;

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/add_words.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/add_words.rs
@@ -45,8 +45,7 @@ impl<F: Field, const N_ADDENDS: usize, const CHECK_OVERFLOW: bool>
             .iter()
             .map(|addend| addend.to_word().hi())
             .collect::<Vec<_>>();
-        let sum_lo = sum.to_word().lo();
-        let sum_hi = sum.to_word().hi();
+        let (sum_lo, sum_hi) = sum.to_word().to_lo_hi();
 
         cb.require_equal(
             "sum(addends_lo) == sum_lo + carry_lo ⋅ 2^128",

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/add_words.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/add_words.rs
@@ -5,11 +5,11 @@ use crate::{
         pow_of_two_expr, split_u256, sum, CachedRegion, Cell,
     },
     util::{
-        word::{Word32Cell, WordExpr, WordLegacy},
+        word::{Word32Cell, WordExpr},
         Expr,
     },
 };
-use eth_types::{Field, ToLittleEndian, ToScalar, Word};
+use eth_types::{Field, ToScalar, Word};
 use halo2_proofs::{circuit::Value, plonk::Error};
 
 /// Construction of 2 256-bit words addition and result, which is useful for
@@ -26,13 +26,6 @@ impl<F: Field, const N_ADDENDS: usize, const CHECK_OVERFLOW: bool>
     AddWordsGadget<F, N_ADDENDS, CHECK_OVERFLOW>
 {
     pub(crate) fn construct(
-        _cb: &mut EVMConstraintBuilder<F>,
-        _addends: [WordLegacy<F>; N_ADDENDS],
-        _sum: WordLegacy<F>,
-    ) -> Self {
-        todo!()
-    }
-    pub(crate) fn construct_new(
         cb: &mut EVMConstraintBuilder<F>,
         addends: [Word32Cell<F>; N_ADDENDS],
         sum: Word32Cell<F>,
@@ -102,9 +95,9 @@ impl<F: Field, const N_ADDENDS: usize, const CHECK_OVERFLOW: bool>
         sum: Word,
     ) -> Result<(), Error> {
         for (word, value) in self.addends.iter().zip(addends.iter()) {
-            word.assign(region, offset, Some(value.to_le_bytes()))?;
+            word.assign_u256(region, offset, *value)?;
         }
-        self.sum.assign(region, offset, Some(sum.to_le_bytes()))?;
+        self.sum.assign_u256(region, offset, sum)?;
 
         let (addends_lo, addends_hi): (Vec<_>, Vec<_>) = addends.iter().map(split_u256).unzip();
         let (sum_lo, sum_hi) = split_u256(&sum);
@@ -181,7 +174,7 @@ mod tests {
         fn configure_gadget_container(cb: &mut EVMConstraintBuilder<F>) -> Self {
             let addends = [(); N_ADDENDS].map(|_| cb.query_word32());
             let sum = cb.query_word32();
-            let addwords_gadget = AddWordsGadget::<F, N_ADDENDS, CHECK_OVERFLOW>::construct_new(
+            let addwords_gadget = AddWordsGadget::<F, N_ADDENDS, CHECK_OVERFLOW>::construct(
                 cb,
                 addends.clone(),
                 sum.clone(),
@@ -211,10 +204,10 @@ mod tests {
             let offset = 0;
             for (i, addend) in self.addends.iter().enumerate() {
                 let a = witnesses[i];
-                addend.assign(region, offset, Some(a.to_le_bytes()))?;
+                addend.assign_u256(region, offset, a)?;
             }
             let sum = witnesses[N_ADDENDS];
-            self.sum.assign(region, offset, Some(sum.to_le_bytes()))?;
+            self.sum.assign_u256(region, offset, sum)?;
 
             let addends = witnesses[0..N_ADDENDS].try_into().unwrap();
             self.addwords_gadget.assign(region, 0, addends, sum)?;

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/byte_size.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/byte_size.rs
@@ -129,7 +129,7 @@ mod tests {
         fn configure_gadget_container(cb: &mut EVMConstraintBuilder<F>) -> Self {
             let value_word32 = cb.query_word32();
             let bytesize_gadget =
-                ByteSizeGadget::<F>::construct(cb, value_word32.word_expr().limbs);
+                ByteSizeGadget::<F>::construct(cb, value_word32.to_word_n().limbs);
             cb.require_equal(
                 "byte size gadget must equal N",
                 bytesize_gadget.byte_size(),
@@ -148,7 +148,7 @@ mod tests {
         ) -> Result<(), Error> {
             let offset = 0;
             let x = witnesses[0];
-            self.a.assign(region, offset, Some(x.to_le_bytes()))?;
+            self.a.assign_u256(region, offset, x)?;
             self.bytesize_gadget.assign(region, offset, x)?;
 
             Ok(())

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/cmp_words.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/cmp_words.rs
@@ -129,8 +129,8 @@ mod tests {
             let b = witnesses[1];
             let offset = 0;
 
-            self.a_word.assign(region, offset, Some(a.to_le_bytes()))?;
-            self.b_word.assign(region, offset, Some(b.to_le_bytes()))?;
+            self.a_word.assign_u256(region, offset, a)?;
+            self.b_word.assign_u256(region, offset, b)?;
             self.cmp_gadget.assign(region, offset, a, b)?;
             Ok(())
         }

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/is_equal_word.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/is_equal_word.rs
@@ -25,7 +25,7 @@ pub struct IsEqualWordGadget<F, T1, T2> {
 }
 
 impl<F: Field, T1: WordExpr<F>, T2: WordExpr<F>> IsEqualWordGadget<F, T1, T2> {
-    pub(crate) fn construct(cb: &mut EVMConstraintBuilder<F>, lhs: T1, rhs: T2) -> Self {
+    pub(crate) fn construct(cb: &mut EVMConstraintBuilder<F>, lhs: &T1, rhs: &T2) -> Self {
         let (lhs_lo, lhs_hi) = lhs.to_word().to_lo_hi();
         let (rhs_lo, rhs_hi) = rhs.to_word().to_lo_hi();
         let is_zero_lo = IsZeroGadget::construct(cb, lhs_lo - rhs_lo);
@@ -51,8 +51,8 @@ impl<F: Field, T1: WordExpr<F>, T2: WordExpr<F>> IsEqualWordGadget<F, T1, T2> {
     ) -> Result<F, Error> {
         let (lhs_lo, lhs_hi) = lhs.to_lo_hi();
         let (rhs_lo, rhs_hi) = rhs.to_lo_hi();
-        self.is_zero_lo.assign(region, offset, rhs_lo - lhs_lo)?;
-        self.is_zero_hi.assign(region, offset, rhs_hi - lhs_hi)?;
+        self.is_zero_lo.assign(region, offset, lhs_lo - rhs_lo)?;
+        self.is_zero_hi.assign(region, offset, lhs_hi - rhs_hi)?;
         Ok(F::from(2))
     }
 
@@ -67,6 +67,16 @@ impl<F: Field, T1: WordExpr<F>, T2: WordExpr<F>> IsEqualWordGadget<F, T1, T2> {
             lhs.zip(rhs)
                 .map(|(lhs, rhs)| self.assign(region, offset, lhs, rhs)),
         )
+    }
+
+    pub(crate) fn assign_u256(
+        &self,
+        region: &mut CachedRegion<'_, '_, F>,
+        offset: usize,
+        lhs: eth_types::Word,
+        rhs: eth_types::Word,
+    ) -> Result<F, Error> {
+        self.assign(region, offset, Word::from(lhs), Word::from(rhs))
     }
 }
 

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/lt_word.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/lt_word.rs
@@ -1,11 +1,8 @@
-use std::marker::PhantomData;
-
 use crate::{
     evm_circuit::util::{
-        self, constraint_builder::EVMConstraintBuilder, from_bytes, math_gadget::*, split_u256,
-        CachedRegion,
+        constraint_builder::EVMConstraintBuilder, math_gadget::*, split_u256, CachedRegion,
     },
-    util::word::WordExpr,
+    util::word::{self},
 };
 use eth_types::{Field, Word};
 use halo2_proofs::plonk::{Error, Expression};
@@ -13,83 +10,24 @@ use halo2_proofs::plonk::{Error, Expression};
 /// Returns `1` when `lhs < rhs`, and returns `0` otherwise.
 /// lhs and rhs are both 256-bit word.
 #[derive(Clone, Debug)]
-#[deprecated(note = "LtWordGadget is favored")]
-pub struct LtWordGadgetLegacy<F> {
+pub struct LtWordGadget<F> {
     comparison_hi: ComparisonGadget<F, 16>,
     lt_lo: LtGadget<F, 16>,
 }
 
-impl<F: Field> LtWordGadgetLegacy<F> {
-    pub(crate) fn construct(
+impl<F: Field> LtWordGadget<F> {
+    pub(crate) fn construct<T: Expr<F> + Clone>(
         cb: &mut EVMConstraintBuilder<F>,
-        lhs: &util::Word<F>,
-        rhs: &util::Word<F>,
+        lhs: &word::Word<T>,
+        rhs: &word::Word<T>,
     ) -> Self {
-        let comparison_hi = ComparisonGadget::construct(
-            cb,
-            from_bytes::expr(&lhs.cells[16..]),
-            from_bytes::expr(&rhs.cells[16..]),
-        );
-        let lt_lo = LtGadget::construct(
-            cb,
-            from_bytes::expr(&lhs.cells[..16]),
-            from_bytes::expr(&rhs.cells[..16]),
-        );
+        let (lhs_lo, lhs_hi) = lhs.to_lo_hi();
+        let (rhs_lo, rhs_hi) = rhs.to_lo_hi();
+        let comparison_hi = ComparisonGadget::construct(cb, lhs_hi.expr(), rhs_hi.expr());
+        let lt_lo = LtGadget::construct(cb, lhs_lo.expr(), rhs_lo.expr());
         Self {
             comparison_hi,
             lt_lo,
-        }
-    }
-
-    pub(crate) fn expr(&self) -> Expression<F> {
-        let (hi_lt, hi_eq) = self.comparison_hi.expr();
-        hi_lt + hi_eq * self.lt_lo.expr()
-    }
-
-    pub(crate) fn assign(
-        &self,
-        region: &mut CachedRegion<'_, '_, F>,
-        offset: usize,
-        lhs: Word,
-        rhs: Word,
-    ) -> Result<(), Error> {
-        let (lhs_lo, lhs_hi) = split_u256(&lhs);
-        let (rhs_lo, rhs_hi) = split_u256(&rhs);
-        self.comparison_hi.assign(
-            region,
-            offset,
-            F::from_u128(lhs_hi.as_u128()),
-            F::from_u128(rhs_hi.as_u128()),
-        )?;
-        self.lt_lo.assign(
-            region,
-            offset,
-            F::from_u128(lhs_lo.as_u128()),
-            F::from_u128(rhs_lo.as_u128()),
-        )?;
-        Ok(())
-    }
-}
-
-/// Returns `1` when `lhs < rhs`, and returns `0` otherwise.
-/// lhs and rhs are both 256-bit word.
-#[derive(Clone, Debug)]
-pub struct LtWordGadget<F, T1, T2> {
-    comparison_hi: ComparisonGadget<F, 16>,
-    lt_lo: LtGadget<F, 16>,
-    _marker: PhantomData<(T1, T2)>,
-}
-
-impl<F: Field, T1: WordExpr<F>, T2: WordExpr<F>> LtWordGadget<F, T1, T2> {
-    pub(crate) fn construct(cb: &mut EVMConstraintBuilder<F>, lhs: T1, rhs: T2) -> Self {
-        let lhs_expr = lhs.to_word();
-        let rhs_expr = rhs.to_word();
-        let comparison_hi = ComparisonGadget::construct(cb, lhs_expr.hi(), rhs_expr.hi());
-        let lt_lo = LtGadget::construct(cb, lhs_expr.lo(), rhs_expr.lo());
-        Self {
-            comparison_hi,
-            lt_lo,
-            _marker: Default::default(),
         }
     }
 
@@ -126,17 +64,17 @@ impl<F: Field, T1: WordExpr<F>, T2: WordExpr<F>> LtWordGadget<F, T1, T2> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        evm_circuit::util::constraint_builder::ConstrainBuilderCommon, util::word::Word32Cell,
+        evm_circuit::util::constraint_builder::ConstrainBuilderCommon,
+        util::word::{Word32Cell, WordExpr},
     };
 
     use super::{test_util::*, *};
-    use eth_types::*;
     use halo2_proofs::{halo2curves::bn256::Fr, plonk::Error};
 
     #[derive(Clone)]
     /// LtWordTestContainer: require(a < b)
     struct LtWordTestContainer<F> {
-        ltword_gadget: LtWordGadget<F, Word32Cell<F>, Word32Cell<F>>,
+        ltword_gadget: LtWordGadget<F>,
         a: Word32Cell<F>,
         b: Word32Cell<F>,
     }
@@ -145,7 +83,7 @@ mod tests {
         fn configure_gadget_container(cb: &mut EVMConstraintBuilder<F>) -> Self {
             let a = cb.query_word32();
             let b = cb.query_word32();
-            let ltword_gadget = LtWordGadget::<F, _, _>::construct(cb, a.clone(), b.clone());
+            let ltword_gadget = LtWordGadget::<F>::construct(cb, &a.to_word(), &b.to_word());
             cb.require_equal("a < b", ltword_gadget.expr(), 1.expr());
             LtWordTestContainer {
                 ltword_gadget,
@@ -163,8 +101,8 @@ mod tests {
             let b = witnesses[1];
             let offset = 0;
 
-            self.a.assign(region, offset, Some(a.to_le_bytes()))?;
-            self.b.assign(region, offset, Some(b.to_le_bytes()))?;
+            self.a.assign_u256(region, offset, a)?;
+            self.b.assign_u256(region, offset, b)?;
             self.ltword_gadget.assign(region, 0, a, b)?;
 
             Ok(())

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/mul_add_words512.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/mul_add_words512.rs
@@ -1,6 +1,5 @@
 use crate::{
     evm_circuit::util::{
-        self,
         constraint_builder::{ConstrainBuilderCommon, EVMConstraintBuilder},
         from_bytes, pow_of_two_expr, split_u256, split_u256_limb64, CachedRegion, Cell,
     },
@@ -54,15 +53,6 @@ pub(crate) struct MulAddWords512Gadget<F> {
 }
 
 impl<F: Field> MulAddWords512Gadget<F> {
-    #[deprecated(note = "construct is favored")]
-    pub(crate) fn legacy_construct(
-        _cb: &mut EVMConstraintBuilder<F>,
-        _words: [&util::Word<F>; 4],
-        _addend: Option<&util::Word<F>>,
-    ) -> Self {
-        todo!()
-    }
-
     /// The words argument is: a, b, d, e
     /// Addend is the optional c.
     pub(crate) fn construct(
@@ -80,8 +70,8 @@ impl<F: Field> MulAddWords512Gadget<F> {
         // Split input words in limbs
         let mut a_limbs = vec![];
         let mut b_limbs = vec![];
-        let word4_a: Word4<Expression<F>> = words[0].word_expr().to_word_n();
-        let word4_b: Word4<Expression<F>> = words[1].word_expr().to_word_n();
+        let word4_a: Word4<Expression<F>> = words[0].to_word_n();
+        let word4_b: Word4<Expression<F>> = words[1].to_word_n();
         for i in 0..4 {
             a_limbs.push(word4_a.limbs[i].expr());
             b_limbs.push(word4_b.limbs[i].expr());
@@ -249,16 +239,11 @@ mod tests {
             region: &mut CachedRegion<'_, '_, F>,
         ) -> Result<(), Error> {
             let offset = 0;
-            self.a
-                .assign(region, offset, Some(witnesses[0].to_le_bytes()))?;
-            self.b
-                .assign(region, offset, Some(witnesses[1].to_le_bytes()))?;
-            self.d
-                .assign(region, offset, Some(witnesses[2].to_le_bytes()))?;
-            self.e
-                .assign(region, offset, Some(witnesses[3].to_le_bytes()))?;
-            self.addend
-                .assign(region, offset, Some(witnesses[4].to_le_bytes()))?;
+            self.a.assign_u256(region, offset, witnesses[0])?;
+            self.b.assign_u256(region, offset, witnesses[1])?;
+            self.d.assign_u256(region, offset, witnesses[2])?;
+            self.e.assign_u256(region, offset, witnesses[3])?;
+            self.addend.assign_u256(region, offset, witnesses[4])?;
             self.math_gadget.assign(
                 region,
                 offset,

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/mul_word_u64.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/mul_word_u64.rs
@@ -9,7 +9,7 @@ use crate::{
         Expr,
     },
 };
-use eth_types::{Field, ToLittleEndian, Word};
+use eth_types::{Field, Word};
 use halo2_proofs::{
     circuit::Value,
     plonk::{Error, Expression},
@@ -64,9 +64,8 @@ impl<F: Field> MulWordByU64Gadget<F> {
         product: Word,
     ) -> Result<(), Error> {
         self.multiplicand
-            .assign(region, offset, Some(multiplicand.to_le_bytes()))?;
-        self.product
-            .assign(region, offset, Some(product.to_le_bytes()))?;
+            .assign_u256(region, offset, multiplicand)?;
+        self.product.assign_u256(region, offset, product)?;
 
         let (multiplicand_lo, _) = split_u256(&multiplicand);
         let (product_lo, _) = split_u256(&product);
@@ -93,7 +92,7 @@ impl<F: Field> MulWordByU64Gadget<F> {
 mod tests {
     use super::{super::test_util::*, *};
     use crate::evm_circuit::util::Cell;
-    use eth_types::Word;
+    use eth_types::{ToLittleEndian, Word};
     use halo2_proofs::{halo2curves::bn256::Fr, plonk::Error};
 
     #[derive(Clone)]
@@ -129,10 +128,9 @@ mod tests {
             let product = witnesses[2];
             let offset = 0;
 
-            self.a.assign(region, offset, Some(a.to_le_bytes()))?;
+            self.a.assign_u256(region, offset, a)?;
             self.b.assign(region, offset, Value::known(F::from(b)))?;
-            self.product
-                .assign(region, offset, Some(product.to_le_bytes()))?;
+            self.product.assign_u256(region, offset, product)?;
             self.mulwords_u64_gadget.assign(region, 0, a, b, product)?;
 
             Ok(())

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/rlp.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/rlp.rs
@@ -1,16 +1,20 @@
-use eth_types::{Address, Field, ToLittleEndian, ToScalar, Word};
+use crate::util::word::{Word32Cell, WordExpr};
+use eth_types::{Address, Field, ToScalar, Word};
 use gadgets::util::{and, expr_from_bytes, not, select, sum, Expr};
 use halo2_proofs::{
     circuit::Value,
     plonk::{Error, Expression},
 };
 
-use crate::evm_circuit::{
-    param::{N_BYTES_ACCOUNT_ADDRESS, N_BYTES_U64, N_BYTES_WORD},
-    util::{
-        constraint_builder::{ConstrainBuilderCommon, EVMConstraintBuilder},
-        CachedRegion, Cell, RandomLinearCombination,
+use crate::{
+    evm_circuit::{
+        param::{N_BYTES_U64, N_BYTES_WORD},
+        util::{
+            constraint_builder::{ConstrainBuilderCommon, EVMConstraintBuilder},
+            AccountAddress, CachedRegion, Cell, RandomLinearCombination,
+        },
     },
+    util::word,
 };
 
 use super::IsZeroGadget;
@@ -197,7 +201,7 @@ impl<F: Field> RlpU64Gadget<F> {
 #[derive(Clone, Debug)]
 pub struct ContractCreateGadget<F, const IS_CREATE2: bool> {
     /// Sender address of the contract creation tx.
-    caller_address: RandomLinearCombination<F, N_BYTES_ACCOUNT_ADDRESS>,
+    caller_address: AccountAddress<F>,
     /// Sender nonce of the contract creation tx.
     nonce: RlpU64Gadget<F>,
     /// Keccak256 hash of init code, used for CREATE2. We don't use a
@@ -205,9 +209,9 @@ pub struct ContractCreateGadget<F, const IS_CREATE2: bool> {
     /// RLC in the case of init code hash, for BeginTx and
     /// CREATE2 respectively. Instead, we store just the bytes and calculate the
     /// appropriate RLC wherever needed.
-    code_hash: [Cell<F>; N_BYTES_WORD],
+    code_hash: Word32Cell<F>,
     /// Random salt for CREATE2.
-    salt: [Cell<F>; N_BYTES_WORD],
+    salt: Word32Cell<F>,
 }
 
 impl<F: Field, const IS_CREATE2: bool> ContractCreateGadget<F, IS_CREATE2> {
@@ -215,8 +219,8 @@ impl<F: Field, const IS_CREATE2: bool> ContractCreateGadget<F, IS_CREATE2> {
     pub(crate) fn construct(cb: &mut EVMConstraintBuilder<F>) -> Self {
         let caller_address = cb.query_keccak_rlc();
         let nonce = RlpU64Gadget::construct(cb);
-        let code_hash = array_init::array_init(|_| cb.query_byte());
-        let salt = array_init::array_init(|_| cb.query_byte());
+        let code_hash = cb.query_word32();
+        let salt = cb.query_word32();
 
         Self {
             caller_address,
@@ -243,27 +247,18 @@ impl<F: Field, const IS_CREATE2: bool> ContractCreateGadget<F, IS_CREATE2> {
 
         self.nonce.assign(region, offset, caller_nonce)?;
 
-        for (c, v) in self
-            .code_hash
-            .iter()
-            .zip(code_hash.map(|v| v.to_le_bytes()).unwrap_or_default())
-        {
-            c.assign(region, offset, Value::known(F::from(v as u64)))?;
-        }
-        for (c, v) in self
-            .salt
-            .iter()
-            .zip(salt.map(|v| v.to_le_bytes()).unwrap_or_default())
-        {
-            c.assign(region, offset, Value::known(F::from(v as u64)))?;
-        }
+        self.code_hash
+            .assign_u256(region, offset, code_hash.unwrap_or_default())?;
+
+        self.salt
+            .assign_u256(region, offset, salt.unwrap_or_default())?;
 
         Ok(())
     }
 
     /// Caller address' value.
-    pub(crate) fn caller_address(&self) -> Expression<F> {
-        expr_from_bytes(&self.caller_address.cells)
+    pub(crate) fn caller_address_word(&self) -> word::Word<Expression<F>> {
+        self.caller_address.to_word()
     }
 
     /// Caller nonce's value.
@@ -272,21 +267,21 @@ impl<F: Field, const IS_CREATE2: bool> ContractCreateGadget<F, IS_CREATE2> {
     }
 
     /// Code hash word RLC.
-    pub(crate) fn code_hash_word_rlc(&self, cb: &EVMConstraintBuilder<F>) -> Expression<F> {
-        cb.word_rlc::<N_BYTES_WORD>(
-            self.code_hash
-                .iter()
-                .map(Expr::expr)
-                .collect::<Vec<_>>()
-                .try_into()
-                .unwrap(),
-        )
+    #[deprecated(note = "in fav of code_hash_word")]
+    pub(crate) fn code_hash_word_rlc(&self) -> Expression<F> {
+        unimplemented!()
+    }
+
+    /// Code hash word RLC.
+    pub(crate) fn code_hash_word(&self) -> word::Word<Expression<F>> {
+        self.code_hash.to_word()
     }
 
     /// Code hash keccak RLC.
     pub(crate) fn code_hash_keccak_rlc(&self, cb: &EVMConstraintBuilder<F>) -> Expression<F> {
         cb.keccak_rlc::<N_BYTES_WORD>(
             self.code_hash
+                .limbs
                 .iter()
                 .map(Expr::expr)
                 .collect::<Vec<_>>()
@@ -296,9 +291,11 @@ impl<F: Field, const IS_CREATE2: bool> ContractCreateGadget<F, IS_CREATE2> {
     }
 
     /// Salt EVM word RLC.
+    #[deprecated(note = "in fav of salt_word")]
     pub(crate) fn salt_word_rlc(&self, cb: &EVMConstraintBuilder<F>) -> Expression<F> {
         cb.word_rlc::<N_BYTES_WORD>(
             self.salt
+                .limbs
                 .iter()
                 .map(Expr::expr)
                 .collect::<Vec<_>>()
@@ -307,10 +304,15 @@ impl<F: Field, const IS_CREATE2: bool> ContractCreateGadget<F, IS_CREATE2> {
         )
     }
 
+    pub(crate) fn salt_word(&self) -> word::Word<Expression<F>> {
+        self.salt.to_word()
+    }
+
     /// Salt keccak RLC.
     pub(crate) fn salt_keccak_rlc(&self, cb: &EVMConstraintBuilder<F>) -> Expression<F> {
         cb.keccak_rlc::<N_BYTES_WORD>(
             self.salt
+                .limbs
                 .iter()
                 .map(Expr::expr)
                 .collect::<Vec<_>>()

--- a/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
@@ -1,6 +1,4 @@
-use super::{
-    constraint_builder::ConstrainBuilderCommon, from_bytes, CachedRegion, MemoryAddress, WordExpr,
-};
+use super::{constraint_builder::ConstrainBuilderCommon, CachedRegion, MemoryAddress, WordExpr};
 use crate::{
     evm_circuit::{
         param::{N_BYTES_GAS, N_BYTES_MEMORY_ADDRESS, N_BYTES_MEMORY_WORD_SIZE},
@@ -89,7 +87,7 @@ impl<F: Field> MemoryAddressGadget<F> {
         memory_offset_word: WordCell<F>,
         memory_length: MemoryAddress<F>,
     ) -> Self {
-        let memory_length_is_zero = IsZeroGadget::construct(cb, memory_length.expr());
+        let memory_length_is_zero = IsZeroGadget::construct(cb, memory_length.sum_expr());
         let memory_offset_bytes = cb.query_memory_address();
 
         let has_length = 1.expr() - memory_length_is_zero.expr();
@@ -134,11 +132,8 @@ impl<F: Field> MemoryAddressGadget<F> {
             .assign_u256(region, offset, memory_offset)?;
         self.memory_length
             .assign_u256(region, offset, memory_length)?;
-        self.memory_length_is_zero.assign(
-            region,
-            offset,
-            from_bytes::value(&memory_length_bytes),
-        )?;
+        self.memory_length_is_zero
+            .assign(region, offset, sum::value(&memory_length_bytes))?;
         Ok(if memory_length_is_zero {
             0
         } else {

--- a/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
@@ -1,19 +1,15 @@
-use super::{constraint_builder::ConstrainBuilderCommon, CachedRegion, MemoryAddress};
+use super::{constraint_builder::ConstrainBuilderCommon, CachedRegion, MemoryAddress, WordExpr};
 use crate::{
     evm_circuit::{
         param::{N_BYTES_GAS, N_BYTES_MEMORY_ADDRESS, N_BYTES_MEMORY_WORD_SIZE},
         util::{
             constraint_builder::EVMConstraintBuilder,
-            from_bytes,
-            math_gadget::{
-                ConstantDivisionGadget, IsZeroGadget, IsZeroWordGadget, MinMaxGadget,
-                RangeCheckGadget,
-            },
+            math_gadget::{ConstantDivisionGadget, IsZeroGadget, MinMaxGadget, RangeCheckGadget},
             select, sum, Cell,
         },
     },
     util::{
-        word::{Word, Word32Cell},
+        word::{Word, WordCell},
         Expr,
     },
 };
@@ -79,30 +75,33 @@ pub(crate) mod address_high {
 /// the RLC value for `memory_offset` need not match the bytes.
 #[derive(Clone, Debug)]
 pub(crate) struct MemoryAddressGadget<F> {
-    memory_offset: Word32Cell<F>,
-    memory_length: Word32Cell<F>,
-    memory_length_is_zero: IsZeroWordGadget<F, Word32Cell<F>>,
+    memory_offset_bytes: MemoryAddress<F>,
+    memory_offset_word: WordCell<F>,
+    memory_length: MemoryAddress<F>,
+    memory_length_is_zero: IsZeroGadget<F>,
 }
 
 impl<F: Field> MemoryAddressGadget<F> {
-    #[deprecated(note = "construct_new is favored")]
     pub(crate) fn construct(
-        _cb: &mut EVMConstraintBuilder<F>,
-        _memory_offset: Cell<F>,
-        _memory_length: MemoryAddress<F>,
-    ) -> Self {
-        todo!()
-    }
-
-    pub(crate) fn construct_new(
         cb: &mut EVMConstraintBuilder<F>,
-        memory_offset: Word32Cell<F>,
-        memory_length: Word32Cell<F>,
+        memory_offset_word: WordCell<F>,
+        memory_length: MemoryAddress<F>,
     ) -> Self {
-        let memory_length_is_zero = IsZeroWordGadget::construct(cb, memory_length.clone());
+        let memory_length_is_zero = IsZeroGadget::construct(cb, sum::expr(&memory_length.cells));
+        let memory_offset_bytes = cb.query_memory_address();
+
+        let has_length = 1.expr() - memory_length_is_zero.expr();
+        cb.condition(has_length, |cb| {
+            cb.require_equal_word(
+                "Offset decomposition into 5 bytes",
+                Word::from_lo_unchecked(memory_offset_bytes.expr()),
+                memory_offset_word.to_word(),
+            );
+        });
 
         Self {
-            memory_offset,
+            memory_offset_bytes,
+            memory_offset_word,
             memory_length,
             memory_length_is_zero,
         }
@@ -115,27 +114,35 @@ impl<F: Field> MemoryAddressGadget<F> {
         memory_offset: U256,
         memory_length: U256,
     ) -> Result<u64, Error> {
+        let memory_offset_bytes = memory_offset.to_le_bytes();
+        let memory_length_bytes = memory_length.to_le_bytes();
         let memory_length_is_zero = memory_length.is_zero();
-        self.memory_offset.assign(
+        self.memory_offset_bytes.assign(
             region,
             offset,
             if memory_length_is_zero {
-                Some([0u8; 32])
+                Some([0; 5])
             } else {
-                Some(memory_offset.to_le_bytes())
+                memory_offset_bytes[..N_BYTES_MEMORY_ADDRESS]
+                    .try_into()
+                    .ok()
             },
         )?;
-
-        self.memory_length
-            .assign(region, offset, Some(memory_length.to_le_bytes()))?;
-
+        self.memory_offset_word
+            .assign_u256(region, offset, memory_offset)?;
+        self.memory_length.assign(
+            region,
+            offset,
+            memory_length_bytes[..N_BYTES_MEMORY_ADDRESS]
+                .try_into()
+                .ok(),
+        )?;
         self.memory_length_is_zero
-            .assign(region, offset, Word::from(memory_length))?;
+            .assign(region, offset, sum::value(&memory_length_bytes))?;
         Ok(if memory_length_is_zero {
             0
         } else {
-            address_low::value(memory_offset.to_le_bytes())
-                + address_low::value(memory_length.to_le_bytes())
+            address_low::value(memory_offset_bytes) + address_low::value(memory_length_bytes)
         })
     }
 
@@ -143,19 +150,13 @@ impl<F: Field> MemoryAddressGadget<F> {
         1.expr() - self.memory_length_is_zero.expr()
     }
 
+    // offset is the valid offset. It might not equal the offset pop from stack if
+    // `self.has_length()` is zero
     pub(crate) fn offset(&self) -> Expression<F> {
-        self.has_length() * from_bytes::expr(&self.memory_offset.limbs[..N_BYTES_MEMORY_ADDRESS])
-    }
-
-    pub(crate) fn offset_rlc(&self) -> Expression<F> {
-        self.memory_offset.expr()
+        self.has_length() * self.memory_offset_bytes.expr()
     }
 
     pub(crate) fn length(&self) -> Expression<F> {
-        from_bytes::expr(&self.memory_length.limbs[..N_BYTES_MEMORY_ADDRESS])
-    }
-
-    pub(crate) fn length_rlc(&self) -> Expression<F> {
         self.memory_length.expr()
     }
 

--- a/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
@@ -1,4 +1,6 @@
-use super::{constraint_builder::ConstrainBuilderCommon, CachedRegion, MemoryAddress, WordExpr};
+use super::{
+    constraint_builder::ConstrainBuilderCommon, from_bytes, CachedRegion, MemoryAddress, WordExpr,
+};
 use crate::{
     evm_circuit::{
         param::{N_BYTES_GAS, N_BYTES_MEMORY_ADDRESS, N_BYTES_MEMORY_WORD_SIZE},
@@ -87,7 +89,7 @@ impl<F: Field> MemoryAddressGadget<F> {
         memory_offset_word: WordCell<F>,
         memory_length: MemoryAddress<F>,
     ) -> Self {
-        let memory_length_is_zero = IsZeroGadget::construct(cb, sum::expr(&memory_length.cells));
+        let memory_length_is_zero = IsZeroGadget::construct(cb, memory_length.expr());
         let memory_offset_bytes = cb.query_memory_address();
 
         let has_length = 1.expr() - memory_length_is_zero.expr();
@@ -130,15 +132,13 @@ impl<F: Field> MemoryAddressGadget<F> {
         )?;
         self.memory_offset_word
             .assign_u256(region, offset, memory_offset)?;
-        self.memory_length.assign(
+        self.memory_length
+            .assign_u256(region, offset, memory_length)?;
+        self.memory_length_is_zero.assign(
             region,
             offset,
-            memory_length_bytes[..N_BYTES_MEMORY_ADDRESS]
-                .try_into()
-                .ok(),
+            from_bytes::value(&memory_length_bytes),
         )?;
-        self.memory_length_is_zero
-            .assign(region, offset, sum::value(&memory_length_bytes))?;
         Ok(if memory_length_is_zero {
             0
         } else {

--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -416,11 +416,7 @@ impl<F: Field> Circuit<F> for SuperCircuit<F> {
         );
         let rws = &self.state_circuit.rows;
 
-        config.block_table.load(
-            &mut layouter,
-            &block.context,
-            Value::known(block.randomness),
-        )?;
+        config.block_table.load(&mut layouter, &block.context)?;
 
         config
             .mpt_table

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -1,7 +1,7 @@
 //! Table definitions used cross-circuits
 
 use crate::{
-    copy_circuit::util::number_or_hash_to_field,
+    copy_circuit::util::number_or_hash_to_word,
     evm_circuit::util::rlc,
     impl_expr,
     util::{build_tx_log_address, keccak, word, Challenges},

--- a/zkevm-circuits/src/table/block_table.rs
+++ b/zkevm-circuits/src/table/block_table.rs
@@ -54,7 +54,6 @@ impl BlockTable {
         &self,
         layouter: &mut impl Layouter<F>,
         block: &BlockContext,
-        randomness: Value<F>,
     ) -> Result<(), Error> {
         layouter.assign_region(
             || "block table",
@@ -71,7 +70,7 @@ impl BlockTable {
                 offset += 1;
 
                 let block_table_columns = <BlockTable as LookupTable<F>>::advice_columns(self);
-                for row in block.table_assignments(randomness) {
+                for row in block.table_assignments::<F>() {
                     for (&column, value) in block_table_columns.iter().zip_eq(row) {
                         region.assign_advice(
                             || format!("block table row {}", offset),

--- a/zkevm-circuits/src/table/bytecode_table.rs
+++ b/zkevm-circuits/src/table/bytecode_table.rs
@@ -50,7 +50,6 @@ impl BytecodeTable {
         &self,
         layouter: &mut impl Layouter<F>,
         bytecodes: impl IntoIterator<Item = &'a Bytecode> + Clone,
-        challenges: &Challenges<Value<F>>,
     ) -> Result<(), Error> {
         layouter.assign_region(
             || "bytecode table",
@@ -69,7 +68,7 @@ impl BytecodeTable {
                 let bytecode_table_columns =
                     <BytecodeTable as LookupTable<F>>::advice_columns(self);
                 for bytecode in bytecodes.clone() {
-                    for row in bytecode.table_assignments(challenges) {
+                    for row in bytecode.table_assignments::<F>() {
                         for (&column, value) in bytecode_table_columns.iter().zip_eq(row) {
                             region.assign_advice(
                                 || format!("bytecode table row {}", offset),

--- a/zkevm-circuits/src/table/copy_table.rs
+++ b/zkevm-circuits/src/table/copy_table.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 type CopyTableRow<F> = [(Value<F>, &'static str); 9];
-type CopyCircuitRow<F> = [(Value<F>, &'static str); 4];
+type CopyCircuitRow<F> = [(Value<F>, &'static str); 5];
 
 /// Copy Table, used to verify copies of byte chunks between Memory, Bytecode,
 /// TxLogs and TxCallData.
@@ -61,7 +61,7 @@ impl CopyTable {
     ) -> Vec<(CopyDataType, CopyTableRow<F>, CopyCircuitRow<F>)> {
         let mut assignments = Vec::new();
         // rlc_acc
-        let rlc_acc = if copy_event.dst_type == CopyDataType::RlcAcc {
+        let rlc_acc = {
             let values = copy_event
                 .bytes
                 .iter()
@@ -70,8 +70,6 @@ impl CopyTable {
             challenges
                 .keccak_input()
                 .map(|keccak_input| rlc::value(values.iter().rev(), keccak_input))
-        } else {
-            Value::known(F::ZERO)
         };
         let mut value_acc = Value::known(F::ZERO);
         for (step_idx, (is_read_step, copy_step)) in copy_event
@@ -146,17 +144,11 @@ impl CopyTable {
             // bytes_left
             let bytes_left = u64::try_from(copy_event.bytes.len() * 2 - step_idx).unwrap() / 2;
             // value
-            let value = if copy_event.dst_type == CopyDataType::RlcAcc {
-                if is_read_step {
-                    Value::known(F::from(copy_step.value as u64))
-                } else {
-                    value_acc = value_acc * challenges.keccak_input()
-                        + Value::known(F::from(copy_step.value as u64));
-                    value_acc
-                }
-            } else {
-                Value::known(F::from(copy_step.value as u64))
-            };
+            let value = Value::known(F::from(copy_step.value as u64));
+            // value_acc
+            if is_read_step {
+                value_acc = value_acc * challenges.keccak_input() + value;
+            }
             // is_pad
             let is_pad = Value::known(F::from(
                 (is_read_step && copy_step_addr >= copy_event.src_addr_end) as u64,
@@ -177,7 +169,14 @@ impl CopyTable {
                         "src_addr_end",
                     ),
                     (Value::known(F::from(bytes_left)), "bytes_left"),
-                    (rlc_acc, "rlc_acc"),
+                    (
+                        match (copy_event.src_type, copy_event.dst_type) {
+                            (CopyDataType::Memory, CopyDataType::Bytecode) => rlc_acc,
+                            (_, CopyDataType::RlcAcc) => rlc_acc,
+                            _ => Value::known(F::ZERO),
+                        },
+                        "rlc_acc",
+                    ),
                     (
                         Value::known(F::from(copy_event.rw_counter(step_idx))),
                         "rw_counter",
@@ -190,6 +189,7 @@ impl CopyTable {
                 [
                     (is_last, "is_last"),
                     (value, "value"),
+                    (value_acc, "value_acc"),
                     (is_pad, "is_pad"),
                     (is_code, "is_code"),
                 ],

--- a/zkevm-circuits/src/table/copy_table.rs
+++ b/zkevm-circuits/src/table/copy_table.rs
@@ -109,9 +109,9 @@ impl CopyTable {
 
             // id
             let id = if is_read_step {
-                number_or_hash_to_field(&copy_event.src_id)
+                number_or_hash_to_word(&copy_event.src_id)
             } else {
-                number_or_hash_to_field(&copy_event.dst_id)
+                number_or_hash_to_word(&copy_event.dst_id)
             };
 
             // tag binary bumber chip

--- a/zkevm-circuits/src/table/copy_table.rs
+++ b/zkevm-circuits/src/table/copy_table.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-type CopyTableRow<F> = [(Value<F>, &'static str); 8];
+type CopyTableRow<F> = [(Value<F>, &'static str); 9];
 type CopyCircuitRow<F> = [(Value<F>, &'static str); 4];
 
 /// Copy Table, used to verify copies of byte chunks between Memory, Bytecode,
@@ -109,9 +109,9 @@ impl CopyTable {
 
             // id
             let id = if is_read_step {
-                number_or_hash_to_field(&copy_event.src_id, challenges.evm_word())
+                number_or_hash_to_field(&copy_event.src_id)
             } else {
-                number_or_hash_to_field(&copy_event.dst_id, challenges.evm_word())
+                number_or_hash_to_field(&copy_event.dst_id)
             };
 
             // tag binary bumber chip
@@ -169,7 +169,8 @@ impl CopyTable {
                 tag,
                 [
                     (is_first, "is_first"),
-                    (id, "id"),
+                    (id.lo(), "id_lo"),
+                    (id.hi(), "id_hi"),
                     (addr, "addr"),
                     (
                         Value::known(F::from(copy_event.src_addr_end)),

--- a/zkevm-circuits/src/table/rw_table.rs
+++ b/zkevm-circuits/src/table/rw_table.rs
@@ -88,11 +88,11 @@ impl RwTable {
         row: &RwRow<Value<F>>,
     ) -> Result<(), Error> {
         for (column, value) in [
-            (self.address, row.address),
             (self.rw_counter, row.rw_counter),
             (self.is_write, row.is_write),
             (self.tag, row.tag),
             (self.id, row.id),
+            (self.address, row.address),
             (self.field_tag, row.field_tag),
         ] {
             region.assign_advice(|| "assign rw row on rw table", column, offset, || value)?;

--- a/zkevm-circuits/src/table/tx_table.rs
+++ b/zkevm-circuits/src/table/tx_table.rs
@@ -116,7 +116,7 @@ impl TxTable {
             offset: usize,
             advice_columns: &[Column<Advice>],
             tag: &Column<Fixed>,
-            row: &[Value<F>; 4],
+            row: &[Value<F>; 5],
             msg: &str,
         ) -> Result<(), Error> {
             for (index, column) in advice_columns.iter().enumerate() {
@@ -147,7 +147,7 @@ impl TxTable {
                     offset,
                     &advice_columns,
                     &self.tag,
-                    &[(); 4].map(|_| Value::known(F::ZERO)),
+                    &[(); 5].map(|_| Value::known(F::ZERO)),
                     "all-zero",
                 )?;
                 offset += 1;
@@ -157,7 +157,7 @@ impl TxTable {
                 // region that has a size parametrized by max_calldata with all
                 // the tx calldata.  This is required to achieve a constant fixed column tag
                 // regardless of the number of input txs or the calldata size of each tx.
-                let mut calldata_assignments: Vec<[Value<F>; 4]> = Vec::new();
+                let mut calldata_assignments: Vec<[Value<F>; 5]> = Vec::new();
                 // Assign Tx data (all tx fields except for calldata)
                 let padding_txs: Vec<_> = (txs.len()..max_txs)
                     .map(|i| Transaction {
@@ -178,6 +178,7 @@ impl TxTable {
                     [
                         Value::known(F::ZERO),
                         Value::known(F::from(TxContextFieldTag::CallData as u64)),
+                        Value::known(F::ZERO),
                         Value::known(F::ZERO),
                         Value::known(F::ZERO),
                     ]

--- a/zkevm-circuits/src/util.rs
+++ b/zkevm-circuits/src/util.rs
@@ -1,4 +1,5 @@
 //! Common utility traits and functions.
+pub mod int_decomposition;
 pub mod word;
 
 use bus_mapping::evm::OpcodeId;

--- a/zkevm-circuits/src/util/int_decomposition.rs
+++ b/zkevm-circuits/src/util/int_decomposition.rs
@@ -1,0 +1,95 @@
+//! Define IntDecomposition to decompose int into byte limbs
+use eth_types::{Field, ToLittleEndian, H160, U256};
+use gadgets::util::Expr;
+use halo2_proofs::{
+    circuit::{AssignedCell, Value},
+    plonk::{Error, Expression},
+};
+use itertools::Itertools;
+
+use crate::evm_circuit::{
+    param::N_BYTES_HALF_WORD,
+    util::{rlc, CachedRegion, Cell},
+};
+
+use super::word::{Word, WordExpr};
+
+#[derive(Clone, Debug)]
+/// IntDecomposition decompose integer into byte limbs
+pub struct IntDecomposition<F, const N_LIMBS: usize> {
+    /// inner cells in little-endian for synthesis
+    pub limbs: [Cell<F>; N_LIMBS],
+}
+
+impl<F: Field, const N_LIMBS: usize> IntDecomposition<F, N_LIMBS> {
+    /// new by cell limbs
+    pub fn new(limbs: [Cell<F>; N_LIMBS]) -> Self {
+        Self { limbs }
+    }
+
+    /// assign bytes to cells
+    pub fn assign<const N_LIMBS_ASSIGN: usize>(
+        &self,
+        region: &mut CachedRegion<'_, '_, F>,
+        offset: usize,
+        bytes: Option<[u8; N_LIMBS_ASSIGN]>,
+    ) -> Result<Vec<AssignedCell<F, F>>, Error> {
+        assert!(N_LIMBS_ASSIGN >= N_LIMBS);
+        bytes.map_or(Err(Error::Synthesis), |bytes| {
+            self.limbs
+                .iter()
+                .zip(bytes.iter())
+                .map(|(cell, byte)| {
+                    cell.assign(region, offset, Value::known(F::from(*byte as u64)))
+                })
+                .collect()
+        })
+    }
+
+    /// assign h160 to cells
+    pub fn assign_h160(
+        &self,
+        region: &mut CachedRegion<'_, '_, F>,
+        offset: usize,
+        h160: H160,
+    ) -> Result<Vec<AssignedCell<F, F>>, Error> {
+        let mut bytes = *h160.as_fixed_bytes();
+        bytes.reverse();
+        self.assign(region, offset, Some(bytes))
+    }
+
+    /// assign u256 to cells
+    pub fn assign_u256(
+        &self,
+        region: &mut CachedRegion<'_, '_, F>,
+        offset: usize,
+        u256: U256,
+    ) -> Result<Vec<AssignedCell<F, F>>, Error> {
+        self.assign(region, offset, Some(u256.to_le_bytes()))
+    }
+}
+
+impl<F: Field, const N_LIMBS: usize> Expr<F> for IntDecomposition<F, N_LIMBS> {
+    fn expr(&self) -> Expression<F> {
+        rlc::expr(&self.limbs.clone().map(|limb| limb.expr()), 256.expr())
+    }
+}
+
+impl<F: Field, const N_LIMBS: usize> WordExpr<F> for IntDecomposition<F, N_LIMBS> {
+    fn to_word(&self) -> Word<Expression<F>> {
+        let exprs = self
+            .limbs
+            .clone()
+            .map(|x| x.expr())
+            .chunks(N_BYTES_HALF_WORD)
+            .map(|chunk| rlc::expr(chunk, 256.expr()))
+            .collect::<Vec<Expression<F>>>();
+        Word::new(
+            (0..2)
+                .map(|id| exprs.get(id).unwrap_or(&0.expr()).clone())
+                .collect_vec()
+                .try_into()
+                .unwrap(),
+        )
+    }
+}

--- a/zkevm-circuits/src/util/int_decomposition.rs
+++ b/zkevm-circuits/src/util/int_decomposition.rs
@@ -1,6 +1,6 @@
 //! Define IntDecomposition to decompose int into byte limbs
 use eth_types::{Field, ToLittleEndian, H160, U256};
-use gadgets::util::Expr;
+use gadgets::util::{sum, Expr};
 use halo2_proofs::{
     circuit::{AssignedCell, Value},
     plonk::{Error, Expression},
@@ -66,6 +66,11 @@ impl<F: Field, const N_LIMBS: usize> IntDecomposition<F, N_LIMBS> {
         u256: U256,
     ) -> Result<Vec<AssignedCell<F, F>>, Error> {
         self.assign(region, offset, Some(u256.to_le_bytes()))
+    }
+
+    /// assign all limbs into one expression
+    pub fn sum_expr(&self) -> Expression<F> {
+        sum::expr(self.limbs.clone())
     }
 }
 

--- a/zkevm-circuits/src/util/int_decomposition.rs
+++ b/zkevm-circuits/src/util/int_decomposition.rs
@@ -28,13 +28,20 @@ impl<F: Field, const N_LIMBS: usize> IntDecomposition<F, N_LIMBS> {
     }
 
     /// assign bytes to cells
-    pub fn assign<const N_LIMBS_ASSIGN: usize>(
+    pub fn assign<const N_BYTES: usize>(
         &self,
         region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
-        bytes: Option<[u8; N_LIMBS_ASSIGN]>,
+        bytes: Option<[u8; N_BYTES]>,
     ) -> Result<Vec<AssignedCell<F, F>>, Error> {
-        assert!(N_LIMBS_ASSIGN >= N_LIMBS);
+        assert!(N_BYTES >= N_LIMBS);
+        if let Some(bytes) = bytes {
+            if N_BYTES > N_LIMBS {
+                for byte in &bytes[N_BYTES - N_LIMBS..] {
+                    assert_eq!(*byte, 0);
+                }
+            }
+        }
         bytes.map_or(Err(Error::Synthesis), |bytes| {
             self.limbs
                 .iter()

--- a/zkevm-circuits/src/util/int_decomposition.rs
+++ b/zkevm-circuits/src/util/int_decomposition.rs
@@ -8,7 +8,7 @@ use halo2_proofs::{
 use itertools::Itertools;
 
 use crate::evm_circuit::{
-    param::N_BYTES_HALF_WORD,
+    param::{MAX_N_BYTES_INTEGER, N_BYTES_HALF_WORD},
     util::{rlc, CachedRegion, Cell},
 };
 
@@ -76,6 +76,7 @@ impl<F: Field, const N_LIMBS: usize> IntDecomposition<F, N_LIMBS> {
 
 impl<F: Field, const N_LIMBS: usize> Expr<F> for IntDecomposition<F, N_LIMBS> {
     fn expr(&self) -> Expression<F> {
+        assert!(N_LIMBS <= MAX_N_BYTES_INTEGER);
         rlc::expr(&self.limbs.clone().map(|limb| limb.expr()), 256.expr())
     }
 }

--- a/zkevm-circuits/src/util/word.rs
+++ b/zkevm-circuits/src/util/word.rs
@@ -44,6 +44,10 @@ impl<T, const N: usize> WordLimbs<T, N> {
     pub fn n() -> usize {
         N
     }
+    /// get limbs by index
+    pub fn get(&self, index: usize) -> &T {
+        &self.limbs[index]
+    }
 }
 
 impl<T: Default, const N: usize> Default for WordLimbs<T, N> {
@@ -93,7 +97,7 @@ impl<F: Field, const N: usize> WordLimbs<Cell<F>, N> {
     /// e.g. N1 = 4 bytes, [b1, b2, b3, b4], and N = 2 limbs [l1, l2]
     /// It equivalent `l1.assign(b1.expr() + b2.expr * F(256))`, `l2.assign(b3.expr() + b4.expr *
     /// F(256))`
-    pub fn assign<const N1: usize>(
+    fn assign<const N1: usize>(
         &self,
         region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
@@ -135,7 +139,7 @@ impl<F: Field, const N: usize> WordLimbs<Cell<F>, N> {
         let bytes_lo_assigned = bytes_lo_le
             .chunks(N_LO / half_limb_size) // chunk in little endian
             .map(|chunk| from_bytes::value(chunk))
-            .zip(self.limbs[0..half_limb_size].iter())
+            .zip_eq(self.limbs[0..half_limb_size].iter())
             .map(|(value, cell)| cell.assign(region, offset, Value::known(value)))
             .collect::<Result<Vec<AssignedCell<F, F>>, _>>()?;
 
@@ -144,7 +148,7 @@ impl<F: Field, const N: usize> WordLimbs<Cell<F>, N> {
             bytes
                 .chunks(N_HI / half_limb_size) // chunk in little endian
                 .map(|chunk| from_bytes::value(chunk))
-                .zip(self.limbs[half_limb_size..].iter())
+                .zip_eq(self.limbs[half_limb_size..].iter())
                 .map(|(value, cell)| cell.assign(region, offset, Value::known(value)))
                 .collect::<Result<Vec<AssignedCell<F, F>>, _>>()
         });
@@ -201,10 +205,14 @@ impl<F: Field, const N: usize> WordLimbs<Cell<F>, N> {
         self.assign_lo_hi(region, offset, value.to_le_bytes(), Option::<[u8; 0]>::None)
     }
 
-    #[deprecated(note = "in fav of to_word trait. Make this private")]
     /// word expr
-    pub fn word_expr(&self) -> WordLimbs<Expression<F>, N> {
+    fn word_expr(&self) -> WordLimbs<Expression<F>, N> {
         WordLimbs::new(self.limbs.clone().map(|cell| cell.expr()))
+    }
+
+    /// convert from N cells to N2 expressions limbs
+    pub fn to_word_n<const N2: usize>(&self) -> WordLimbs<Expression<F>, N2> {
+        self.word_expr().to_word_n()
     }
 }
 
@@ -375,22 +383,24 @@ impl<F: Field> Word<Expression<F>> {
         Self(WordLimbs::<Expression<F>, 2>::new([0.expr(), 0.expr()]))
     }
 
-    /// select based on selector. Here assume selector is 1/0 therefore no overflow check
-    pub fn select<T: WordExpr<F>>(
-        selector: Expression<F>,
-        when_true: T,
-        when_false: T,
-    ) -> Word<Expression<F>> {
-        let (true_lo, true_hi) = when_true
-            .to_word()
-            .mul_selector(selector.clone())
-            .to_lo_hi();
+    /// one word
+    pub fn one() -> Self {
+        Self(WordLimbs::<Expression<F>, 2>::new([1.expr(), 0.expr()]))
+    }
 
-        let (false_lo, false_hi) = when_false
-            .to_word()
-            .mul_selector(1.expr() - selector)
-            .to_lo_hi();
-        Word::new([true_lo + false_lo, true_hi + false_hi])
+    /// select based on selector. Here assume selector is 1/0 therefore no overflow check
+    pub fn select<T: Expr<F> + Clone>(
+        selector: T,
+        when_true: Word<T>,
+        when_false: Word<T>,
+    ) -> Word<Expression<F>> {
+        let (true_lo, true_hi) = when_true.to_lo_hi();
+
+        let (false_lo, false_hi) = when_false.to_lo_hi();
+        Word::new([
+            selector.expr() * true_lo.expr() + (1.expr() - selector.expr()) * false_lo.expr(),
+            selector.expr() * true_hi.expr() + (1.expr() - selector.expr()) * false_hi.expr(),
+        ])
     }
 
     /// Assume selector is 1/0 therefore no overflow check
@@ -408,12 +418,9 @@ impl<F: Field> Word<Expression<F>> {
         Word::new([self.lo() - rhs.lo(), self.hi() - rhs.hi()])
     }
 
-    /// Compress the lo and hi limbs into an expression without checking the overflow.
-    /// So far only use it for address.
-    /// TODO We should remove it before merging to the main branch.
-    #[deprecated(note = "no overflow check and unsafe. please consider keep word type")]
-    pub fn expr_unchecked(&self) -> Expression<F> {
-        self.lo() + self.hi() * (1 << (N_BYTES_HALF_WORD * 8)).expr()
+    /// No overflow check on lo/hi limbs
+    pub fn mul_unchecked(self, rhs: Self) -> Self {
+        Word::new([self.lo() * rhs.lo(), self.hi() * rhs.hi()])
     }
 }
 

--- a/zkevm-circuits/src/util/word.rs
+++ b/zkevm-circuits/src/util/word.rs
@@ -3,7 +3,7 @@
 // - Limbs: An EVN word is 256 bits. Limbs N means split 256 into N limb. For example, N = 4, each
 //   limb is 256/4 = 64 bits
 
-use eth_types::{Field, ToLittleEndian, H160};
+use eth_types::{Field, ToLittleEndian, H160, H256};
 use gadgets::util::{not, or, Expr};
 use halo2_proofs::{
     circuit::{AssignedCell, Region, Value},
@@ -294,6 +294,21 @@ impl<F: Field> From<eth_types::Word> for Word<F> {
         Word::new([
             from_bytes::value(&bytes[..N_BYTES_HALF_WORD]),
             from_bytes::value(&bytes[N_BYTES_HALF_WORD..]),
+        ])
+    }
+}
+
+impl<F: Field> From<H256> for Word<F> {
+    /// Construct the word from u256
+    fn from(h: H256) -> Self {
+        let le_bytes = {
+            let mut b = h.to_fixed_bytes();
+            b.reverse();
+            b
+        };
+        Word::new([
+            from_bytes::value(&le_bytes[..N_BYTES_HALF_WORD]),
+            from_bytes::value(&le_bytes[N_BYTES_HALF_WORD..]),
         ])
     }
 }

--- a/zkevm-circuits/src/util/word.rs
+++ b/zkevm-circuits/src/util/word.rs
@@ -44,10 +44,6 @@ impl<T, const N: usize> WordLimbs<T, N> {
     pub fn n() -> usize {
         N
     }
-    /// get limbs by index
-    pub fn get(&self, index: usize) -> &T {
-        &self.limbs[index]
-    }
 }
 
 impl<T: Default, const N: usize> Default for WordLimbs<T, N> {
@@ -342,21 +338,6 @@ impl<F: Field> From<H160> for Word<F> {
         Word::new([
             from_bytes::value(&bytes[..N_BYTES_HALF_WORD]),
             from_bytes::value(&bytes[N_BYTES_HALF_WORD..]),
-        ])
-    }
-}
-
-impl<F: Field> Word<Cell<F>> {
-    /// Assign low 128 bits for the word
-    pub fn assign_lo(
-        &self,
-        region: &mut CachedRegion<'_, '_, F>,
-        offset: usize,
-        value: Value<F>,
-    ) -> Result<Vec<AssignedCell<F, F>>, Error> {
-        Ok(vec![
-            self.limbs[0].assign(region, offset, value)?,
-            self.limbs[1].assign(region, offset, Value::known(F::from(0)))?,
         ])
     }
 }

--- a/zkevm-circuits/src/witness/block.rs
+++ b/zkevm-circuits/src/witness/block.rs
@@ -152,7 +152,7 @@ pub struct BlockContext {
 
 impl BlockContext {
     /// Assignments for block table
-    pub fn table_assignments<F: Field>(&self, _randomness: Value<F>) -> Vec<[Value<F>; 4]> {
+    pub fn table_assignments<F: Field>(&self) -> Vec<[Value<F>; 4]> {
         [
             vec![
                 [
@@ -239,8 +239,7 @@ pub fn block_convert<F: Field>(
     code_db: &bus_mapping::state_db::CodeDB,
 ) -> Result<Block<F>, Error> {
     let rws = RwMap::from(&block.container);
-    // TODO add me back
-    // rws.check_value();
+    rws.check_value();
     Ok(Block {
         // randomness: F::from(0x100), // Special value to reveal elements after RLC
         randomness: F::from(0xcafeu64),

--- a/zkevm-circuits/src/witness/block.rs
+++ b/zkevm-circuits/src/witness/block.rs
@@ -1,16 +1,16 @@
 use std::collections::HashMap;
 
 use crate::{
-    evm_circuit::{detect_fixed_table_tags, util::rlc, EvmCircuit},
+    evm_circuit::{detect_fixed_table_tags, EvmCircuit},
     exp_circuit::param::OFFSET_INCREMENT,
     table::BlockContextFieldTag,
-    util::{log2_ceil, SubCircuit},
+    util::{log2_ceil, word, SubCircuit},
 };
 use bus_mapping::{
     circuit_input_builder::{self, CircuitsParams, CopyEvent, ExpEvent},
     Error,
 };
-use eth_types::{Address, Field, ToLittleEndian, ToScalar, Word};
+use eth_types::{Address, Field, ToScalar, Word};
 use halo2_proofs::circuit::Value;
 
 use super::{tx::tx_convert, Bytecode, ExecStep, Rw, RwMap, Transaction};
@@ -152,46 +152,50 @@ pub struct BlockContext {
 
 impl BlockContext {
     /// Assignments for block table
-    pub fn table_assignments<F: Field>(&self, randomness: Value<F>) -> Vec<[Value<F>; 3]> {
+    pub fn table_assignments<F: Field>(&self, _randomness: Value<F>) -> Vec<[Value<F>; 4]> {
         [
             vec![
                 [
                     Value::known(F::from(BlockContextFieldTag::Coinbase as u64)),
                     Value::known(F::ZERO),
-                    Value::known(self.coinbase.to_scalar().unwrap()),
+                    Value::known(word::Word::from(self.coinbase).lo()),
+                    Value::known(word::Word::from(self.coinbase).hi()),
                 ],
                 [
                     Value::known(F::from(BlockContextFieldTag::Timestamp as u64)),
                     Value::known(F::ZERO),
                     Value::known(self.timestamp.to_scalar().unwrap()),
+                    Value::known(F::ZERO),
                 ],
                 [
                     Value::known(F::from(BlockContextFieldTag::Number as u64)),
                     Value::known(F::ZERO),
                     Value::known(self.number.to_scalar().unwrap()),
+                    Value::known(F::ZERO),
                 ],
                 [
                     Value::known(F::from(BlockContextFieldTag::Difficulty as u64)),
                     Value::known(F::ZERO),
-                    randomness
-                        .map(|randomness| rlc::value(&self.difficulty.to_le_bytes(), randomness)),
+                    Value::known(word::Word::from(self.difficulty).lo()),
+                    Value::known(word::Word::from(self.difficulty).hi()),
                 ],
                 [
                     Value::known(F::from(BlockContextFieldTag::GasLimit as u64)),
                     Value::known(F::ZERO),
                     Value::known(F::from(self.gas_limit)),
+                    Value::known(F::ZERO),
                 ],
                 [
                     Value::known(F::from(BlockContextFieldTag::BaseFee as u64)),
                     Value::known(F::ZERO),
-                    randomness
-                        .map(|randomness| rlc::value(&self.base_fee.to_le_bytes(), randomness)),
+                    Value::known(word::Word::from(self.base_fee).lo()),
+                    Value::known(word::Word::from(self.base_fee).hi()),
                 ],
                 [
                     Value::known(F::from(BlockContextFieldTag::ChainId as u64)),
                     Value::known(F::ZERO),
-                    randomness
-                        .map(|randomness| rlc::value(&self.chain_id.to_le_bytes(), randomness)),
+                    Value::known(word::Word::from(self.chain_id).lo()),
+                    Value::known(word::Word::from(self.chain_id).hi()),
                 ],
             ],
             {
@@ -203,8 +207,8 @@ impl BlockContext {
                         [
                             Value::known(F::from(BlockContextFieldTag::BlockHash as u64)),
                             Value::known((self.number - len_history + idx).to_scalar().unwrap()),
-                            randomness
-                                .map(|randomness| rlc::value(&hash.to_le_bytes(), randomness)),
+                            Value::known(word::Word::from(*hash).lo()),
+                            Value::known(word::Word::from(*hash).hi()),
                         ]
                     })
                     .collect()
@@ -235,7 +239,8 @@ pub fn block_convert<F: Field>(
     code_db: &bus_mapping::state_db::CodeDB,
 ) -> Result<Block<F>, Error> {
     let rws = RwMap::from(&block.container);
-    rws.check_value();
+    // TODO add me back
+    // rws.check_value();
     Ok(Block {
         // randomness: F::from(0x100), // Special value to reveal elements after RLC
         randomness: F::from(0xcafeu64),

--- a/zkevm-circuits/src/witness/bytecode.rs
+++ b/zkevm-circuits/src/witness/bytecode.rs
@@ -1,9 +1,12 @@
 use bus_mapping::evm::OpcodeId;
-use eth_types::{Field, ToLittleEndian, Word};
+use eth_types::{Field, Word};
 use halo2_proofs::circuit::Value;
 use sha3::{Digest, Keccak256};
 
-use crate::{evm_circuit::util::rlc, table::BytecodeFieldTag, util::Challenges};
+use crate::{
+    table::BytecodeFieldTag,
+    util::{word, Challenges},
+};
 
 /// Bytecode
 #[derive(Clone, Debug)]
@@ -24,16 +27,14 @@ impl Bytecode {
     /// Assignments for bytecode table
     pub fn table_assignments<F: Field>(
         &self,
-        challenges: &Challenges<Value<F>>,
-    ) -> Vec<[Value<F>; 5]> {
+        _challenges: &Challenges<Value<F>>,
+    ) -> Vec<[Value<F>; 6]> {
         let n = 1 + self.bytes.len();
         let mut rows = Vec::with_capacity(n);
-        let hash = challenges
-            .evm_word()
-            .map(|challenge| rlc::value(&self.hash.to_le_bytes(), challenge));
 
         rows.push([
-            hash,
+            Value::known(word::Word::from(self.hash).lo()),
+            Value::known(word::Word::from(self.hash).hi()),
             Value::known(F::from(BytecodeFieldTag::Header as u64)),
             Value::known(F::ZERO),
             Value::known(F::ZERO),
@@ -52,7 +53,8 @@ impl Bytecode {
             };
 
             rows.push([
-                hash,
+                Value::known(word::Word::from(self.hash).lo()),
+                Value::known(word::Word::from(self.hash).hi()),
                 Value::known(F::from(BytecodeFieldTag::Byte as u64)),
                 Value::known(F::from(idx as u64)),
                 Value::known(F::from(is_code as u64)),

--- a/zkevm-circuits/src/witness/bytecode.rs
+++ b/zkevm-circuits/src/witness/bytecode.rs
@@ -3,10 +3,7 @@ use eth_types::{Field, Word};
 use halo2_proofs::circuit::Value;
 use sha3::{Digest, Keccak256};
 
-use crate::{
-    table::BytecodeFieldTag,
-    util::{word, Challenges},
-};
+use crate::{table::BytecodeFieldTag, util::word};
 
 /// Bytecode
 #[derive(Clone, Debug)]
@@ -25,10 +22,7 @@ impl Bytecode {
     }
 
     /// Assignments for bytecode table
-    pub fn table_assignments<F: Field>(
-        &self,
-        _challenges: &Challenges<Value<F>>,
-    ) -> Vec<[Value<F>; 6]> {
+    pub fn table_assignments<F: Field>(&self) -> Vec<[Value<F>; 6]> {
         let n = 1 + self.bytes.len();
         let mut rows = Vec::with_capacity(n);
 

--- a/zkevm-circuits/src/witness/rw.rs
+++ b/zkevm-circuits/src/witness/rw.rs
@@ -269,6 +269,7 @@ pub struct RwRow<F> {
     pub(crate) init_val: word::Word<F>,
 }
 
+// TODO figure out a better trait bound on T to support function word lo()/hi()
 impl<F: Field> RwRow<F> {
     pub(crate) fn values(&self) -> [F; 14] {
         [

--- a/zkevm-circuits/src/witness/rw.rs
+++ b/zkevm-circuits/src/witness/rw.rs
@@ -269,7 +269,6 @@ pub struct RwRow<F> {
     pub(crate) init_val: word::Word<F>,
 }
 
-// TODO figure out a better trait bound on T to support function word lo()/hi()
 impl<F: Field> RwRow<F> {
     pub(crate) fn values(&self) -> [F; 14] {
         [

--- a/zkevm-circuits/src/witness/tx.rs
+++ b/zkevm-circuits/src/witness/tx.rs
@@ -3,7 +3,7 @@ use bus_mapping::circuit_input_builder;
 use eth_types::{Address, Field, Word};
 use halo2_proofs::circuit::Value;
 
-use crate::{table::TxContextFieldTag, util::Challenges};
+use crate::table::TxContextFieldTag;
 
 use super::{Call, ExecStep};
 
@@ -41,10 +41,7 @@ pub struct Transaction {
 impl Transaction {
     /// Assignments for tx table, split into tx_data (all fields except
     /// calldata) and tx_calldata
-    pub fn table_assignments<F: Field>(
-        &self,
-        _challenges: Challenges<Value<F>>,
-    ) -> [Vec<[Value<F>; 5]>; 2] {
+    pub fn table_assignments<F: Field>(&self) -> [Vec<[Value<F>; 5]>; 2] {
         let tx_data = vec![
             [
                 Value::known(F::from(self.id as u64)),

--- a/zkevm-circuits/src/witness/tx.rs
+++ b/zkevm-circuits/src/witness/tx.rs
@@ -1,8 +1,9 @@
+use crate::util::word;
 use bus_mapping::circuit_input_builder;
-use eth_types::{Address, Field, ToLittleEndian, ToScalar, Word};
+use eth_types::{Address, Field, Word};
 use halo2_proofs::circuit::Value;
 
-use crate::{evm_circuit::util::rlc, table::TxContextFieldTag, util::Challenges};
+use crate::{table::TxContextFieldTag, util::Challenges};
 
 use super::{Call, ExecStep};
 
@@ -42,66 +43,71 @@ impl Transaction {
     /// calldata) and tx_calldata
     pub fn table_assignments<F: Field>(
         &self,
-        challenges: Challenges<Value<F>>,
-    ) -> [Vec<[Value<F>; 4]>; 2] {
+        _challenges: Challenges<Value<F>>,
+    ) -> [Vec<[Value<F>; 5]>; 2] {
         let tx_data = vec![
             [
                 Value::known(F::from(self.id as u64)),
                 Value::known(F::from(TxContextFieldTag::Nonce as u64)),
                 Value::known(F::ZERO),
                 Value::known(F::from(self.nonce)),
+                Value::known(F::ZERO),
             ],
             [
                 Value::known(F::from(self.id as u64)),
                 Value::known(F::from(TxContextFieldTag::Gas as u64)),
                 Value::known(F::ZERO),
                 Value::known(F::from(self.gas)),
+                Value::known(F::ZERO),
             ],
             [
                 Value::known(F::from(self.id as u64)),
                 Value::known(F::from(TxContextFieldTag::GasPrice as u64)),
                 Value::known(F::ZERO),
-                challenges
-                    .evm_word()
-                    .map(|challenge| rlc::value(&self.gas_price.to_le_bytes(), challenge)),
+                Value::known(word::Word::from(self.gas_price).lo()),
+                Value::known(word::Word::from(self.gas_price).hi()),
             ],
             [
                 Value::known(F::from(self.id as u64)),
                 Value::known(F::from(TxContextFieldTag::CallerAddress as u64)),
                 Value::known(F::ZERO),
-                Value::known(self.caller_address.to_scalar().unwrap()),
+                Value::known(word::Word::from(self.caller_address).lo()),
+                Value::known(word::Word::from(self.caller_address).hi()),
             ],
             [
                 Value::known(F::from(self.id as u64)),
                 Value::known(F::from(TxContextFieldTag::CalleeAddress as u64)),
                 Value::known(F::ZERO),
-                Value::known(self.callee_address.to_scalar().unwrap()),
+                Value::known(word::Word::from(self.callee_address).lo()),
+                Value::known(word::Word::from(self.callee_address).hi()),
             ],
             [
                 Value::known(F::from(self.id as u64)),
                 Value::known(F::from(TxContextFieldTag::IsCreate as u64)),
                 Value::known(F::ZERO),
                 Value::known(F::from(self.is_create as u64)),
+                Value::known(F::ZERO),
             ],
             [
                 Value::known(F::from(self.id as u64)),
                 Value::known(F::from(TxContextFieldTag::Value as u64)),
                 Value::known(F::ZERO),
-                challenges
-                    .evm_word()
-                    .map(|challenge| rlc::value(&self.value.to_le_bytes(), challenge)),
+                Value::known(word::Word::from(self.value).lo()),
+                Value::known(word::Word::from(self.value).hi()),
             ],
             [
                 Value::known(F::from(self.id as u64)),
                 Value::known(F::from(TxContextFieldTag::CallDataLength as u64)),
                 Value::known(F::ZERO),
                 Value::known(F::from(self.call_data_length as u64)),
+                Value::known(F::ZERO),
             ],
             [
                 Value::known(F::from(self.id as u64)),
                 Value::known(F::from(TxContextFieldTag::CallDataGasCost as u64)),
                 Value::known(F::ZERO),
                 Value::known(F::from(self.call_data_gas_cost)),
+                Value::known(F::ZERO),
             ],
         ];
         let tx_calldata = self
@@ -114,6 +120,7 @@ impl Transaction {
                     Value::known(F::from(TxContextFieldTag::CallData as u64)),
                     Value::known(F::from(idx as u64)),
                     Value::known(F::from(*byte as u64)),
+                    Value::known(F::ZERO),
                 ]
             })
             .collect();


### PR DESCRIPTION
### Description

This PR is based on https://github.com/privacy-scaling-explorations/zkevm-circuits/pull/1394
Need to merge https://github.com/privacy-scaling-explorations/zkevm-circuits/pull/1394 first before review this.

### Issue Link

https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/1379

### Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Contents

- [x] fixed most of op compiling errors other than `callop.rs` and `begin_tx.rs`.
- [x] fixed `callop.rs` and `begin_tx.rs` 
- [x] remove all compatible workaround `construct_new` under evm circuit
- [x] unittest under evm circuit all pass `cargo test --features warn-unimplemented --features test --package zkevm-circuits --lib -- evm_circuit::execution::` 
- [x] fix few `word` gadgets generics to take `Word<T>`  instead of `T`  to restrict it flexibility, since it's non sense to put type not related to word
- [x] remove most of `deprecated` api under evm circuits
- [x] add IntDecomposition type as an alternative to RandomLinearComposition, with base 256

### Cell utilization on main branch vs on word-lo-hi branch

#### Storage_1
```
Main:
+-----------------------------------+------------------------------+-------------------------+
| "storage_1" total_available_cells | "storage_1" total_used_cells | "storage_1" Utilization (%) |
+-----------------------------------+------------------------------+-------------------------+
| 25480                             | 6482                         | 25.4                    |
+-----------------------------------+------------------------------+-------------------------+

Word-lo-hi
+-----------------------------------+------------------------------+-----------------------------+
| "storage_1" total_available_cells | "storage_1" total_used_cells | "storage_1" Utilization (%) |
+-----------------------------------+------------------------------+-----------------------------+
| 24080                             | 7078                         | 29.4                        |
+-----------------------------------+------------------------------+-----------------------------+
```

#### Storage_2
```
Main
+-----------------------------------+------------------------------+-------------------------+
| "storage_2" total_available_cells | "storage_2" total_used_cells | "storage_2" Utilization |
+-----------------------------------+------------------------------+-------------------------+
| 1456                              | 467                          | 32.1                    |
+-----------------------------------+------------------------------+-------------------------+

Word-lo-hi
+-----------------------------------+------------------------------+-----------------------------+
| "storage_2" total_available_cells | "storage_2" total_used_cells | "storage_2" Utilization (%) |
+-----------------------------------+------------------------------+-----------------------------+
| 1376                              | 14                           | 1.0                         |
+-----------------------------------+------------------------------+-----------------------------+
```

#### Byte_lookup
```
Main
 +-------------------------------------+--------------------------------+---------------------------+
| "byte_lookup" total_available_cells | "byte_lookup" total_used_cells | "byte_lookup" Utilization |
+-------------------------------------+--------------------------------+---------------------------+
| 8736                                | 6786                           | 77.7                      |
+-------------------------------------+--------------------------------+---------------------------+

Word-lo-hi
+-------------------------------------+--------------------------------+-------------------------------+
| "byte_lookup" total_available_cells | "byte_lookup" total_used_cells | "byte_lookup" Utilization (%) |
+-------------------------------------+--------------------------------+-------------------------------+
| 8256                                | 6566                           | 79.5                          |
+-------------------------------------+--------------------------------+-------------------------------+
```
