### PR TITLE
[word lo/hi] retype table, common gadget and util design

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution/caller.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/caller.rs
@@ -1,20 +1,17 @@
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
-        param::N_BYTES_HALF_WORD,
+        param::N_BYTES_ACCOUNT_ADDRESS,
         step::ExecutionState,
         util::{
             common_gadget::SameContextGadget,
             constraint_builder::{EVMConstraintBuilder, StepStateTransition, Transition::Delta},
-            CachedRegion,
+            AccountAddress, CachedRegion,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
     table::CallContextFieldTag,
-    util::{
-        word::{WordCell, WordExpr},
-        Expr,
-    },
+    util::{word::WordExpr, Expr},
 };
 use bus_mapping::evm::OpcodeId;
 use eth_types::{Field, ToLittleEndian};
@@ -24,7 +21,7 @@ use halo2_proofs::plonk::Error;
 pub(crate) struct CallerGadget<F> {
     same_context: SameContextGadget<F>,
     // Using RLC to match against rw_table->stack_op value
-    caller_address: WordCell<F>,
+    caller_address: AccountAddress<F>,
 }
 
 impl<F: Field> ExecutionGadget<F> for CallerGadget<F> {
@@ -33,7 +30,9 @@ impl<F: Field> ExecutionGadget<F> for CallerGadget<F> {
     const EXECUTION_STATE: ExecutionState = ExecutionState::CALLER;
 
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
-        let caller_address = cb.query_word_unchecked();
+        // TODO switch to query_word_unchecked once callcontext -> XXXaddress encoded to Word2 type
+        // properly refer discussion thread https://github.com/privacy-scaling-explorations/zkevm-circuits/pull/1414/files#r1197845688
+        let caller_address = cb.query_account_address();
 
         // Lookup rw_table -> call_context with caller address
         cb.call_context_lookup_read(
@@ -75,11 +74,12 @@ impl<F: Field> ExecutionGadget<F> for CallerGadget<F> {
 
         let caller = block.rws[step.rw_indices[1]].stack_value();
 
-        self.caller_address.assign_lo_hi(
+        self.caller_address.assign(
             region,
             offset,
-            caller.to_le_bytes()[..N_BYTES_HALF_WORD].try_into().ok(),
-            caller.to_le_bytes()[N_BYTES_HALF_WORD..].try_into().ok(),
+            caller.to_le_bytes()[0..N_BYTES_ACCOUNT_ADDRESS]
+                .try_into()
+                .ok(),
         )?;
 
         Ok(())

--- a/zkevm-circuits/src/evm_circuit/param.rs
+++ b/zkevm-circuits/src/evm_circuit/param.rs
@@ -80,6 +80,9 @@ pub(crate) const MAX_N_BYTES_INTEGER: usize = 31;
 // Number of bytes an EVM word has.
 pub(crate) const N_BYTES_WORD: usize = 32;
 
+// Number of bytes an half EVM word has.
+pub(crate) const N_BYTES_HALF_WORD: usize = 16;
+
 // Number of bytes an u64 has.
 pub(crate) const N_BYTES_U64: usize = 8;
 

--- a/zkevm-circuits/src/evm_circuit/table.rs
+++ b/zkevm-circuits/src/evm_circuit/table.rs
@@ -142,8 +142,8 @@ pub struct RwValues<F> {
     pub storage_key: Word<Expression<F>>,
     pub value: Word<Expression<F>>,
     pub value_prev: Word<Expression<F>>,
-    pub aux1: Expression<F>,
-    pub aux2: Expression<F>,
+    pub aux1: Expression<F>,       // for AccountStorage::tx_id
+    pub aux2: Word<Expression<F>>, // for AccountStorage committed value
 }
 
 impl<F: Field> RwValues<F> {
@@ -156,7 +156,7 @@ impl<F: Field> RwValues<F> {
         value: Word<Expression<F>>,
         value_prev: Word<Expression<F>>,
         aux1: Expression<F>,
-        aux2: Expression<F>,
+        aux2: Word<Expression<F>>,
     ) -> Self {
         Self {
             id,
@@ -338,7 +338,8 @@ impl<F: Field> Lookup<F> {
                 values.value_prev.lo().clone(),
                 values.value_prev.hi().clone(),
                 values.aux1.clone(),
-                values.aux2.clone(),
+                values.aux2.lo().clone(),
+                values.aux2.hi().clone(),
             ],
             Self::Bytecode {
                 hash,

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -622,10 +622,10 @@ impl<F: Field, const IS_SUCCESS_CALL: bool> CommonCallGadget<F, IS_SUCCESS_CALL>
         let gas_word = cb.query_word32();
         let callee_address_word = cb.query_account_address();
         let value = cb.query_word32();
-        let cd_offset = cb.query_word32();
-        let cd_length = cb.query_word32();
-        let rd_offset = cb.query_word32();
-        let rd_length = cb.query_word32();
+        let cd_offset = cb.query_word_unchecked();
+        let cd_length = cb.query_memory_address();
+        let rd_offset = cb.query_word_unchecked();
+        let rd_length = cb.query_memory_address();
         let is_success = cb.query_bool();
 
         // Lookup values from stack

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -697,6 +697,10 @@ impl<F: Field, const IS_SUCCESS_CALL: bool> CommonCallGadget<F, IS_SUCCESS_CALL>
         self.callee_address.expr()
     }
 
+    pub fn callee_address_word(&self) -> Word<Expression<F>> {
+        self.callee_address.to_word()
+    }
+
     pub fn gas_expr(&self) -> Expression<F> {
         from_bytes::expr(&self.gas.limbs[..N_BYTES_GAS])
     }
@@ -844,7 +848,13 @@ pub(crate) struct SstoreGasGadget<F, T> {
 }
 
 impl<F: Field, T: WordExpr<F>> SstoreGasGadget<F, T> {
-    pub(crate) fn construct(cb: &mut EVMConstraintBuilder<F>, is_warm: Cell<F>, value: T, value_prev: T, original_value: T) -> Self {
+    pub(crate) fn construct(
+        cb: &mut EVMConstraintBuilder<F>,
+        is_warm: Cell<F>,
+        value: T,
+        value_prev: T,
+        original_value: T,
+    ) -> Self {
         let value_eq_prev = IsEqualWordGadget::construct(cb, value, value_prev);
         let original_eq_prev = IsEqualWordGadget::construct(cb, original_value, value_prev);
         let original_is_zero = IsZeroWordGadget::construct(cb, original_value);

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -1347,8 +1347,32 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 build_tx_log_expression(index, field_tag.expr(), log_id),
                 0.expr(),
                 Word::zero(),
-                // TODO assure range check since here is write
                 Word::from_lo_unchecked(value),
+                Word::zero(),
+                0.expr(),
+                Word::zero(),
+            ),
+        );
+    }
+
+    pub(crate) fn tx_log_lookup_word(
+        &mut self,
+        tx_id: Expression<F>,
+        log_id: Expression<F>,
+        field_tag: TxLogFieldTag,
+        index: Expression<F>,
+        value: Word<Expression<F>>,
+    ) {
+        self.rw_lookup(
+            "log data lookup",
+            1.expr(),
+            RwTableTag::TxLog,
+            RwValues::new(
+                tx_id,
+                build_tx_log_expression(index, field_tag.expr(), log_id),
+                0.expr(),
+                Word::zero(),
+                value,
                 Word::zero(),
                 0.expr(),
                 Word::zero(),

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -754,6 +754,17 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         word
     }
 
+    pub(crate) fn tx_context_as_account_address(
+        &mut self,
+        id: Expression<F>,
+        field_tag: TxContextFieldTag,
+        index: Option<Expression<F>>,
+    ) -> AccountAddress<F> {
+        let word = self.query_account_address();
+        self.tx_context_lookup(id, field_tag, index, word.to_word());
+        word
+    }
+
     pub(crate) fn tx_context_lookup(
         &mut self,
         id: Expression<F>,

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -899,7 +899,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 value,
                 value_prev,
                 0.expr(),
-                0.expr(),
+                Word::zero(),
             ),
             reversion_info,
         );
@@ -923,7 +923,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 value.clone(),
                 value,
                 0.expr(),
-                0.expr(),
+                Word::zero(),
             ),
         );
     }
@@ -948,7 +948,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 value,
                 value_prev,
                 0.expr(),
-                0.expr(),
+                Word::zero(),
             ),
             reversion_info,
         );
@@ -973,7 +973,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 value.clone(),
                 value,
                 0.expr(),
-                0.expr(),
+                Word::zero(),
             ),
         );
     }
@@ -993,7 +993,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 value.clone(),
                 value,
                 0.expr(),
-                0.expr(),
+                Word::zero(),
             ),
         );
     }
