### PR TITLE
Fix infinite loop

### DIFF
--- a/bus-mapping/src/operation.rs
+++ b/bus-mapping/src/operation.rs
@@ -121,7 +121,7 @@ impl_expr!(Target);
 
 impl From<Target> for usize {
     fn from(value: Target) -> usize {
-        value.into()
+        value as usize
     }
 }
 


### PR DESCRIPTION
### Description

Fix an infinite loop from a `From` implementation calling itself.

### Issue Link

Resolve https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/1420
Related https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/1417

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Contents

@ChihChengLiang found that this issue was introduced in https://github.com/privacy-scaling-explorations/zkevm-circuits/pull/1406 and by debugging on the debug build I found the infinite loop (which caused the stack to overflow which terminated the program with a segfault).  The segfault is not observed in the release build, I guess the compiler optimizes the recursive call into an infinite loop, so the stack is never exhausted.