### PR TITLE
Fix EXTCODECOPY with empty account

### DIFF
--- a/bus-mapping/src/evm/opcodes/extcodecopy.rs
+++ b/bus-mapping/src/evm/opcodes/extcodecopy.rs
@@ -11,9 +11,6 @@ use eth_types::{Bytecode, GethExecStep, ToAddress, ToWord, H256, U256};
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct Extcodecopy;
 
-// TODO: Update to treat code_hash == 0 as account not_exists once the circuit
-// is implemented https://github.com/privacy-scaling-explorations/zkevm-circuits/pull/720
-
 impl Opcode for Extcodecopy {
     fn gen_associated_ops(
         state: &mut CircuitInputStateRef,

--- a/bus-mapping/src/state_db.rs
+++ b/bus-mapping/src/state_db.rs
@@ -8,6 +8,7 @@ use std::collections::{HashMap, HashSet};
 
 lazy_static! {
     static ref ACCOUNT_ZERO: Account = Account::zero();
+    /// Hash value for empty code hash.
     static ref EMPTY_CODE_HASH: Hash = CodeDB::hash(&[]);
     /// bytes of empty code hash, in little endian order.
     pub static ref EMPTY_CODE_HASH_LE: [u8; 32] = {

--- a/zkevm-circuits/src/evm_circuit/execution/extcodecopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodecopy.rs
@@ -9,6 +9,7 @@ use crate::{
                 Transition,
             },
             from_bytes,
+            math_gadget::IsZeroGadget,
             memory_gadget::{MemoryAddressGadget, MemoryCopierGasGadget, MemoryExpansionGadget},
             not, select, CachedRegion, Cell, Word,
         },
@@ -33,6 +34,7 @@ pub(crate) struct ExtcodecopyGadget<F> {
     reversion_info: ReversionInfo<F>,
     is_warm: Cell<F>,
     code_hash: Cell<F>,
+    not_exists: IsZeroGadget<F>,
     code_size: Cell<F>,
     copy_rwc_inc: Cell<F>,
     memory_expansion: MemoryExpansionGadget<F, 1, N_BYTES_MEMORY_WORD_SIZE>,
@@ -79,11 +81,14 @@ impl<F: Field> ExecutionGadget<F> for ExtcodecopyGadget<F> {
             AccountFieldTag::CodeHash,
             code_hash.expr(),
         );
-        // TODO: If external_address doesn't exist, we will get code_hash = 0.  With
-        // this value, the bytecode_length lookup will not work, and the copy
-        // from code_hash = 0 will not work. We should use EMPTY_HASH when
-        // code_hash = 0.
-        cb.bytecode_length(code_hash.expr(), code_size.expr());
+        let not_exists = IsZeroGadget::construct(cb, code_hash.expr());
+        let exists = not::expr(not_exists.expr());
+        cb.condition(exists.expr(), |cb| {
+            cb.bytecode_length(code_hash.expr(), code_size.expr());
+        });
+        cb.condition(not_exists.expr(), |cb| {
+            cb.require_zero("code_size is zero when non_exists", code_size.expr());
+        });
 
         let memory_address = MemoryAddressGadget::construct(cb, memory_offset, memory_length);
         let memory_expansion = MemoryExpansionGadget::construct(cb, [memory_address.address()]);
@@ -148,6 +153,7 @@ impl<F: Field> ExecutionGadget<F> for ExtcodecopyGadget<F> {
             is_warm,
             reversion_info,
             code_hash,
+            not_exists,
             code_size,
             copy_rwc_inc,
             memory_expansion,
@@ -190,6 +196,8 @@ impl<F: Field> ExecutionGadget<F> for ExtcodecopyGadget<F> {
         let code_hash = block.get_rws(step, 8).account_value_pair().0;
         self.code_hash
             .assign(region, offset, region.word_rlc(code_hash))?;
+        self.not_exists
+            .assign_value(region, offset, region.word_rlc(code_hash))?;
 
         let code_size = if code_hash.is_zero() {
             0

--- a/zkevm-circuits/src/witness/block.rs
+++ b/zkevm-circuits/src/witness/block.rs
@@ -54,6 +54,20 @@ pub struct Block<F> {
 }
 
 impl<F: Field> Block<F> {
+    /// For each tx, for each step, print the rwc at the beginning of the step,
+    /// and all the rw operations of the step.
+    pub(crate) fn debug_print_txs_steps_rw_ops(&self) {
+        for (tx_idx, tx) in self.txs.iter().enumerate() {
+            println!("tx {}", tx_idx);
+            for step in &tx.steps {
+                println!(" step {:?} rwc: {}", step.exec_state, step.rwc.0);
+                for rw_idx in 0..step.bus_mapping_instance.len() {
+                    println!("  - {:?}", self.get_rws(step, rw_idx));
+                }
+            }
+        }
+    }
+
     /// Get a read-write record
     pub(crate) fn get_rws(&self, step: &ExecStep, index: usize) -> Rw {
         self.rws[step.rw_index(index)]


### PR DESCRIPTION
### Description

We treat empty accounts by storing their code_hash in the RwTable as 0.  EXTCODECOPY was obtaining the bytecode length by querying the bytecode table with code_hash=0 on existing accounts, but that entry should be invalid (there's no bytecode with code_hash=0).  Skip the bytecode table length lookup when code_hash=0.

I've also reintroduced the `Block::debug_print_txs_steps_rw_ops` function, updated to use the new `Block::get_rws` API.  This function is not used in the code, but it's very convenient to call it when debugging.

### Issue Link

Resolve https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/1190

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)