@@ -1016,7 +1016,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 value,
                 value_prev,
                 0.expr(),
-                0.expr(),
+                Word::zero(),
             ),
             reversion_info,
         );
@@ -1042,7 +1042,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 value.clone(),
                 value,
                 0.expr(),
-                0.expr(),
+                Word::zero(),
             ),
         );
     }
@@ -1066,7 +1066,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 value,
                 value_prev,
                 0.expr(),
-                0.expr(),
+                Word::zero(),
             ),
             reversion_info,
         );
@@ -1080,7 +1080,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         key: Word<Expression<F>>,
         value: Word<Expression<F>>,
         tx_id: Expression<F>,
-        committed_value: Expression<F>,
+        committed_value: Word<Expression<F>>,
     ) {
         self.rw_lookup(
             "account_storage_read",
@@ -1107,7 +1107,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         value: Word<Expression<F>>,
         value_prev: Word<Expression<F>>,
         tx_id: Expression<F>,
-        committed_value: Expression<F>,
+        committed_value: Word<Expression<F>>,
         reversion_info: Option<&mut ReversionInfo<F>>,
     ) {
         self.reversible_write(
@@ -1175,7 +1175,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 value,
                 Word::zero(),
                 0.expr(),
-                0.expr(),
+                Word::zero(),
             ),
         );
     }
