### PR TITLE
[word lo/hi] keccak circuit to word

### DIFF
--- a/zkevm-circuits/src/util/word.rs
+++ b/zkevm-circuits/src/util/word.rs
@@ -243,6 +243,11 @@ impl<T: Clone> Word<T> {
     pub fn map<T2: Clone>(&self, mut func: impl FnMut(T) -> T2) -> Word<T2> {
         Word(WordLimbs::<T2, 2>::new([func(self.lo()), func(self.hi())]))
     }
+    /// Convert the word to Known Value
+    pub fn into_value(self) -> Word<Value<T>> {
+        let [lo, hi] = self.0.limbs;
+        Word::new([Value::known(lo), Value::known(hi)])
+    }
 }
 
 impl<T> std::ops::Deref for Word<T> {


### PR DESCRIPTION
### Description

Support word lo-hi in keccak circuit

### Issue Link

#1385 

### Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Contents

- Change the keccak circuit hash output format from RLC to word lo-hi.
- Add convenient methods `map` for Word. This can easily map two limbs to other types.
- Add a constructor for the zero known value word.


### Rationale

### Testss

The following tests can pass if we remove math_gadget tests below

```
cargo test -p zkevm-circuits packed_multi_keccak_simple --features test
```

```
zkevm-circuits/src/evm_circuit/util/math_gadget/add_words.rs
zkevm-circuits/src/evm_circuit/util/math_gadget/cmp_words.rs
zkevm-circuits/src/evm_circuit/util/math_gadget/lt_word.rs
zkevm-circuits/src/evm_circuit/util/math_gadget/min_max_word.rs
zkevm-circuits/src/evm_circuit/util/math_gadget/modulo.rs
zkevm-circuits/src/evm_circuit/util/math_gadget/mul_add_words.rs
```

