### PR TITLE
Feat/CREATE Part B - Error cases that will be handled within opcode gadgets

### DIFF
--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -1309,8 +1309,11 @@ impl<'a> CircuitInputStateRef<'a> {
                 })));
             }
 
-            //  Nonce Uint overflow
-            if account.nonce >= u64::MAX.into() {
+            // Nonce Uint overflow
+            // If user's nonce is equal u64::MAX, nonce will be overflow in this call
+            // Nonce is u64 so it's impossible to larger than u64::MAX, that's why we're using `==`
+            // here.
+            if account.nonce == u64::MAX {
                 return Ok(Some(ExecError::NonceUintOverflow(match step.op {
                     OpcodeId::CREATE => NonceUintOverflowError::Create,
                     OpcodeId::CREATE2 => NonceUintOverflowError::Create2,

--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -6,7 +6,7 @@ use super::{
     TransactionContext,
 };
 use crate::{
-    error::{get_step_reported_error, ExecError},
+    error::{get_step_reported_error, ExecError, InsufficientBalanceError, NonceUintOverflowError},
     exec_trace::OperationRef,
     operation::{
         AccountField, AccountOp, CallContextField, CallContextOp, MemoryOp, Op, OpEnum, Operation,
@@ -434,6 +434,24 @@ impl<'a> CircuitInputStateRef<'a> {
         Ok(())
     }
 
+    /// Add address to access list for the current transaction.
+    pub fn tx_access_list_write(
+        &mut self,
+        step: &mut ExecStep,
+        address: Address,
+    ) -> Result<(), Error> {
+        let is_warm = self.sdb.check_account_in_access_list(&address);
+        self.push_op_reversible(
+            step,
+            TxAccessListAccountOp {
+                tx_id: self.tx_ctx.id(),
+                address,
+                is_warm: true,
+                is_warm_prev: is_warm,
+            },
+        )
+    }
+
     /// Push a write type [`TxAccessListAccountOp`] into the
     /// [`OperationContainer`](crate::operation::OperationContainer) with the
     /// next [`RWCounter`](crate::operation::RWCounter), and then
@@ -686,6 +704,18 @@ impl<'a> CircuitInputStateRef<'a> {
             salt.to_be_bytes().to_vec(),
             init_code,
         ))
+    }
+
+    pub(crate) fn reversion_info_read(&mut self, step: &mut ExecStep, call: &Call) {
+        for (field, value) in [
+            (
+                CallContextField::RwCounterEndOfReversion,
+                call.rw_counter_end_of_reversion.to_word(),
+            ),
+            (CallContextField::IsPersistent, call.is_persistent.to_word()),
+        ] {
+            self.call_context_read(step, call.call_id, field, value);
+        }
     }
 
     /// Check if address is a precompiled or not.
@@ -1299,7 +1329,23 @@ impl<'a> CircuitInputStateRef<'a> {
                 return Err(Error::AccountNotFound(sender));
             }
             if account.balance < value {
-                return Ok(Some(ExecError::InsufficientBalance));
+                return Ok(Some(ExecError::InsufficientBalance(match step.op {
+                    OpcodeId::CALL | OpcodeId::CALLCODE => InsufficientBalanceError::Call,
+                    OpcodeId::CREATE => InsufficientBalanceError::Create,
+                    OpcodeId::CREATE2 => InsufficientBalanceError::Create2,
+                    op => {
+                        unreachable!("insufficient balance error unexpected for opcode: {:?}", op)
+                    }
+                })));
+            }
+
+            //  Nonce Uint overflow
+            if account.nonce >= u64::MAX.into() {
+                return Ok(Some(ExecError::NonceUintOverflow(match step.op {
+                    OpcodeId::CREATE => NonceUintOverflowError::Create,
+                    OpcodeId::CREATE2 => NonceUintOverflowError::Create2,
+                    op => unreachable!("Nonce Uint overflow error unexpected for opcode: {:?}", op),
+                })));
             }
 
             // Address collision

--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -434,24 +434,6 @@ impl<'a> CircuitInputStateRef<'a> {
         Ok(())
     }
 
-    /// Add address to access list for the current transaction.
-    pub fn tx_access_list_write(
-        &mut self,
-        step: &mut ExecStep,
-        address: Address,
-    ) -> Result<(), Error> {
-        let is_warm = self.sdb.check_account_in_access_list(&address);
-        self.push_op_reversible(
-            step,
-            TxAccessListAccountOp {
-                tx_id: self.tx_ctx.id(),
-                address,
-                is_warm: true,
-                is_warm_prev: is_warm,
-            },
-        )
-    }
-
     /// Push a write type [`TxAccessListAccountOp`] into the
     /// [`OperationContainer`](crate::operation::OperationContainer) with the
     /// next [`RWCounter`](crate::operation::RWCounter), and then
@@ -704,18 +686,6 @@ impl<'a> CircuitInputStateRef<'a> {
             salt.to_be_bytes().to_vec(),
             init_code,
         ))
-    }
-
-    pub(crate) fn reversion_info_read(&mut self, step: &mut ExecStep, call: &Call) {
-        for (field, value) in [
-            (
-                CallContextField::RwCounterEndOfReversion,
-                call.rw_counter_end_of_reversion.to_word(),
-            ),
-            (CallContextField::IsPersistent, call.is_persistent.to_word()),
-        ] {
-            self.call_context_read(step, call.call_id, field, value);
-        }
     }
 
     /// Check if address is a precompiled or not.

--- a/bus-mapping/src/circuit_input_builder/tracer_tests.rs
+++ b/bus-mapping/src/circuit_input_builder/tracer_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{
     circuit_input_builder::access::gen_state_access_trace,
-    error::{ExecError, InsufficientBalanceError, OogError},
+    error::{DepthError, ExecError, InsufficientBalanceError, OogError},
     geth_errors::{
         GETH_ERR_GAS_UINT_OVERFLOW, GETH_ERR_OUT_OF_GAS, GETH_ERR_STACK_OVERFLOW,
         GETH_ERR_STACK_UNDERFLOW,
@@ -208,7 +208,7 @@ fn tracer_err_depth() {
     let mut builder = CircuitInputBuilderTx::new(&block, step);
     assert_eq!(
         builder.state_ref().get_step_err(step, next_step).unwrap(),
-        Some(ExecError::Depth)
+        Some(ExecError::Depth(DepthError::Call))
     );
 }
 

--- a/bus-mapping/src/circuit_input_builder/tracer_tests.rs
+++ b/bus-mapping/src/circuit_input_builder/tracer_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{
     circuit_input_builder::access::gen_state_access_trace,
-    error::{ExecError, OogError},
+    error::{ExecError, InsufficientBalanceError, OogError},
     geth_errors::{
         GETH_ERR_GAS_UINT_OVERFLOW, GETH_ERR_OUT_OF_GAS, GETH_ERR_STACK_OVERFLOW,
         GETH_ERR_STACK_UNDERFLOW,
@@ -274,7 +274,9 @@ fn tracer_err_insufficient_balance() {
     let mut builder = CircuitInputBuilderTx::new(&block, step);
     assert_eq!(
         builder.state_ref().get_step_err(step, next_step).unwrap(),
-        Some(ExecError::InsufficientBalance)
+        Some(ExecError::InsufficientBalance(
+            InsufficientBalanceError::Call
+        ))
     );
 }
 

--- a/bus-mapping/src/error.rs
+++ b/bus-mapping/src/error.rs
@@ -98,6 +98,26 @@ pub enum OogError {
     SelfDestruct,
 }
 
+/// Insufficient balance errors by opcode/state.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum InsufficientBalanceError {
+    /// Insufficient balance during CALL/CALLCODE opcode.
+    Call,
+    /// Insufficient balance during CREATE opcode.
+    Create,
+    /// Insufficient balance during CREATE2 opcode.
+    Create2,
+}
+
+/// Nonce uint overflow errors by opcode/state.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum NonceUintOverflowError {
+    /// Nonce uint overflow during CREATE opcode.
+    Create,
+    /// Nonce uint overflow during CREATE2 opcode.
+    Create2,
+}
+
 /// EVM Execution Error
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ExecError {
@@ -114,9 +134,9 @@ pub enum ExecError {
     WriteProtection,
     /// For CALL, CALLCODE, DELEGATECALL, STATICCALL
     Depth,
-    /// For CALL, CALLCODE
-    InsufficientBalance,
-    /// For CREATE, CREATE2
+    /// For CALL, CALLCODE, CREATE, CREATE2
+    InsufficientBalance(InsufficientBalanceError),
+    /// For CREATE2
     ContractAddressCollision,
     /// contract must not begin with 0xef due to EIP #3541 EVM Object Format
     /// (EOF)
@@ -129,6 +149,8 @@ pub enum ExecError {
     CodeStoreOutOfGas,
     /// For RETURN in a CREATE, CREATE2
     MaxCodeSizeExceeded,
+    /// For CREATE, CREATE2
+    NonceUintOverflow(NonceUintOverflowError),
 }
 
 // TODO: Move to impl block.

--- a/bus-mapping/src/error.rs
+++ b/bus-mapping/src/error.rs
@@ -118,6 +118,17 @@ pub enum NonceUintOverflowError {
     Create2,
 }
 
+/// Call depth errors by opcode/state.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DepthError {
+    /// Call depth errors in CALL/CALLCODE opcode.
+    Call,
+    /// Call depth errors in CREATE opcode.
+    Create,
+    /// Call depth errors in CREATE2 opcode.
+    Create2,
+}
+
 /// EVM Execution Error
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ExecError {
@@ -132,8 +143,8 @@ pub enum ExecError {
     /// For SSTORE, LOG0, LOG1, LOG2, LOG3, LOG4, CREATE, CALL, CREATE2,
     /// SELFDESTRUCT
     WriteProtection,
-    /// For CALL, CALLCODE, DELEGATECALL, STATICCALL
-    Depth,
+    /// For CALL, CALLCODE, DELEGATECALL, STATICCALL, CREATE, CREATE2
+    Depth(DepthError),
     /// For CALL, CALLCODE, CREATE, CREATE2
     InsufficientBalance(InsufficientBalanceError),
     /// For CREATE2

--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -286,6 +286,7 @@ fn fn_gen_error_state_associated_ops(
         ExecError::OutOfGas(OogError::SloadSstore) => Some(OOGSloadSstore::gen_associated_ops),
         ExecError::StackOverflow => Some(ErrorSimple::gen_associated_ops),
         ExecError::StackUnderflow => Some(ErrorSimple::gen_associated_ops),
+        // call & callcode can encounter InsufficientBalance error, Use pop-7 generic CallOpcode
         ExecError::InsufficientBalance(InsufficientBalanceError::Call) => {
             Some(CallOpcode::<7>::gen_associated_ops)
         }

--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -1,6 +1,6 @@
 //! Definition of each opcode of the EVM.
 use crate::{
-    circuit_input_builder::{CircuitInputStateRef, ExecStep},
+    circuit_input_builder::{CircuitInputStateRef, ExecState, ExecStep},
     error::{ExecError, InsufficientBalanceError, NonceUintOverflowError, OogError},
     evm::OpcodeId,
     operation::TxAccessListAccountOp,

--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -271,10 +271,7 @@ fn fn_gen_associated_ops(opcode_id: &OpcodeId) -> FnGenAssociatedOps {
     }
 }
 
-fn fn_gen_error_state_associated_ops(
-    geth_step: &GethExecStep,
-    error: &ExecError,
-) -> Option<FnGenAssociatedOps> {
+fn fn_gen_error_state_associated_ops(error: &ExecError) -> Option<FnGenAssociatedOps> {
     match error {
         ExecError::InvalidJump => Some(InvalidJump::gen_associated_ops),
         ExecError::InvalidOpcode => Some(ErrorSimple::gen_associated_ops),
@@ -357,7 +354,7 @@ pub fn gen_associated_ops(
         // TODO: after more error state handled, refactor all error handling in
         // fn_gen_error_state_associated_ops method
         // For exceptions that have been implemented
-        if let Some(fn_gen_error_ops) = fn_gen_error_state_associated_ops(geth_step, &exec_error) {
+        if let Some(fn_gen_error_ops) = fn_gen_error_state_associated_ops(&exec_error) {
             return fn_gen_error_ops(state, geth_steps);
         } else {
             // For exceptions that fail to enter next call context, we need

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -1289,9 +1289,6 @@ impl<F: Field> ExecutionConfig<F> {
             ExecutionState::ErrorWriteProtection => {
                 assign_exec_step!(self.error_write_protection)
             }
-            ExecutionState::ErrorDepth => {
-                assign_exec_step!(self.error_depth)
-            }
             ExecutionState::ErrorInvalidCreationCode => {
                 assign_exec_step!(self.error_invalid_creation_code)
             }

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -1280,9 +1280,6 @@ impl<F: Field> ExecutionConfig<F> {
                 assign_exec_step!(self.error_stack)
             }
 
-            ExecutionState::ErrorInsufficientBalance => {
-                assign_exec_step!(self.call_op_gadget)
-            }
             ExecutionState::ErrorInvalidJump => {
                 assign_exec_step!(self.error_invalid_jump)
             }
@@ -1294,9 +1291,6 @@ impl<F: Field> ExecutionConfig<F> {
             }
             ExecutionState::ErrorDepth => {
                 assign_exec_step!(self.error_depth)
-            }
-            ExecutionState::ErrorContractAddressCollision => {
-                assign_exec_step!(self.error_contract_address_collision)
             }
             ExecutionState::ErrorInvalidCreationCode => {
                 assign_exec_step!(self.error_invalid_creation_code)

--- a/zkevm-circuits/src/evm_circuit/step.rs
+++ b/zkevm-circuits/src/evm_circuit/step.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use bus_mapping::{
     circuit_input_builder::ExecState,
-    error::{ExecError, InsufficientBalanceError, NonceUintOverflowError, OogError},
+    error::{DepthError, ExecError, InsufficientBalanceError, NonceUintOverflowError, OogError},
     evm::OpcodeId,
 };
 use eth_types::{evm_unimplemented, Field, ToWord};
@@ -131,12 +131,18 @@ impl From<&ExecError> for ExecutionState {
             ExecError::InvalidOpcode => ExecutionState::ErrorInvalidOpcode,
             ExecError::StackOverflow | ExecError::StackUnderflow => ExecutionState::ErrorStack,
             ExecError::WriteProtection => ExecutionState::ErrorWriteProtection,
-            ExecError::Depth => ExecutionState::ErrorDepth,
-            ExecError::InsufficientBalance(insuff_balance_err) => match insuff_balance_err {
-                InsufficientBalanceError::Call => ExecutionState::CALL_OP,
-                InsufficientBalanceError::Create => ExecutionState::CREATE,
-                InsufficientBalanceError::Create2 => ExecutionState::CREATE2,
+            ExecError::Depth(depth_error) => match depth_error {
+                DepthError::Call => ExecutionState::CALL_OP,
+                DepthError::Create => ExecutionState::CREATE,
+                DepthError::Create2 => ExecutionState::CREATE2,
             },
+            ExecError::InsufficientBalance(insufficient_balance_err) => {
+                match insufficient_balance_err {
+                    InsufficientBalanceError::Call => ExecutionState::CALL_OP,
+                    InsufficientBalanceError::Create => ExecutionState::CREATE,
+                    InsufficientBalanceError::Create2 => ExecutionState::CREATE2,
+                }
+            }
             ExecError::NonceUintOverflow(nonce_overflow_err) => match nonce_overflow_err {
                 NonceUintOverflowError::Create => ExecutionState::CREATE,
                 NonceUintOverflowError::Create2 => ExecutionState::CREATE2,

--- a/zkevm-circuits/src/evm_circuit/step.rs
+++ b/zkevm-circuits/src/evm_circuit/step.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use bus_mapping::{
     circuit_input_builder::ExecState,
-    error::{ExecError, OogError},
+    error::{ExecError, InsufficientBalanceError, NonceUintOverflowError, OogError},
     evm::OpcodeId,
 };
 use eth_types::{evm_unimplemented, Field, ToWord};

--- a/zkevm-circuits/src/evm_circuit/step.rs
+++ b/zkevm-circuits/src/evm_circuit/step.rs
@@ -132,8 +132,16 @@ impl From<&ExecError> for ExecutionState {
             ExecError::StackOverflow | ExecError::StackUnderflow => ExecutionState::ErrorStack,
             ExecError::WriteProtection => ExecutionState::ErrorWriteProtection,
             ExecError::Depth => ExecutionState::ErrorDepth,
-            ExecError::InsufficientBalance => ExecutionState::ErrorInsufficientBalance,
-            ExecError::ContractAddressCollision => ExecutionState::ErrorContractAddressCollision,
+            ExecError::InsufficientBalance(insuff_balance_err) => match insuff_balance_err {
+                InsufficientBalanceError::Call => ExecutionState::CALL_OP,
+                InsufficientBalanceError::Create => ExecutionState::CREATE,
+                InsufficientBalanceError::Create2 => ExecutionState::CREATE2,
+            },
+            ExecError::NonceUintOverflow(nonce_overflow_err) => match nonce_overflow_err {
+                NonceUintOverflowError::Create => ExecutionState::CREATE,
+                NonceUintOverflowError::Create2 => ExecutionState::CREATE2,
+            },
+            ExecError::ContractAddressCollision => ExecutionState::CREATE2,
             ExecError::InvalidCreationCode => ExecutionState::ErrorInvalidCreationCode,
             ExecError::InvalidJump => ExecutionState::ErrorInvalidJump,
             ExecError::ReturnDataOutOfBounds => ExecutionState::ErrorReturnDataOutOfBound,


### PR DESCRIPTION
### Description

**NOTE: This is an updated version of https://github.com/privacy-scaling-explorations/zkevm-circuits/pull/1357**

This PR is actually based on top of #1419

### Issue Link

#1130 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Contents
Error types for insufficient balance and nonce overflow. These are supporting changes required for the CREATE/CREATE2 opcodes' gadget.

### Rationale
The above errors will be handled within the CREATE/CREATE2 opcodes' gadget. In case of insufficient balance, it is also handled in the CallOp gadget for call related opcodes.