### PR TITLE
fix rw operation mismatch and reuse exec_step

### DIFF
--- a/bus-mapping/src/evm/opcodes/calldatacopy.rs
+++ b/bus-mapping/src/evm/opcodes/calldatacopy.rs
@@ -28,7 +28,7 @@ impl Opcode for Calldatacopy {
 
         memory.copy_from(memory_offset, data_offset, length, &call_ctx.call_data);
 
-        let copy_event = gen_copy_event(state, geth_step)?;
+        let copy_event = gen_copy_event(state, geth_step, &mut exec_steps[0])?;
         state.push_copy(&mut exec_steps[0], copy_event);
         Ok(exec_steps)
     }
@@ -95,6 +95,7 @@ fn gen_calldatacopy_step(
 fn gen_copy_event(
     state: &mut CircuitInputStateRef,
     geth_step: &GethExecStep,
+    exec_step: &mut ExecStep,
 ) -> Result<CopyEvent, Error> {
     let rw_counter_start = state.block_ctx.rwc;
 
@@ -117,14 +118,8 @@ fn gen_copy_event(
         .unwrap_or(src_addr_end)
         .min(src_addr_end);
 
-    let mut exec_step = state.new_step(geth_step)?;
-    let copy_steps = state.gen_copy_steps_for_call_data(
-        &mut exec_step,
-        src_addr,
-        dst_addr,
-        src_addr_end,
-        length,
-    )?;
+    let copy_steps =
+        state.gen_copy_steps_for_call_data(exec_step, src_addr, dst_addr, src_addr_end, length)?;
 
     let (src_type, src_id) = if state.call()?.is_root {
         (CopyDataType::TxCalldata, state.tx_ctx.id())
@@ -229,8 +224,8 @@ mod calldatacopy_tests {
         let caller_id = builder.block.txs()[0].calls()[step.call_index].caller_id;
         let expected_call_id = builder.block.txs()[0].calls()[step.call_index].call_id;
 
-        // 3 stack reads + 3 call context reads.
-        assert_eq!(step.bus_mapping_instance.len(), 6);
+        // 3 stack reads + 3 call context reads + `copy_size` x 2 memory r/w
+        assert_eq!(step.bus_mapping_instance.len(), 6 + copy_size * 2);
 
         // 3 stack reads.
         assert_eq!(
@@ -433,7 +428,8 @@ mod calldatacopy_tests {
             .unwrap();
 
         let expected_call_id = builder.block.txs()[0].calls()[step.call_index].call_id;
-        assert_eq!(step.bus_mapping_instance.len(), 5);
+        // 3 stack reads + 2 call context reads + `size` memory write
+        assert_eq!(step.bus_mapping_instance.len(), 5 + size);
 
         assert_eq!(
             [0, 1, 2]

--- a/bus-mapping/src/evm/opcodes/codecopy.rs
+++ b/bus-mapping/src/evm/opcodes/codecopy.rs
@@ -32,7 +32,7 @@ impl Opcode for Codecopy {
 
         memory.copy_from(dst_offset, code_offset, length, &code);
 
-        let copy_event = gen_copy_event(state, geth_step)?;
+        let copy_event = gen_copy_event(state, geth_step, &mut exec_steps[0])?;
         state.push_copy(&mut exec_steps[0], copy_event);
         Ok(exec_steps)
     }
@@ -67,6 +67,7 @@ fn gen_codecopy_step(
 fn gen_copy_event(
     state: &mut CircuitInputStateRef,
     geth_step: &GethExecStep,
+    exec_step: &mut ExecStep,
 ) -> Result<CopyEvent, Error> {
     let rw_counter_start = state.block_ctx.rwc;
 
@@ -88,9 +89,8 @@ fn gen_copy_event(
         .unwrap_or(src_addr_end)
         .min(src_addr_end);
 
-    let mut exec_step = state.new_step(geth_step)?;
     let copy_steps = state.gen_copy_steps_for_bytecode(
-        &mut exec_step,
+        exec_step,
         &bytecode,
         src_addr,
         dst_addr,

--- a/bus-mapping/src/evm/opcodes/extcodecopy.rs
+++ b/bus-mapping/src/evm/opcodes/extcodecopy.rs
@@ -34,7 +34,7 @@ impl Opcode for Extcodecopy {
 
         memory.copy_from(dst_offset, code_offset, length, &code);
 
-        let copy_event = gen_copy_event(state, geth_step)?;
+        let copy_event = gen_copy_event(state, geth_step, &mut exec_steps[0])?;
         state.push_copy(&mut exec_steps[0], copy_event);
         Ok(exec_steps)
     }
@@ -111,6 +111,7 @@ fn gen_extcodecopy_step(
 fn gen_copy_event(
     state: &mut CircuitInputStateRef,
     geth_step: &GethExecStep,
+    exec_step: &mut ExecStep,
 ) -> Result<CopyEvent, Error> {
     let rw_counter_start = state.block_ctx.rwc;
 
@@ -144,9 +145,8 @@ fn gen_copy_event(
         .unwrap_or(src_addr_end)
         .min(src_addr_end);
 
-    let mut exec_step = state.new_step(geth_step)?;
     let copy_steps = state.gen_copy_steps_for_bytecode(
-        &mut exec_step,
+        exec_step,
         &bytecode,
         src_addr,
         dst_addr,

--- a/bus-mapping/src/evm/opcodes/returndatacopy.rs
+++ b/bus-mapping/src/evm/opcodes/returndatacopy.rs
@@ -32,7 +32,7 @@ impl Opcode for Returndatacopy {
         let memory = &mut call_ctx.memory;
         memory.copy_from(dst_offset, src_offset, length, &return_data);
 
-        let copy_event = gen_copy_event(state, geth_step)?;
+        let copy_event = gen_copy_event(state, geth_step, &mut exec_steps[0])?;
         state.push_copy(&mut exec_steps[0], copy_event);
         Ok(exec_steps)
     }
@@ -122,6 +122,7 @@ fn gen_copy_steps(
 fn gen_copy_event(
     state: &mut CircuitInputStateRef,
     geth_step: &GethExecStep,
+    exec_step: &mut ExecStep,
 ) -> Result<CopyEvent, Error> {
     // Get low Uint64 of destination offset to generate copy steps. Since it
     // could be Uint64 overflow if length is zero.
@@ -137,15 +138,7 @@ fn gen_copy_event(
     );
 
     let rw_counter_start = state.block_ctx.rwc;
-    let mut exec_step = state.new_step(geth_step)?;
-    let copy_steps = gen_copy_steps(
-        state,
-        &mut exec_step,
-        src_addr,
-        dst_addr,
-        src_addr_end,
-        length,
-    )?;
+    let copy_steps = gen_copy_steps(state, exec_step, src_addr, dst_addr, src_addr_end, length)?;
 
     let (src_type, dst_type, src_id, dst_id) = (
         CopyDataType::Memory,

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -1382,7 +1382,7 @@ impl<F: Field> ExecutionConfig<F> {
         // TODO: We should find a better way to avoid this kind of special case.
         // #1489 is the issue for this refactor.
         if copy_lookup_count > 1 {
-            log::warn!("The number of copy events is more than 1, it's not supported by current design. Stop checking this step: {:?}", 
+            log::warn!("The number of copy events is more than 1, it's not supported by current design. Stop checking this step: {:?}",
                 step
             );
             return;
@@ -1423,7 +1423,7 @@ impl<F: Field> ExecutionConfig<F> {
             != assigned_rw_values.len() + step.copy_rw_counter_delta as usize - copy_lookup_count
         {
             log::error!(
-                "step.rw_indices.len: {} != assigned_rw_values.len: {} + step.copy_rw_counter_delta: {} - copy_lookup_count: {} in step: {:?}", 
+                "step.rw_indices.len: {} != assigned_rw_values.len: {} + step.copy_rw_counter_delta: {} - copy_lookup_count: {} in step: {:?}",
                 step.rw_indices_len(),
                 assigned_rw_values.len(),
                 step.copy_rw_counter_delta,
@@ -1457,15 +1457,6 @@ impl<F: Field> ExecutionConfig<F> {
             } else {
                 idx - rev_count + offset - copy_lookup_processed as usize
             };
-
-            // TODO: can remove after #1483 fixed
-            // step.rw_indices_len() doesn't inclued copy_rw_counter_delta in some cases
-            // which will cuase out of boundary while calling rw_index().
-            // Beside, if this condition holds, `copy lookup` is the last element of
-            // assigned_rw_value. Therefore, can ignore it for now.
-            if idx > step.rw_indices_len() - 1 {
-                continue;
-            }
 
             // If assigned_rw_value is a `copy lookup` event, the following
             // `step.copy_rw_counter_delta` rw lookups must be memory operations.


### PR DESCRIPTION
### Description

Fix rw operation mismatch due to not reuse exec_step

### Issue Link

https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/1483

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Verify
Verify via below command

```
RUST_LOG=DEBUG cargo test --package zkevm-circuits --lib -- evm_circuit::execution::returndatacopy::test evm_circuit::execution::codedatacopy::test  evm_circuit::execution::extcodecopy::test evm_circuit::execution::codecopy::test
```
and no error msg, with all test pass though