### PR TITLE
fix docker compose

### DIFF
--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -76,9 +76,9 @@ done
 
 docker_compose_cmd() {
     if [ -n "$ARG_SUDO" ]; then
-        sudo docker compose $@
+        sudo docker-compose $@
     else
-        docker compose $@
+        docker-compose $@
     fi
 }
 


### PR DESCRIPTION
### Description

Update integration-tests/run.sh docker_compose_cmd() function to use `docker-compose` instead of `docker compose`.

### Issue Link

[link](https://github.com/docker/compose/issues/8630)

When using `./run.sh --sudo`, I encountered the following error message.
```
docker: 'compose' is not a docker command.
See 'docker --help'
```

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update