@@ -1198,7 +1198,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 value,
                 Word::zero(),
                 0.expr(),
-                0.expr(),
+                Word::zero(),
             ),
         );
     }
@@ -1287,7 +1287,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 value,
                 Word::zero(),
                 0.expr(),
-                0.expr(),
+                Word::zero(),
             ),
         );
     }
@@ -1314,7 +1314,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 Word::from_lo_unchecked(byte),
                 Word::zero(),
                 0.expr(),
-                0.expr(),
+                Word::zero(),
             ),
         );
     }
@@ -1340,7 +1340,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 Word::from_lo_unchecked(value),
                 Word::zero(),
                 0.expr(),
-                0.expr(),
+                Word::zero(),
             ),
         );
     }
@@ -1367,7 +1367,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 Word::from_lo_unchecked(value),
                 Word::zero(),
                 0.expr(),
-                0.expr(),
+                Word::zero(),
             ),
         );
     }
@@ -1388,7 +1388,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 value: Word::zero(),
                 value_prev: Word::zero(),
                 aux1: 0.expr(),
-                aux2: 0.expr(),
+                aux2: Word::zero(),
             },
         );
     }

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/lt_word.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/lt_word.rs
@@ -84,7 +84,8 @@ mod tests {
         fn configure_gadget_container(cb: &mut EVMConstraintBuilder<F>) -> Self {
             let a = cb.query_word32();
             let b = cb.query_word32();
-            let ltword_gadget = LtWordGadget::<F>::construct(cb, &a, &b);
+            let ltword_gadget =
+                LtWordGadget::<F, Word32Cell<F>, Word32Cell<F>>::construct(cb, a, b);
             cb.require_equal("a < b", ltword_gadget.expr(), 1.expr());
             LtWordTestContainer {
                 ltword_gadget,

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/lt_word.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/lt_word.rs
@@ -84,8 +84,7 @@ mod tests {
         fn configure_gadget_container(cb: &mut EVMConstraintBuilder<F>) -> Self {
             let a = cb.query_word32();
             let b = cb.query_word32();
-            let ltword_gadget =
-                LtWordGadget::<F, Word32Cell<F>, Word32Cell<F>>::construct(cb, a, b);
+            let ltword_gadget = LtWordGadget::construct(cb, a, b);
             cb.require_equal("a < b", ltword_gadget.expr(), 1.expr());
             LtWordTestContainer {
                 ltword_gadget,

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/min_max_word.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/min_max_word.rs
@@ -1,16 +1,11 @@
 use std::marker::PhantomData;
 
 use crate::{
-    evm_circuit::util::{
-        constraint_builder::EVMConstraintBuilder, math_gadget::*, transpose_val_ret, CachedRegion,
-    },
+    evm_circuit::util::{constraint_builder::EVMConstraintBuilder, math_gadget::*, CachedRegion},
     util::word::{Word, WordExpr},
 };
 use eth_types::Field;
-use halo2_proofs::{
-    circuit::Value,
-    plonk::{Error, Expression},
-};
+use halo2_proofs::plonk::{Error, Expression};
 /// Returns `rhs` when `lhs < rhs`, and returns `lhs` otherwise.
 /// lhs and rhs `< 256**N_BYTES`
 /// `N_BYTES` is required to be `<= MAX_N_BYTES_INTEGER`.
@@ -48,28 +43,11 @@ impl<F: Field, T: WordExpr<F> + Clone> MinMaxWordGadget<F, T> {
         &self,
         region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
-        lhs: Word<F>,
-        rhs: Word<F>,
-    ) -> Result<(F, F), Error> {
-        let (lt, _) = self.lt.assign(region, offset, lhs, rhs)?;
-        Ok(if lt.is_zero_vartime() {
-            (rhs, lhs)
-        } else {
-            (lhs, rhs)
-        })
-    }
-
-    pub(crate) fn assign_value(
-        &self,
-        region: &mut CachedRegion<'_, '_, F>,
-        offset: usize,
-        lhs: Value<F>,
-        rhs: Value<F>,
-    ) -> Result<Value<(F, F)>, Error> {
-        transpose_val_ret(
-            lhs.zip(rhs)
-                .map(|(lhs, rhs)| self.assign(region, offset, lhs, rhs)),
-        )
+        lhs: eth_types::Word,
+        rhs: eth_types::Word,
+    ) -> Result<(), Error> {
+        self.lt.assign(region, offset, lhs, rhs)?;
+        Ok(())
     }
 }
 

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/modulo.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/modulo.rs
@@ -40,7 +40,7 @@ impl<F: Field> ModGadget<F> {
         let a_or_is_zero = IsZeroWordGadget::construct(cb, a_or_zero.clone());
         let mul_add_words = MulAddWordsGadget::construct(cb, [&k, n, r, &a_or_zero]);
         let eq = IsEqualWordGadget::construct(cb, a.clone(), a_or_zero);
-        let lt = LtWordGadget::construct(cb, r, n);
+        let lt = LtWordGadget::construct(cb, r.clone(), n.clone());
         // Constrain the aux variable a_or_zero to be =a or =0 if n==0:
         // (a == a_or_zero) ^ (n == 0 & a_or_zero == 0)
         cb.add_constraint(

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -452,7 +452,7 @@ pub struct RwTable {
     /// Aux1
     pub aux1: Column<Advice>,
     /// Aux2 (Committed Value)
-    pub aux2: Column<Advice>,
+    pub aux2: word::Word<Column<Advice>>,
 }
 
 impl<F: Field> LookupTable<F> for RwTable {
@@ -471,7 +471,8 @@ impl<F: Field> LookupTable<F> for RwTable {
             self.value_prev.lo().clone().into(),
             self.value_prev.hi().clone().into(),
             self.aux1.into(),
-            self.aux2.into(),
+            self.aux2.lo().clone().into(),
+            self.aux2.hi().clone().into(),
         ]
     }
 
@@ -490,7 +491,8 @@ impl<F: Field> LookupTable<F> for RwTable {
             String::from("value_prev_lo"),
             String::from("value_prev_hi"),
             String::from("aux1"),
-            String::from("aux2"),
+            String::from("aux2_lo"),
+            String::from("aux2_hi"),
         ]
     }
 }
@@ -510,7 +512,7 @@ impl RwTable {
             // It seems that aux1 for the moment is not using randomness
             // TODO check in a future review
             aux1: meta.advice_column_in(SecondPhase),
-            aux2: meta.advice_column_in(SecondPhase),
+            aux2: word::Word::new([meta.advice_column(), meta.advice_column()]),
         }
     }
     fn assign<F: Field>(

--- a/zkevm-circuits/src/util/word.rs
+++ b/zkevm-circuits/src/util/word.rs
@@ -139,8 +139,8 @@ impl<F: Field, const N: usize> WordLimbs<Cell<F>, N> {
         self.assign_lo_hi(
             region,
             offset,
-            word.to_le_bytes()[0..N_BYTES_HALF_WORD],
-            word.to_le_bytes()[N_BYTES_HALF_WORD..],
+            word.to_le_bytes()[0..N_BYTES_HALF_WORD].try_into().ok(),
+            word.to_le_bytes()[N_BYTES_HALF_WORD..].try_into().ok(),
         )
     }
 

--- a/zkevm-circuits/src/util/word.rs
+++ b/zkevm-circuits/src/util/word.rs
@@ -275,7 +275,7 @@ impl<F: Field> Word<Expression<F>> {
 
     // No overflow check
     pub fn expr_unchecked(&self) -> Expression<F> {
-        self.lo().clone() * (1 << 128).expr() + self.hi().clone()
+        self.lo().clone() + self.hi().clone() * (1 << 128).expr()
     }
 }
 

--- a/zkevm-circuits/src/util/word.rs
+++ b/zkevm-circuits/src/util/word.rs
@@ -258,7 +258,7 @@ impl<F: Field> Word<Expression<F>> {
     }
 
     // No overflow check on lo/hi limbs
-    pub fn add_unchecked(self, rhs: Self) -> Self {
+    pub fn add_unchecked(&self, rhs: Self) -> Self {
         Word::new([
             self.lo().clone() + rhs.lo().clone(),
             self.hi().clone() + rhs.hi().clone(),
@@ -266,11 +266,16 @@ impl<F: Field> Word<Expression<F>> {
     }
 
     // No underflow check on lo/hi limbs
-    pub fn sub_unchecked(self, rhs: Self) -> Self {
+    pub fn sub_unchecked(&self, rhs: Self) -> Self {
         Word::new([
             self.lo().clone() - rhs.lo().clone(),
             self.hi().clone() - rhs.hi().clone(),
         ])
+    }
+
+    // No overflow check
+    pub fn expr_unchecked(&self) -> Expression<F> {
+        self.lo().clone() * (1 << 128).expr() + self.hi().clone()
     }
 }
 

--- a/zkevm-circuits/src/util/word.rs
+++ b/zkevm-circuits/src/util/word.rs
@@ -11,7 +11,10 @@ use halo2_proofs::{
 };
 use itertools::Itertools;
 
-use crate::evm_circuit::util::{from_bytes, CachedRegion, Cell};
+use crate::evm_circuit::{
+    param::N_BYTES_HALF_WORD,
+    util::{from_bytes, CachedRegion, Cell},
+};
 
 #[derive(Clone, Debug, Copy)]
 pub(crate) struct WordLimbs<T, const N: usize> {
@@ -125,6 +128,20 @@ impl<F: Field, const N: usize> WordLimbs<Cell<F>, N> {
             .concat()),
             _ => Err(Error::Synthesis),
         }
+    }
+
+    pub fn assign_u256(
+        &self,
+        region: &mut CachedRegion<'_, '_, F>,
+        offset: usize,
+        word: eth_types::Word,
+    ) -> Result<Vec<AssignedCell<F, F>>, Error> {
+        self.assign_lo_hi(
+            region,
+            offset,
+            word.to_le_bytes()[0..N_BYTES_HALF_WORD],
+            word.to_le_bytes()[N_BYTES_HALF_WORD..],
+        )
     }
 
     pub fn word_expr(&self) -> WordLimbs<Expression<F>, N> {

--- a/zkevm-circuits/src/witness/rw.rs
+++ b/zkevm-circuits/src/witness/rw.rs
@@ -257,11 +257,11 @@ pub struct RwRow<F> {
     pub(crate) value: word::Word<F>,
     pub(crate) value_prev: word::Word<F>,
     pub(crate) aux1: F,
-    pub(crate) aux2: F,
+    pub(crate) aux2: word::Word<F>,
 }
 
 impl<F: Field> RwRow<F> {
-    pub(crate) fn values(&self) -> [F; 14] {
+    pub(crate) fn values(&self) -> [F; 15] {
         [
             self.rw_counter,
             self.is_write,
@@ -276,7 +276,8 @@ impl<F: Field> RwRow<F> {
             self.value_prev.lo().clone(),
             self.value_prev.hi().clone(),
             self.aux1,
-            self.aux2,
+            self.aux2.lo().clone(),
+            self.aux2.hi().clone(),
         ]
     }
     pub(crate) fn rlc(&self, randomness: F) -> F {


### PR DESCRIPTION
### Description

Few fix to iterating utilities api.

### Issue Link

https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/1388

### Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Contents

- more documentations
- word limbs add `assign_lo_hi`, while lo, hi part support assign with different length of bytes respectively.  Refer the use case in `evm_circuit/execution/address.rs`, `evm_circuit/execution/caller.rs`.
- `rwtable.aux2` change to `Word` type to fit committed value
- `lt_word` gadget usage fix
- fix `MemoryAddressGadget` to fit EVM spec, for length = 0 then `offset` can be arbitrary value still legal (even larger than 5 bytes, since it will be ignore).
- fix `SstoreGasGadget` unnecessary assignment. For the `cells/word` passed from constructor should be assigned by caller, not callee.

### How to test
- based on reviewing/fixing compiling error in evm execution gadgets
