### PR TITLE
fix: modify assign function of LtChip to take `Value<F>` input instead of `F`

### DIFF
--- a/zkevm-circuits/src/copy_circuit.rs
+++ b/zkevm-circuits/src/copy_circuit.rs
@@ -503,8 +503,10 @@ impl<F: Field> CopyCircuitConfig<F> {
                 lt_chip.assign(
                     region,
                     *offset,
-                    F::from(copy_event.src_addr + u64::try_from(step_idx).unwrap() / 2u64),
-                    F::from(copy_event.src_addr_end),
+                    Value::known(F::from(
+                        copy_event.src_addr + u64::try_from(step_idx).unwrap() / 2u64,
+                    )),
+                    Value::known(F::from(copy_event.src_addr_end)),
                 )?;
             }
 
@@ -683,7 +685,7 @@ impl<F: Field> CopyCircuitConfig<F> {
         // tag
         tag_chip.assign(region, *offset, &CopyDataType::Padding)?;
         // Assign LT gadget
-        lt_chip.assign(region, *offset, F::ZERO, F::ONE)?;
+        lt_chip.assign(region, *offset, Value::known(F::ZERO), Value::known(F::ONE))?;
 
         *offset += 1;
 


### PR DESCRIPTION
### Description

The PR modifies the assign function of the LtChip to take `Value<F>` input instead of `F`. According to this discussion [Halo2 - Discord](https://discord.com/channels/995022112811135148/1113747239534346250/1113854493646397621) with @therealyingtong and @ed255, it emerged how the current design of the chip makes its usage prone to bugs. 

For example, this is how it is currently used in summa-solvency => https://github.com/summa-dev/summa-solvency/blob/a7d0c1f51c7e146bac2686c432c945ff6f3f063f/src/chips/merkle_sum_tree.rs#L338-L354

In order to extract `F` from an assigned cell, I need to create an if conditional that performs the `assign` function only if a witness value is Some. This is a problem as the assignment function won't be called during keygen.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

`cargo test less_than`