### PR TITLE
Add PiCircuit to integration tests

### DIFF
--- a/integration-tests/src/integration_test_circuits.rs
+++ b/integration-tests/src/integration_test_circuits.rs
@@ -33,6 +33,7 @@ use zkevm_circuits::{
     evm_circuit::TestEvmCircuit,
     exp_circuit::TestExpCircuit,
     keccak_circuit::TestKeccakCircuit,
+    pi_circuit::TestPiCircuit,
     state_circuit::TestStateCircuit,
     super_circuit::SuperCircuit,
     tx_circuit::TestTxCircuit,
@@ -79,6 +80,7 @@ const COPY_CIRCUIT_DEGREE: u32 = 16;
 const KECCAK_CIRCUIT_DEGREE: u32 = 16;
 const SUPER_CIRCUIT_DEGREE: u32 = 20;
 const EXP_CIRCUIT_DEGREE: u32 = 16;
+const PI_CIRCUIT_DEGREE: u32 = 17;
 
 lazy_static! {
     /// Data generation.
@@ -125,6 +127,10 @@ lazy_static! {
      /// Integration test for Exp circuit
      pub static ref EXP_CIRCUIT_TEST: TokioMutex<IntegrationTest<TestExpCircuit::<Fr>>> =
      TokioMutex::new(IntegrationTest::new("Exp", EXP_CIRCUIT_DEGREE));
+
+     /// Integration test for Pi circuit
+     pub static ref PI_CIRCUIT_TEST: TokioMutex<IntegrationTest<TestPiCircuit::<Fr>>> =
+     TokioMutex::new(IntegrationTest::new("Pi", PI_CIRCUIT_DEGREE));
 }
 
 /// Generic implementation for integration tests

--- a/integration-tests/tests/circuits.rs
+++ b/integration-tests/tests/circuits.rs
@@ -49,6 +49,11 @@ macro_rules! declare_tests {
             async fn [<serial_test_exp_ $name>]() {
                 run_test! (EXP_CIRCUIT_TEST, $block_tag, $real_prover);
             }
+
+            #[tokio::test]
+            async fn [<serial_test_pi_ $name>]() {
+                run_test! (PI_CIRCUIT_TEST, $block_tag, $real_prover);
+            }
         }
     };
 }
@@ -64,7 +69,8 @@ macro_rules! unroll_tests {
             COPY_CIRCUIT_TEST,
             KECCAK_CIRCUIT_TEST,
             SUPER_CIRCUIT_TEST,
-            EXP_CIRCUIT_TEST
+            EXP_CIRCUIT_TEST,
+            PI_CIRCUIT_TEST,
         };
         use integration_tests::log_init;
         mod real_prover {

--- a/zkevm-circuits/src/pi_circuit.rs
+++ b/zkevm-circuits/src/pi_circuit.rs
@@ -5,6 +5,8 @@ mod param;
 mod dev;
 #[cfg(any(feature = "test", test))]
 mod test;
+#[cfg(any(feature = "test", test, feature = "test-circuits"))]
+pub use dev::PiCircuit as TestPiCircuit;
 
 use eth_types::{
     geth_types::{BlockConstants, Transaction},

--- a/zkevm-circuits/src/pi_circuit/dev.rs
+++ b/zkevm-circuits/src/pi_circuit/dev.rs
@@ -1,3 +1,4 @@
+pub use super::PiCircuit;
 use super::*;
 
 /// Public Input Circuit configuration parameters


### PR DESCRIPTION
### Description

This is a very small PR.  While investigating https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/1439 I noticed we don't have an integration test for the Public Inputs Circuit, so I just added it.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update