### PR TITLE
[word lo/hi] cleanup evm_circuit workaround 

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution/add_sub.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/add_sub.rs
@@ -54,9 +54,9 @@ impl<F: Field> ExecutionGadget<F> for AddSubGadget<F> {
         // ADD: Pop a and b from the stack, push c on the stack
         // SUB: Pop c and b from the stack, push a on the stack
 
-        cb.stack_pop_word(Word::select(is_sub.expr().0, c.to_word(), a.to_word()));
-        cb.stack_pop_word(b.to_word());
-        cb.stack_push_word(Word::select(is_sub.expr().0, a.to_word(), c.to_word()));
+        cb.stack_pop(Word::select(is_sub.expr().0, c.to_word(), a.to_word()));
+        cb.stack_pop(b.to_word());
+        cb.stack_push(Word::select(is_sub.expr().0, a.to_word(), c.to_word()));
 
         // State transition
         let step_state_transition = StepStateTransition {

--- a/zkevm-circuits/src/evm_circuit/execution/addmod.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/addmod.rs
@@ -109,10 +109,10 @@ impl<F: Field> ExecutionGadget<F> for AddModGadget<F> {
 
         // pop/push values
         // take care that if n==0 pushed value for r should be zero also
-        cb.stack_pop_word(a.to_word());
-        cb.stack_pop_word(b.to_word());
-        cb.stack_pop_word(n.clone().to_word());
-        cb.stack_push_word(
+        cb.stack_pop(a.to_word());
+        cb.stack_pop(b.to_word());
+        cb.stack_pop(n.clone().to_word());
+        cb.stack_push(
             r.clone()
                 .to_word()
                 .mul_selector(not::expr(n_is_zero.expr())),

--- a/zkevm-circuits/src/evm_circuit/execution/address.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/address.rs
@@ -36,7 +36,7 @@ impl<F: Field> ExecutionGadget<F> for AddressGadget<F> {
         // Lookup callee address in call context.
         cb.call_context_lookup_read(None, CallContextFieldTag::CalleeAddress, address.to_word());
 
-        cb.stack_push_word(address.to_word());
+        cb.stack_push(address.to_word());
 
         let step_state_transition = StepStateTransition {
             rw_counter: Delta(2.expr()),

--- a/zkevm-circuits/src/evm_circuit/execution/balance.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/balance.rs
@@ -41,7 +41,7 @@ impl<F: Field> ExecutionGadget<F> for BalanceGadget<F> {
 
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
         let address = cb.query_account_address();
-        cb.stack_pop_word(address.to_word());
+        cb.stack_pop(address.to_word());
 
         let tx_id = cb.call_context(None, CallContextFieldTag::TxId);
         let mut reversion_info = cb.reversion_info_read(None);
@@ -55,7 +55,7 @@ impl<F: Field> ExecutionGadget<F> for BalanceGadget<F> {
         );
         let code_hash = cb.query_word_unchecked();
         // For non-existing accounts the code_hash must be 0 in the rw_table.
-        cb.account_read_word(
+        cb.account_read(
             address.to_word(),
             AccountFieldTag::CodeHash,
             code_hash.to_word(),
@@ -64,7 +64,7 @@ impl<F: Field> ExecutionGadget<F> for BalanceGadget<F> {
         let exists = not::expr(not_exists.expr());
         let balance = cb.query_word32();
         cb.condition(exists.expr(), |cb| {
-            cb.account_read_word(
+            cb.account_read(
                 address.to_word(),
                 AccountFieldTag::Balance,
                 balance.to_word(),
@@ -74,7 +74,7 @@ impl<F: Field> ExecutionGadget<F> for BalanceGadget<F> {
             cb.require_zero_word("balance is zero when non_exists", balance.to_word());
         });
 
-        cb.stack_push_word(balance.to_word());
+        cb.stack_push(balance.to_word());
 
         let gas_cost = select::expr(
             is_warm.expr(),

--- a/zkevm-circuits/src/evm_circuit/execution/bitwise.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/bitwise.rs
@@ -38,9 +38,9 @@ impl<F: Field> ExecutionGadget<F> for BitwiseGadget<F> {
         let b = cb.query_word32();
         let c = cb.query_word32();
 
-        cb.stack_pop_word(a.to_word());
-        cb.stack_pop_word(b.to_word());
-        cb.stack_push_word(c.to_word());
+        cb.stack_pop(a.to_word());
+        cb.stack_pop(b.to_word());
+        cb.stack_push(c.to_word());
 
         // Because opcode AND, OR, and XOR are continuous, so we can make the
         // FixedTableTag of them also continuous, and use the opcode delta from

--- a/zkevm-circuits/src/evm_circuit/execution/block_ctx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/block_ctx.rs
@@ -34,7 +34,7 @@ impl<F: Field> ExecutionGadget<F> for BlockCtxGadget<F> {
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
         let value = cb.query_word_unchecked(); // block table lookup below
 
-        cb.stack_push_word(value.to_word());
+        cb.stack_push(value.to_word());
 
         // Get op's FieldTag
         let opcode = cb.query_cell();
@@ -43,7 +43,7 @@ impl<F: Field> ExecutionGadget<F> for BlockCtxGadget<F> {
 
         // Lookup block table with block context ops
         // TIMESTAMP/NUMBER/GASLIMIT, COINBASE and DIFFICULTY/BASEFEE
-        cb.block_lookup_word(blockctx_tag, None, value.to_word());
+        cb.block_lookup(blockctx_tag, None, value.to_word());
 
         // State transition
         let step_state_transition = StepStateTransition {

--- a/zkevm-circuits/src/evm_circuit/execution/blockhash.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/blockhash.rs
@@ -39,14 +39,14 @@ impl<F: Field> ExecutionGadget<F> for BlockHashGadget<F> {
 
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
         let current_block_number = cb.query_cell();
-        cb.block_lookup_word(
+        cb.block_lookup(
             BlockContextFieldTag::Number.expr(),
             None,
             Word::from_lo_unchecked(current_block_number.expr()),
         );
 
         let block_number = WordByteCapGadget::construct(cb, current_block_number.expr());
-        cb.stack_pop_word(block_number.original_word_new().to_word());
+        cb.stack_pop(block_number.original_word().to_word());
 
         let block_hash = cb.query_word_unchecked();
 
@@ -59,7 +59,7 @@ impl<F: Field> ExecutionGadget<F> for BlockHashGadget<F> {
         let is_valid = and::expr([block_number.lt_cap(), diff_lt.expr()]);
 
         cb.condition(is_valid.expr(), |cb| {
-            cb.block_lookup_word(
+            cb.block_lookup(
                 BlockContextFieldTag::BlockHash.expr(),
                 Some(block_number.valid_value()),
                 block_hash.to_word(),
@@ -73,7 +73,7 @@ impl<F: Field> ExecutionGadget<F> for BlockHashGadget<F> {
             );
         });
 
-        cb.stack_push_word(block_hash.to_word());
+        cb.stack_push(block_hash.to_word());
 
         let step_state_transition = StepStateTransition {
             rw_counter: Delta(2.expr()),

--- a/zkevm-circuits/src/evm_circuit/execution/byte.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/byte.rs
@@ -68,9 +68,9 @@ impl<F: Field> ExecutionGadget<F> for ByteGadget<F> {
         // push the selected byte on the stack
         // We can push the selected byte here directly because
         // it only uses the LSB of a word.
-        cb.stack_pop_word(index.to_word());
-        cb.stack_pop_word(value.to_word());
-        cb.stack_push_word(Word::from_lo_unchecked(selected_byte));
+        cb.stack_pop(index.to_word());
+        cb.stack_pop(value.to_word());
+        cb.stack_push(Word::from_lo_unchecked(selected_byte));
 
         // State transition
         let step_state_transition = StepStateTransition {

--- a/zkevm-circuits/src/evm_circuit/execution/calldatacopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldatacopy.rs
@@ -56,9 +56,9 @@ impl<F: Field> ExecutionGadget<F> for CallDataCopyGadget<F> {
         let data_offset = WordByteCapGadget::construct(cb, call_data_length.expr());
 
         // Pop memory_offset, data_offset, length from stack
-        cb.stack_pop_word(memory_offset.to_word());
-        cb.stack_pop_word(data_offset.original_word_new().to_word());
-        cb.stack_pop_word(length.to_word());
+        cb.stack_pop(memory_offset.to_word());
+        cb.stack_pop(data_offset.original_word().to_word());
+        cb.stack_pop(length.to_word());
 
         // Lookup the calldata_length and caller_address in Tx context table or
         // Call context table

--- a/zkevm-circuits/src/evm_circuit/execution/calldataload.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldataload.rs
@@ -68,7 +68,7 @@ impl<F: Field> ExecutionGadget<F> for CallDataLoadGadget<F> {
         let call_data_offset = cb.query_cell();
 
         let data_offset = WordByteCapGadget::construct(cb, call_data_length.expr());
-        cb.stack_pop_word(data_offset.original_word_new().to_word());
+        cb.stack_pop(data_offset.original_word().to_word());
 
         cb.condition(
             and::expr([data_offset.not_overflow(), cb.curr.state.is_root.expr()]),
@@ -137,7 +137,7 @@ impl<F: Field> ExecutionGadget<F> for CallDataLoadGadget<F> {
                         cb.curr.state.is_root.expr(),
                     ]),
                     |cb| {
-                        cb.tx_context_lookup_word(
+                        cb.tx_context_lookup(
                             src_id.expr(),
                             TxContextFieldTag::CallData,
                             Some(src_addr.expr() + idx.expr()),
@@ -178,7 +178,7 @@ impl<F: Field> ExecutionGadget<F> for CallDataLoadGadget<F> {
             calldata_word.to_word().mul_selector(data_offset.overflow()),
         );
 
-        cb.stack_push_word(calldata_word.to_word());
+        cb.stack_push(calldata_word.to_word());
 
         let step_state_transition = StepStateTransition {
             rw_counter: Delta(cb.rw_counter_offset()),

--- a/zkevm-circuits/src/evm_circuit/execution/calldatasize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldatasize.rs
@@ -42,7 +42,7 @@ impl<F: Field> ExecutionGadget<F> for CallDataSizeGadget<F> {
         );
 
         // The calldatasize should be pushed to the top of the stack.
-        cb.stack_push_word(call_data_size.to_word());
+        cb.stack_push(call_data_size.to_word());
 
         let step_state_transition = StepStateTransition {
             rw_counter: Delta(2.expr()),

--- a/zkevm-circuits/src/evm_circuit/execution/caller.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/caller.rs
@@ -41,7 +41,7 @@ impl<F: Field> ExecutionGadget<F> for CallerGadget<F> {
         );
 
         // Push the value to the stack
-        cb.stack_push_word(caller_address.to_word());
+        cb.stack_push(caller_address.to_word());
 
         // State transition
         let opcode = cb.query_cell();

--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -114,7 +114,7 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
         let callee_address = Word::select(
             is_callcode.expr() + is_delegatecall.expr(),
             current_callee_address.to_word(),
-            call_gadget.callee_address_word(),
+            call_gadget.callee_address(),
         );
 
         // Add callee to access list
@@ -122,7 +122,7 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
         let is_warm_prev = cb.query_bool();
         cb.account_access_list_write_unchecked(
             tx_id.expr(),
-            call_gadget.callee_address_word(),
+            call_gadget.callee_address(),
             is_warm.expr(),
             is_warm_prev.expr(),
             Some(&mut reversion_info),
@@ -152,7 +152,7 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
         });
 
         let caller_balance_word = cb.query_word_unchecked();
-        cb.account_read_word(
+        cb.account_read(
             caller_address.to_word(),
             AccountFieldTag::Balance,
             caller_balance_word.to_word(),

--- a/zkevm-circuits/src/evm_circuit/execution/callvalue.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callvalue.rs
@@ -43,7 +43,7 @@ impl<F: Field> ExecutionGadget<F> for CallValueGadget<F> {
         );
 
         // Push the value to the stack
-        cb.stack_push_word(call_value.to_word());
+        cb.stack_push(call_value.to_word());
 
         // State transition
         let opcode = cb.query_cell();

--- a/zkevm-circuits/src/evm_circuit/execution/chainid.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/chainid.rs
@@ -34,10 +34,10 @@ impl<F: Field> ExecutionGadget<F> for ChainIdGadget<F> {
         let chain_id = cb.query_word_unchecked();
 
         // Push the value to the stack
-        cb.stack_push_word(chain_id.to_word());
+        cb.stack_push(chain_id.to_word());
 
         // Lookup block table with chain_id
-        cb.block_lookup_word(
+        cb.block_lookup(
             BlockContextFieldTag::ChainId.expr(),
             None,
             chain_id.to_word(),

--- a/zkevm-circuits/src/evm_circuit/execution/codecopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/codecopy.rs
@@ -61,9 +61,9 @@ impl<F: Field> ExecutionGadget<F> for CodeCopyGadget<F> {
         let code_offset = WordByteCapGadget::construct(cb, code_size.expr());
 
         // Pop items from stack.
-        cb.stack_pop_word(dst_memory_offset.to_word());
-        cb.stack_pop_word(code_offset.original_word_new().to_word());
-        cb.stack_pop_word(Word::from_lo_unchecked(length.expr()));
+        cb.stack_pop(dst_memory_offset.to_word());
+        cb.stack_pop(code_offset.original_word().to_word());
+        cb.stack_pop(Word::from_lo_unchecked(length.expr()));
 
         // Construct memory address in the destionation (memory) to which we copy code.
         let dst_memory_addr = MemoryAddressGadget::construct(cb, dst_memory_offset, length);
@@ -72,7 +72,7 @@ impl<F: Field> ExecutionGadget<F> for CodeCopyGadget<F> {
         let code_hash = cb.curr.state.code_hash.clone();
 
         // Fetch the bytecode length from the bytecode table.
-        cb.bytecode_length_word(code_hash.to_word(), code_size.expr());
+        cb.bytecode_length(code_hash.to_word(), code_size.expr());
 
         // Calculate the next memory size and the gas cost for this memory
         // access. This also accounts for the dynamic gas required to copy bytes to

--- a/zkevm-circuits/src/evm_circuit/execution/codesize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/codesize.rs
@@ -38,7 +38,7 @@ impl<F: Field> ExecutionGadget<F> for CodesizeGadget<F> {
 
         let code_hash = cb.curr.state.code_hash.clone();
         let codesize = cb.query_cell();
-        cb.bytecode_length_word(code_hash.to_word(), codesize.expr());
+        cb.bytecode_length(code_hash.to_word(), codesize.expr());
 
         cb.require_equal(
             "Constraint: bytecode length lookup == codesize",
@@ -46,7 +46,7 @@ impl<F: Field> ExecutionGadget<F> for CodesizeGadget<F> {
             codesize.expr(),
         );
 
-        cb.stack_push_word(codesize_bytes.to_word());
+        cb.stack_push(codesize_bytes.to_word());
 
         let step_state_transition = StepStateTransition {
             gas_left: Transition::Delta(-OpcodeId::CODESIZE.constant_gas_cost().expr()),

--- a/zkevm-circuits/src/evm_circuit/execution/comparator.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/comparator.rs
@@ -62,9 +62,9 @@ impl<F: Field> ExecutionGadget<F> for ComparatorGadget<F> {
         // When swap is enabled we swap stack places between a and b.
         // We can push result here directly because
         // it only uses the LSB of a word.
-        cb.stack_pop_word(Word::select(is_gt.expr(), b.to_word(), a.to_word()));
-        cb.stack_pop_word(Word::select(is_gt.expr(), a.to_word(), b.to_word()));
-        cb.stack_push_word(Word::from_lo_unchecked(result.expr()));
+        cb.stack_pop(Word::select(is_gt.expr(), b.to_word(), a.to_word()));
+        cb.stack_pop(Word::select(is_gt.expr(), a.to_word(), b.to_word()));
+        cb.stack_push(Word::from_lo_unchecked(result.expr()));
 
         // State transition
         let step_state_transition = StepStateTransition {

--- a/zkevm-circuits/src/evm_circuit/execution/dummy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/dummy.rs
@@ -30,10 +30,10 @@ impl<F: Field, const N_POP: usize, const N_PUSH: usize, const S: ExecutionState>
         let pops: [WordCell<F>; N_POP] = [(); N_POP].map(|_| cb.query_word_unchecked());
         let pushes: [WordCell<F>; N_PUSH] = [(); N_PUSH].map(|_| cb.query_word_unchecked());
         for pop in pops.iter() {
-            cb.stack_pop_word(pop.to_word());
+            cb.stack_pop(pop.to_word());
         }
         for push in pushes.iter() {
-            cb.stack_push_word(push.to_word());
+            cb.stack_push(push.to_word());
         }
         Self {
             pops,

--- a/zkevm-circuits/src/evm_circuit/execution/dup.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/dup.rs
@@ -38,8 +38,8 @@ impl<F: Field> ExecutionGadget<F> for DupGadget<F> {
         let dup_offset = opcode.expr() - OpcodeId::DUP1.expr();
 
         // Peek the value at `dup_offset` and push the value on the stack
-        cb.stack_lookup_word(false.expr(), dup_offset, value.to_word());
-        cb.stack_push_word(value.to_word());
+        cb.stack_lookup(false.expr(), dup_offset, value.to_word());
+        cb.stack_push(value.to_word());
 
         // State transition
         let step_state_transition = StepStateTransition {

--- a/zkevm-circuits/src/evm_circuit/execution/end_block.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/end_block.rs
@@ -68,7 +68,7 @@ impl<F: Field> ExecutionGadget<F> for EndBlockGadget<F> {
             // Verify that there are at most total_txs meaningful txs in the tx_table, by
             // showing that the Tx following the last processed one has
             // CallerAddress = 0x0 (which means padding tx).
-            cb.tx_context_lookup_word(
+            cb.tx_context_lookup(
                 total_txs.expr() + 1.expr(),
                 TxContextFieldTag::CallerAddress,
                 None,

--- a/zkevm-circuits/src/evm_circuit/execution/end_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/end_tx.rs
@@ -93,7 +93,7 @@ impl<F: Field> ExecutionGadget<F> for EndTxGadget<F> {
             (BlockContextFieldTag::Coinbase, coinbase.to_word()),
             (BlockContextFieldTag::BaseFee, base_fee.to_word()),
         ] {
-            cb.block_lookup_word(tag.expr(), None, value);
+            cb.block_lookup(tag.expr(), None, value);
         }
         let effective_tip = cb.query_word32();
         let sub_gas_price_by_base_fee =

--- a/zkevm-circuits/src/evm_circuit/execution/error_invalid_jump.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_invalid_jump.rs
@@ -64,20 +64,20 @@ impl<F: Field> ExecutionGadget<F> for ErrorInvalidJumpGadget<F> {
         let is_condition_zero = IsZeroWordGadget::construct(cb, &condition);
 
         // Pop the value from the stack
-        cb.stack_pop_word(dest.original_word_new().to_word());
+        cb.stack_pop(dest.original_word().to_word());
 
         cb.condition(is_jumpi.expr(), |cb| {
-            cb.stack_pop_word(condition.to_word());
+            cb.stack_pop(condition.to_word());
             // if condition is zero, jump will not happen, so constrain condition not zero
             cb.require_zero("condition is not zero", is_condition_zero.expr());
         });
 
         // Look up bytecode length
-        cb.bytecode_length_word(cb.curr.state.code_hash.to_word(), code_len.expr());
+        cb.bytecode_length(cb.curr.state.code_hash.to_word(), code_len.expr());
 
         // If destination is in valid range, lookup for the value.
         cb.condition(dest.lt_cap(), |cb| {
-            cb.bytecode_lookup_word(
+            cb.bytecode_lookup(
                 cb.curr.state.code_hash.to_word(),
                 dest.valid_value(),
                 is_code.expr(),

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_call.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_call.rs
@@ -64,11 +64,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGCallGadget<F> {
 
         // Add callee to access list
         let is_warm = cb.query_bool();
-        cb.account_access_list_read(
-            tx_id.expr(),
-            call_gadget.callee_address_word(),
-            is_warm.expr(),
-        );
+        cb.account_access_list_read(tx_id.expr(), call_gadget.callee_address(), is_warm.expr());
 
         cb.condition(call_gadget.has_value.expr(), |cb| {
             cb.require_zero(

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_exp.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_exp.rs
@@ -50,8 +50,8 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGExpGadget<F> {
 
         let base = cb.query_word32();
         let exponent = cb.query_word32();
-        cb.stack_pop_word(base.to_word());
-        cb.stack_pop_word(exponent.to_word());
+        cb.stack_pop(base.to_word());
+        cb.stack_pop(exponent.to_word());
 
         let exponent_byte_size = ByteSizeGadget::construct(
             cb,

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_log.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_log.rs
@@ -45,8 +45,8 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGLogGadget<F> {
         let msize = cb.query_memory_address();
 
         // Pop mstart_address, msize from stack
-        cb.stack_pop_word(mstart.to_word());
-        cb.stack_pop_word(msize.to_word());
+        cb.stack_pop(mstart.to_word());
+        cb.stack_pop(msize.to_word());
 
         // constrain not in static call
         let is_static_call = cb.call_context(None, CallContextFieldTag::IsStatic);

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_memory_copy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_memory_copy.rs
@@ -85,12 +85,12 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGMemoryCopyGadget<F> {
             cb.account_access_list_read(tx_id.expr(), external_address.to_word(), is_warm.expr());
 
             // EXTCODECOPY has an extra stack pop for external address.
-            cb.stack_pop_word(external_address.to_word());
+            cb.stack_pop(external_address.to_word());
         });
 
-        cb.stack_pop_word(dst_offset.to_word());
-        cb.stack_pop_word(src_offset.to_word());
-        cb.stack_pop_word(copy_size.to_word());
+        cb.stack_pop(dst_offset.to_word());
+        cb.stack_pop(src_offset.to_word());
+        cb.stack_pop(copy_size.to_word());
 
         let dst_memory_addr = MemoryAddressGadget::construct(cb, dst_offset, copy_size);
         let memory_expansion = MemoryExpansionGadget::construct(cb, [dst_memory_addr.address()]);

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_sload_sstore.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_sload_sstore.rs
@@ -76,8 +76,8 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGSloadSstoreGadget<F> {
         let original_value = cb.query_word_unchecked();
         let is_warm = cb.query_bool();
 
-        cb.stack_pop_word(key.to_word());
-        cb.account_storage_access_list_read_word(
+        cb.stack_pop(key.to_word());
+        cb.account_storage_access_list_read(
             tx_id.expr(),
             callee_address.to_word(),
             key.to_word(),
@@ -86,9 +86,9 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGSloadSstoreGadget<F> {
 
         let sload_gas_cost = SloadGasGadget::construct(cb, is_warm.expr());
         let sstore_gas_cost = cb.condition(is_sstore.expr().0, |cb| {
-            cb.stack_pop_word(value.to_word());
+            cb.stack_pop(value.to_word());
 
-            cb.account_storage_read_word(
+            cb.account_storage_read(
                 callee_address.to_word(),
                 key.to_word(),
                 value_prev.to_word(),

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_static_memory.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_static_memory.rs
@@ -57,11 +57,11 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGStaticMemoryGadget<F> {
         // Get the next memory size and the gas cost for this memory access
         let memory_expansion = MemoryExpansionGadget::construct(
             cb,
-            [address_low::expr_word(&address) + 1.expr() + (is_not_mstore8 * 31.expr())],
+            [address_low::expr(&address) + 1.expr() + (is_not_mstore8 * 31.expr())],
         );
 
         // Check if the memory address is too large
-        let address_in_range = IsZeroGadget::construct(cb, address_high::expr_word(&address));
+        let address_in_range = IsZeroGadget::construct(cb, address_high::expr(&address));
         // Check if the amount of gas available is less than the amount of gas
         // required
         let insufficient_gas = cb.condition(address_in_range.expr(), |cb| {
@@ -74,7 +74,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGStaticMemoryGadget<F> {
 
         // Pop the address from the stack
         // We still have to do this to verify the correctness of `address`
-        cb.stack_pop_word(address.to_word());
+        cb.stack_pop(address.to_word());
 
         // TODO: Use ContextSwitchGadget to switch call context to caller's and
         // consume all gas_left.

--- a/zkevm-circuits/src/evm_circuit/execution/error_return_data_oo_bound.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_return_data_oo_bound.rs
@@ -56,9 +56,9 @@ impl<F: Field> ExecutionGadget<F> for ErrorReturnDataOutOfBoundGadget<F> {
         );
 
         // Pop memory_offset, offset, size from stack
-        cb.stack_pop_word(memory_offset.to_word());
-        cb.stack_pop_word(data_offset.to_word());
-        cb.stack_pop_word(size.to_word());
+        cb.stack_pop(memory_offset.to_word());
+        cb.stack_pop(data_offset.to_word());
+        cb.stack_pop(size.to_word());
 
         // Read last callee return data length
         cb.call_context_lookup_read(

--- a/zkevm-circuits/src/evm_circuit/execution/error_write_protection.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_write_protection.rs
@@ -66,9 +66,9 @@ impl<F: Field> ExecutionGadget<F> for ErrorWriteProtectionGadget<F> {
         // Lookup values from stack if opcode is call
         // Precondition: If there's a StackUnderflow CALL, is handled before this error
         cb.condition(is_call.expr(), |cb| {
-            cb.stack_pop_word(gas_word.to_word());
-            cb.stack_pop_word(code_address.to_word());
-            cb.stack_pop_word(value.to_word());
+            cb.stack_pop(gas_word.to_word());
+            cb.stack_pop(code_address.to_word());
+            cb.stack_pop(value.to_word());
             cb.require_zero("value of call is not zero", is_value_zero.expr());
         });
 

--- a/zkevm-circuits/src/evm_circuit/execution/exp.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/exp.rs
@@ -63,11 +63,11 @@ impl<F: Field> ExecutionGadget<F> for ExponentiationGadget<F> {
         let exponentiation = cb.query_word32();
 
         // Pop RLC-encoded base and exponent from the stack.
-        cb.stack_pop_word(base.to_word());
-        cb.stack_pop_word(exponent.to_word());
+        cb.stack_pop(base.to_word());
+        cb.stack_pop(exponent.to_word());
 
         // Push RLC-encoded exponentiation to the stack.
-        cb.stack_push_word(exponentiation.to_word());
+        cb.stack_push(exponentiation.to_word());
 
         // Extract low and high bytes of the base.
         let (base_lo, base_hi) = base.to_word().to_lo_hi();

--- a/zkevm-circuits/src/evm_circuit/execution/extcodecopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodecopy.rs
@@ -66,10 +66,10 @@ impl<F: Field> ExecutionGadget<F> for ExtcodecopyGadget<F> {
         let memory_offset = cb.query_word_unchecked();
         let code_offset = WordByteCapGadget::construct(cb, code_size.expr());
 
-        cb.stack_pop_word(external_address_word.to_word());
-        cb.stack_pop_word(memory_offset.to_word());
-        cb.stack_pop_word(code_offset.original_word_new().to_word());
-        cb.stack_pop_word(memory_length.to_word());
+        cb.stack_pop(external_address_word.to_word());
+        cb.stack_pop(memory_offset.to_word());
+        cb.stack_pop(code_offset.original_word().to_word());
+        cb.stack_pop(memory_length.to_word());
 
         let tx_id = cb.call_context(None, CallContextFieldTag::TxId);
         let mut reversion_info = cb.reversion_info_read(None);
@@ -83,7 +83,7 @@ impl<F: Field> ExecutionGadget<F> for ExtcodecopyGadget<F> {
         );
 
         let code_hash = cb.query_word32();
-        cb.account_read_word(
+        cb.account_read(
             external_address.to_word(),
             AccountFieldTag::CodeHash,
             code_hash.to_word(),
@@ -91,7 +91,7 @@ impl<F: Field> ExecutionGadget<F> for ExtcodecopyGadget<F> {
         let not_exists = IsZeroWordGadget::construct(cb, &code_hash.to_word());
         let exists = not::expr(not_exists.expr());
         cb.condition(exists.expr(), |cb| {
-            cb.bytecode_length_word(code_hash.to_word(), code_size.expr());
+            cb.bytecode_length(code_hash.to_word(), code_size.expr());
         });
         cb.condition(not_exists.expr(), |cb| {
             cb.require_zero("code_size is zero when non_exists", code_size.expr());

--- a/zkevm-circuits/src/evm_circuit/execution/extcodehash.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodehash.rs
@@ -44,7 +44,7 @@ impl<F: Field> ExecutionGadget<F> for ExtcodehashGadget<F> {
                 .try_into()
                 .unwrap(),
         );
-        cb.stack_pop_word(address_word.to_word());
+        cb.stack_pop(address_word.to_word());
 
         let tx_id = cb.call_context(None, CallContextFieldTag::TxId);
         let mut reversion_info = cb.reversion_info_read(None);
@@ -61,12 +61,12 @@ impl<F: Field> ExecutionGadget<F> for ExtcodehashGadget<F> {
         // range check will be cover by account code_hash lookup
         let code_hash = cb.query_word_unchecked();
         // For non-existing accounts the code_hash must be 0 in the rw_table.
-        cb.account_read_word(
+        cb.account_read(
             address.to_word(),
             AccountFieldTag::CodeHash,
             code_hash.to_word(),
         );
-        cb.stack_push_word(code_hash.to_word());
+        cb.stack_push(code_hash.to_word());
 
         let gas_cost = select::expr(
             is_warm.expr(),

--- a/zkevm-circuits/src/evm_circuit/execution/extcodesize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodesize.rs
@@ -48,7 +48,7 @@ impl<F: Field> ExecutionGadget<F> for ExtcodesizeGadget<F> {
                 .try_into()
                 .unwrap(),
         );
-        cb.stack_pop_word(address_word.to_word());
+        cb.stack_pop(address_word.to_word());
 
         let tx_id = cb.call_context(None, CallContextFieldTag::TxId);
         let mut reversion_info = cb.reversion_info_read(None);
@@ -64,7 +64,7 @@ impl<F: Field> ExecutionGadget<F> for ExtcodesizeGadget<F> {
         // range check will be cover by account code_hash lookup
         let code_hash = cb.query_word_unchecked();
         // For non-existing accounts the code_hash must be 0 in the rw_table.
-        cb.account_read_word(
+        cb.account_read(
             address.to_word(),
             AccountFieldTag::CodeHash,
             code_hash.to_word(),
@@ -74,13 +74,13 @@ impl<F: Field> ExecutionGadget<F> for ExtcodesizeGadget<F> {
 
         let code_size = cb.query_u64();
         cb.condition(exists.expr(), |cb| {
-            cb.bytecode_length_word(code_hash.to_word(), code_size.expr());
+            cb.bytecode_length(code_hash.to_word(), code_size.expr());
         });
         cb.condition(not_exists.expr(), |cb| {
             cb.require_zero("code_size is zero when non_exists", code_size.expr());
         });
 
-        cb.stack_push_word(code_size.to_word());
+        cb.stack_push(code_size.to_word());
 
         let gas_cost = select::expr(
             is_warm.expr(),

--- a/zkevm-circuits/src/evm_circuit/execution/gas.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/gas.rs
@@ -41,7 +41,7 @@ impl<F: Field> ExecutionGadget<F> for GasGadget<F> {
         );
 
         // Construct the value and push it to stack.
-        cb.stack_push_word(gas_left.to_word());
+        cb.stack_push(gas_left.to_word());
 
         let step_state_transition = StepStateTransition {
             rw_counter: Delta(1.expr()),

--- a/zkevm-circuits/src/evm_circuit/execution/gasprice.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/gasprice.rs
@@ -38,7 +38,7 @@ impl<F: Field> ExecutionGadget<F> for GasPriceGadget<F> {
         // Lookup in call_ctx the TxId
         let tx_id = cb.call_context(None, CallContextFieldTag::TxId);
         // Lookup the gas_price in tx table
-        cb.tx_context_lookup_word(
+        cb.tx_context_lookup(
             tx_id.expr(),
             TxContextFieldTag::GasPrice,
             None,
@@ -46,7 +46,7 @@ impl<F: Field> ExecutionGadget<F> for GasPriceGadget<F> {
         );
 
         // Push the value to the stack
-        cb.stack_push_word(gas_price.to_word());
+        cb.stack_push(gas_price.to_word());
 
         // State transition
         let opcode = cb.query_cell();

--- a/zkevm-circuits/src/evm_circuit/execution/is_zero.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/is_zero.rs
@@ -36,8 +36,8 @@ impl<F: Field> ExecutionGadget<F> for IsZeroGadget<F> {
         let value = cb.query_word_unchecked();
         let is_zero_word = math_gadget::IsZeroWordGadget::construct(cb, &value);
 
-        cb.stack_pop_word(value.to_word());
-        cb.stack_push_word(Word::from_lo_unchecked(is_zero_word.expr()));
+        cb.stack_pop(value.to_word());
+        cb.stack_push(Word::from_lo_unchecked(is_zero_word.expr()));
 
         // State transition
         let step_state_transition = StepStateTransition {

--- a/zkevm-circuits/src/evm_circuit/execution/jump.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/jump.rs
@@ -32,7 +32,7 @@ impl<F: Field> ExecutionGadget<F> for JumpGadget<F> {
         let destination = cb.query_u64();
 
         // Pop the value from the stack
-        cb.stack_pop_word(destination.to_word());
+        cb.stack_pop(destination.to_word());
 
         // Lookup opcode at destination
         cb.opcode_lookup_at(destination.expr(), OpcodeId::JUMPDEST.expr(), 1.expr());

--- a/zkevm-circuits/src/evm_circuit/execution/jumpi.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/jumpi.rs
@@ -40,8 +40,8 @@ impl<F: Field> ExecutionGadget<F> for JumpiGadget<F> {
         let condition = cb.query_word_unchecked();
 
         // Pop the value from the stack
-        cb.stack_pop_word(dest.original());
-        cb.stack_pop_word(condition.to_word());
+        cb.stack_pop(dest.original());
+        cb.stack_pop(condition.to_word());
 
         // Determine if the jump condition is met
         let is_condition_zero = IsZeroWordGadget::construct(cb, &condition);

--- a/zkevm-circuits/src/evm_circuit/execution/logs.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/logs.rs
@@ -55,8 +55,8 @@ impl<F: Field> ExecutionGadget<F> for LogGadget<F> {
         let msize = cb.query_memory_address();
 
         // Pop mstart_address, msize from stack
-        cb.stack_pop_word(mstart.to_word());
-        cb.stack_pop_word(msize.to_word());
+        cb.stack_pop(mstart.to_word());
+        cb.stack_pop(msize.to_word());
         // read tx id
         let tx_id = cb.call_context(None, CallContextFieldTag::TxId);
         // constrain not in static call
@@ -71,7 +71,7 @@ impl<F: Field> ExecutionGadget<F> for LogGadget<F> {
         cb.require_boolean("is_persistent is bool", is_persistent.expr());
 
         cb.condition(is_persistent.expr(), |cb| {
-            cb.tx_log_lookup_word(
+            cb.tx_log_lookup(
                 tx_id.expr(),
                 cb.curr.state.log_id.expr() + 1.expr(),
                 TxLogFieldTag::Address,
@@ -85,10 +85,10 @@ impl<F: Field> ExecutionGadget<F> for LogGadget<F> {
         let topic_selectors: [Cell<F>; 4] = array_init(|_| cb.query_cell());
         for (idx, topic) in topics.iter().enumerate() {
             cb.condition(topic_selectors[idx].expr(), |cb| {
-                cb.stack_pop_word(topic.to_word());
+                cb.stack_pop(topic.to_word());
             });
             cb.condition(topic_selectors[idx].expr() * is_persistent.expr(), |cb| {
-                cb.tx_log_lookup_word(
+                cb.tx_log_lookup(
                     tx_id.expr(),
                     cb.curr.state.log_id.expr() + 1.expr(),
                     TxLogFieldTag::Topic,

--- a/zkevm-circuits/src/evm_circuit/execution/memory.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/memory.rs
@@ -63,10 +63,10 @@ impl<F: Field> ExecutionGadget<F> for MemoryGadget<F> {
 
         // Stack operations
         // Pop the address from the stack
-        cb.stack_pop_word(address.to_word());
+        cb.stack_pop(address.to_word());
         // For MLOAD push the value to the stack
         // FOR MSTORE pop the value from the stack
-        cb.stack_lookup_word(
+        cb.stack_lookup(
             is_mload.expr(),
             cb.stack_pointer_offset().expr() - is_mload.expr(),
             value.to_word(),

--- a/zkevm-circuits/src/evm_circuit/execution/msize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/msize.rs
@@ -42,7 +42,7 @@ impl<F: Field> ExecutionGadget<F> for MsizeGadget<F> {
         );
 
         // Push the value on the stack
-        cb.stack_push_word(Word::from_lo_unchecked(value.expr()));
+        cb.stack_push(Word::from_lo_unchecked(value.expr()));
 
         // State transition
         let step_state_transition = StepStateTransition {

--- a/zkevm-circuits/src/evm_circuit/execution/mul_div_mod.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/mul_div_mod.rs
@@ -71,9 +71,9 @@ impl<F: Field> ExecutionGadget<F> for MulDivModGadget<F> {
         // The second pop is multiplicand for MUL and divisor for DIV/MOD
         // The push is product for MUL, quotient for DIV, and residue for MOD
         // Note that for DIV/MOD, when divisor == 0, the push value is also 0.
-        cb.stack_pop_word(Word::select(is_mul.clone(), a.to_word(), d.to_word()));
-        cb.stack_pop_word(b.to_word());
-        cb.stack_push_word(
+        cb.stack_pop(Word::select(is_mul.clone(), a.to_word(), d.to_word()));
+        cb.stack_pop(b.to_word());
+        cb.stack_push(
             d.to_word()
                 .mul_selector(is_mul.clone())
                 .add_unchecked(

--- a/zkevm-circuits/src/evm_circuit/execution/mulmod.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/mulmod.rs
@@ -77,10 +77,10 @@ impl<F: Field> ExecutionGadget<F> for MulModGadget<F> {
             1.expr() - lt.expr() - n_is_zero.expr(),
         );
 
-        cb.stack_pop_word(a.to_word());
-        cb.stack_pop_word(b.to_word());
-        cb.stack_pop_word(n.to_word());
-        cb.stack_push_word(r.to_word());
+        cb.stack_pop(a.to_word());
+        cb.stack_pop(b.to_word());
+        cb.stack_pop(n.to_word());
+        cb.stack_push(r.to_word());
 
         // State transition
         let step_state_transition = StepStateTransition {

--- a/zkevm-circuits/src/evm_circuit/execution/not.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/not.rs
@@ -36,8 +36,8 @@ impl<F: Field> ExecutionGadget<F> for NotGadget<F> {
         let input = cb.query_word32();
         let output = cb.query_word32();
 
-        cb.stack_pop_word(input.to_word());
-        cb.stack_push_word(output.to_word());
+        cb.stack_pop(input.to_word());
+        cb.stack_push(output.to_word());
 
         for (i, o) in input.limbs.iter().zip(output.limbs.iter()) {
             cb.add_lookup(

--- a/zkevm-circuits/src/evm_circuit/execution/origin.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/origin.rs
@@ -34,7 +34,7 @@ impl<F: Field> ExecutionGadget<F> for OriginGadget<F> {
         // Lookup in call_ctx the TxId
         let tx_id = cb.call_context(None, CallContextFieldTag::TxId);
         // Lookup rw_table -> call_context with tx origin address
-        cb.tx_context_lookup_word(
+        cb.tx_context_lookup(
             tx_id.expr(),
             TxContextFieldTag::CallerAddress,
             None, // None because unrelated to calldata
@@ -42,7 +42,7 @@ impl<F: Field> ExecutionGadget<F> for OriginGadget<F> {
         );
 
         // Push the value to the stack
-        cb.stack_push_word(origin.to_word());
+        cb.stack_push(origin.to_word());
 
         // State transition
         let opcode = cb.query_cell();

--- a/zkevm-circuits/src/evm_circuit/execution/pc.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/pc.rs
@@ -40,7 +40,7 @@ impl<F: Field> ExecutionGadget<F> for PcGadget<F> {
         );
 
         // Push the value on the stack
-        cb.stack_push_word(value.to_word());
+        cb.stack_push(value.to_word());
 
         // State transition
         let step_state_transition = StepStateTransition {

--- a/zkevm-circuits/src/evm_circuit/execution/pop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/pop.rs
@@ -33,7 +33,7 @@ impl<F: Field> ExecutionGadget<F> for PopGadget<F> {
         let value = cb.query_word_unchecked();
 
         // Pop the value from the stack
-        cb.stack_pop_word(value.to_word());
+        cb.stack_pop(value.to_word());
 
         // State transition
         let step_state_transition = StepStateTransition {

--- a/zkevm-circuits/src/evm_circuit/execution/push.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/push.rs
@@ -98,7 +98,7 @@ impl<F: Field> ExecutionGadget<F> for PushGadget<F> {
         );
 
         // Push the value on the stack
-        cb.stack_push_word(value.to_word());
+        cb.stack_push(value.to_word());
 
         // State transition
         // `program_counter` needs to be increased by number of bytes pushed + 1

--- a/zkevm-circuits/src/evm_circuit/execution/return_revert.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/return_revert.rs
@@ -61,8 +61,8 @@ impl<F: Field> ExecutionGadget<F> for ReturnRevertGadget<F> {
 
         let offset = cb.query_word_unchecked();
         let length = cb.query_memory_address();
-        cb.stack_pop_word(offset.to_word());
-        cb.stack_pop_word(length.to_word());
+        cb.stack_pop(offset.to_word());
+        cb.stack_pop(length.to_word());
         let range = MemoryAddressGadget::construct(cb, offset, length);
 
         let is_success = cb.call_context(None, CallContextFieldTag::IsSuccess);
@@ -126,11 +126,11 @@ impl<F: Field> ExecutionGadget<F> for ReturnRevertGadget<F> {
 
                 let mut reversion_info = cb.reversion_info_read(None);
 
-                cb.account_write_word(
+                cb.account_write(
                     address.to_word(),
                     AccountFieldTag::CodeHash,
                     code_hash.to_word(),
-                    cb.empty_code_hash_word(),
+                    cb.empty_code_hash(),
                     Some(&mut reversion_info),
                 );
 

--- a/zkevm-circuits/src/evm_circuit/execution/returndatacopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/returndatacopy.rs
@@ -67,9 +67,9 @@ impl<F: Field> ExecutionGadget<F> for ReturnDataCopyGadget<F> {
         let size = cb.query_memory_address();
 
         // 1. Pop dest_offset, offset, length from stack
-        cb.stack_pop_word(dest_offset.to_word());
-        cb.stack_pop_word(Word::from_lo_unchecked(data_offset.expr()));
-        cb.stack_pop_word(Word::from_lo_unchecked(size.expr()));
+        cb.stack_pop(dest_offset.to_word());
+        cb.stack_pop(Word::from_lo_unchecked(data_offset.expr()));
+        cb.stack_pop(Word::from_lo_unchecked(size.expr()));
 
         // 2. Add lookup constraint in the call context for the returndatacopy field.
         let last_callee_id = cb.query_cell();

--- a/zkevm-circuits/src/evm_circuit/execution/returndatasize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/returndatasize.rs
@@ -42,7 +42,7 @@ impl<F: Field> ExecutionGadget<F> for ReturnDataSizeGadget<F> {
         );
 
         // The returndatasize should be pushed to the top of the stack.
-        cb.stack_push_word(return_data_size.to_word());
+        cb.stack_push(return_data_size.to_word());
 
         let step_state_transition = StepStateTransition {
             rw_counter: Delta(2.expr()),

--- a/zkevm-circuits/src/evm_circuit/execution/sar.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sar.rs
@@ -85,9 +85,9 @@ impl<F: Field> ExecutionGadget<F> for SarGadget<F> {
         let a = cb.query_word32();
         let b = cb.query_word32();
 
-        cb.stack_pop_word(shift.to_word());
-        cb.stack_pop_word(a.to_word());
-        cb.stack_push_word(b.to_word());
+        cb.stack_pop(shift.to_word());
+        cb.stack_pop(a.to_word());
+        cb.stack_push(b.to_word());
 
         let a64s: Word4<Expression<F>> = a.to_word_n();
         let b64s: Word4<Expression<F>> = b.to_word_n();

--- a/zkevm-circuits/src/evm_circuit/execution/selfbalance.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/selfbalance.rs
@@ -35,13 +35,13 @@ impl<F: Field> ExecutionGadget<F> for SelfbalanceGadget<F> {
         let callee_address = cb.call_context_read_as_word(None, CallContextFieldTag::CalleeAddress);
 
         let self_balance = cb.query_word_unchecked();
-        cb.account_read_word(
+        cb.account_read(
             callee_address.to_word(),
             AccountFieldTag::Balance,
             self_balance.to_word(),
         );
 
-        cb.stack_push_word(self_balance.to_word());
+        cb.stack_push(self_balance.to_word());
 
         let opcode = cb.query_cell();
         let step_state_transition = StepStateTransition {

--- a/zkevm-circuits/src/evm_circuit/execution/sha3.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sha3.rs
@@ -45,9 +45,9 @@ impl<F: Field> ExecutionGadget<F> for Sha3Gadget<F> {
         let size = cb.query_memory_address();
         let sha3_digest = cb.query_word_unchecked();
 
-        cb.stack_pop_word(offset.to_word());
-        cb.stack_pop_word(size.to_word());
-        cb.stack_push_word(sha3_digest.to_word());
+        cb.stack_pop(offset.to_word());
+        cb.stack_pop(size.to_word());
+        cb.stack_push(sha3_digest.to_word());
 
         let memory_address = MemoryAddressGadget::construct(cb, offset, size);
 
@@ -73,7 +73,7 @@ impl<F: Field> ExecutionGadget<F> for Sha3Gadget<F> {
             cb.require_zero("copy_rwc_inc == 0 for size = 0", copy_rwc_inc.expr());
             cb.require_zero("rlc_acc == 0 for size = 0", rlc_acc.expr());
         });
-        cb.keccak_table_lookup_word(
+        cb.keccak_table_lookup(
             rlc_acc.expr(),
             memory_address.length(),
             sha3_digest.to_word(),

--- a/zkevm-circuits/src/evm_circuit/execution/shl_shr.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/shl_shr.rs
@@ -78,14 +78,14 @@ impl<F: Field> ExecutionGadget<F> for ShlShrGadget<F> {
         // Constrain stack pops and pushes as:
         // - for SHL, two pops are shift and quotient, and push is dividend.
         // - for SHR, two pops are shift and dividend, and push is quotient.
-        cb.stack_pop_word(shift.to_word());
-        cb.stack_pop_word(
+        cb.stack_pop(shift.to_word());
+        cb.stack_pop(
             quotient
                 .to_word()
                 .mul_selector(is_shl.expr())
                 .add_unchecked(dividend.to_word().mul_selector(is_shr.expr())),
         );
-        cb.stack_push_word(
+        cb.stack_push(
             (dividend
                 .to_word()
                 .mul_selector(is_shl.expr())

--- a/zkevm-circuits/src/evm_circuit/execution/signed_comparator.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/signed_comparator.rs
@@ -109,9 +109,9 @@ impl<F: Field> ExecutionGadget<F> for SignedComparatorGadget<F> {
         let result = a_neg_b_pos.clone() + (1.expr() - a_neg_b_pos - b_neg_a_pos) * a_lt_b.expr();
 
         // Pop a and b from the stack, push the result on the stack.
-        cb.stack_pop_word(Word::select(is_sgt.expr(), b.to_word(), a.to_word()));
-        cb.stack_pop_word(Word::select(is_sgt.expr(), a.to_word(), b.to_word()));
-        cb.stack_push_word(Word::from_lo_unchecked(result));
+        cb.stack_pop(Word::select(is_sgt.expr(), b.to_word(), a.to_word()));
+        cb.stack_pop(Word::select(is_sgt.expr(), a.to_word(), b.to_word()));
+        cb.stack_push(Word::from_lo_unchecked(result));
 
         // The read-write counter changes by three since we're reading two words
         // from stack and writing one. The program counter shifts only by one

--- a/zkevm-circuits/src/evm_circuit/execution/signextend.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/signextend.rs
@@ -128,9 +128,9 @@ impl<F: Field> ExecutionGadget<F> for SignextendGadget<F> {
 
         // Pop the byte index and the value from the stack, push the result on
         // the stack
-        cb.stack_pop_word(index.to_word());
-        cb.stack_pop_word(value.to_word());
-        cb.stack_push_word(result.to_word());
+        cb.stack_pop(index.to_word());
+        cb.stack_pop(value.to_word());
+        cb.stack_push(result.to_word());
 
         // State transition
         let step_state_transition = StepStateTransition {

--- a/zkevm-circuits/src/evm_circuit/execution/sload.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sload.rs
@@ -46,11 +46,11 @@ impl<F: Field> ExecutionGadget<F> for SloadGadget<F> {
 
         let key = cb.query_word_unchecked();
         // Pop the key from the stack
-        cb.stack_pop_word(key.to_word());
+        cb.stack_pop(key.to_word());
 
         let value = cb.query_word_unchecked();
         let committed_value = cb.query_word_unchecked();
-        cb.account_storage_read_word(
+        cb.account_storage_read(
             callee_address.to_word(),
             key.to_word(),
             value.to_word(),
@@ -58,10 +58,10 @@ impl<F: Field> ExecutionGadget<F> for SloadGadget<F> {
             committed_value.to_word(),
         );
 
-        cb.stack_push_word(value.to_word());
+        cb.stack_push(value.to_word());
 
         let is_warm = cb.query_bool();
-        cb.account_storage_access_list_write_word(
+        cb.account_storage_access_list_write(
             tx_id.expr(),
             callee_address.to_word(),
             key.to_word(),

--- a/zkevm-circuits/src/evm_circuit/execution/sstore.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sstore.rs
@@ -65,15 +65,15 @@ impl<F: Field> ExecutionGadget<F> for SstoreGadget<F> {
 
         let key = cb.query_word32();
         // Pop the key from the stack
-        cb.stack_pop_word(key.to_word());
+        cb.stack_pop(key.to_word());
 
         let value = cb.query_word32();
         // Pop the value from the stack
-        cb.stack_pop_word(value.to_word());
+        cb.stack_pop(value.to_word());
 
         let value_prev = cb.query_word32();
         let original_value = cb.query_word32();
-        cb.account_storage_write_word(
+        cb.account_storage_write(
             callee_address.to_word(),
             key.to_word(),
             value.to_word(),
@@ -84,7 +84,7 @@ impl<F: Field> ExecutionGadget<F> for SstoreGadget<F> {
         );
 
         let is_warm = cb.query_bool();
-        cb.account_storage_access_list_write_word(
+        cb.account_storage_access_list_write(
             tx_id.expr(),
             callee_address.to_word(),
             key.to_word(),
@@ -121,7 +121,7 @@ impl<F: Field> ExecutionGadget<F> for SstoreGadget<F> {
             value_prev.clone(),
             original_value.clone(),
         );
-        cb.tx_refund_write_word(
+        cb.tx_refund_write(
             tx_id.expr(),
             Word::from_lo_unchecked(tx_refund.expr()),
             tx_refund_prev.to_word(),

--- a/zkevm-circuits/src/evm_circuit/execution/stop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/stop.rs
@@ -38,7 +38,7 @@ impl<F: Field> ExecutionGadget<F> for StopGadget<F> {
 
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
         let code_length = cb.query_cell();
-        cb.bytecode_length_word(cb.curr.state.code_hash.to_word(), code_length.expr());
+        cb.bytecode_length(cb.curr.state.code_hash.to_word(), code_length.expr());
         let is_out_of_range = IsZeroGadget::construct(
             cb,
             code_length.expr() - cb.curr.state.program_counter.expr(),

--- a/zkevm-circuits/src/evm_circuit/execution/swap.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/swap.rs
@@ -38,13 +38,13 @@ impl<F: Field> ExecutionGadget<F> for SwapGadget<F> {
         let swap_offset = opcode.expr() - (OpcodeId::SWAP1.as_u64() - 1).expr();
 
         // Peek the value at `swap_offset`
-        cb.stack_lookup_word(false.expr(), swap_offset.clone(), values[0].to_word());
+        cb.stack_lookup(false.expr(), swap_offset.clone(), values[0].to_word());
         // Peek the value at the top of the stack
-        cb.stack_lookup_word(false.expr(), 0.expr(), values[1].to_word());
+        cb.stack_lookup(false.expr(), 0.expr(), values[1].to_word());
         // Write the value previously at the top of the stack to `swap_offset`
-        cb.stack_lookup_word(true.expr(), swap_offset, values[1].to_word());
+        cb.stack_lookup(true.expr(), swap_offset, values[1].to_word());
         // Write the value previously at `swap_offset` to the top of the stack
-        cb.stack_lookup_word(true.expr(), 0.expr(), values[0].to_word());
+        cb.stack_lookup(true.expr(), 0.expr(), values[0].to_word());
 
         // State transition
         let step_state_transition = StepStateTransition {

--- a/zkevm-circuits/src/evm_circuit/util.rs
+++ b/zkevm-circuits/src/evm_circuit/util.rs
@@ -13,8 +13,7 @@ use crate::{
     util::int_decomposition::IntDecomposition,
     witness::{Block, ExecStep, Rw, RwMap},
 };
-use bus_mapping::state_db::CodeDB;
-use eth_types::{Address, Field, ToLittleEndian, ToWord, U256};
+use eth_types::{Address, Field, ToLittleEndian, U256};
 use halo2_proofs::{
     circuit::{AssignedCell, Region, Value},
     plonk::{Advice, Assigned, Column, ConstraintSystem, Error, Expression, VirtualCells},
@@ -207,11 +206,7 @@ impl<'r, 'b, F: Field> CachedRegion<'r, 'b, F> {
             .map(|r| rlc::value(le_bytes, r))
     }
 
-    pub fn empty_code_hash_rlc(&self) -> Value<F> {
-        self.word_rlc(CodeDB::empty_code_hash().to_word())
-    }
-
-    pub fn code_hash_word(&self, n: U256) -> Word<Value<F>> {
+    pub fn code_hash(&self, n: U256) -> Word<Value<F>> {
         Word::from(n).into_value()
     }
 

--- a/zkevm-circuits/src/evm_circuit/util.rs
+++ b/zkevm-circuits/src/evm_circuit/util.rs
@@ -211,13 +211,6 @@ impl<'r, 'b, F: Field> CachedRegion<'r, 'b, F> {
         self.word_rlc(CodeDB::empty_code_hash().to_word())
     }
 
-    #[deprecated(note = "in fav of code_hash_word")]
-    pub fn code_hash(&self, n: U256) -> Value<F> {
-        self.challenges
-            .evm_word()
-            .map(|r| rlc::value(&n.to_le_bytes(), r))
-    }
-
     pub fn code_hash_word(&self, n: U256) -> Word<Value<F>> {
         Word::from(n).into_value()
     }

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -536,11 +536,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         rlc::expr(&bytes, self.challenges.keccak_input())
     }
 
-    pub(crate) fn empty_code_hash_rlc(&self) -> Expression<F> {
-        self.word_rlc((*EMPTY_CODE_HASH_LE).map(|byte| byte.expr()))
-    }
-
-    pub(crate) fn empty_code_hash_word(&self) -> Word<Expression<F>> {
+    pub(crate) fn empty_code_hash(&self) -> Word<Expression<F>> {
         Word32::new(EMPTY_CODE_HASH_LE.map(|byte| byte.expr())).to_word()
     }
 
@@ -680,7 +676,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         );
     }
 
-    pub(crate) fn bytecode_lookup_word(
+    pub(crate) fn bytecode_lookup(
         &mut self,
         code_hash: Word<Expression<F>>,
         index: Expression<F>,
@@ -699,11 +695,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         )
     }
 
-    pub(crate) fn bytecode_length_word(
-        &mut self,
-        code_hash: Word<Expression<F>>,
-        value: Expression<F>,
-    ) {
+    pub(crate) fn bytecode_length(&mut self, code_hash: Word<Expression<F>>, value: Expression<F>) {
         self.add_lookup(
             "Bytecode (length)",
             Lookup::Bytecode {
@@ -726,7 +718,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
     ) -> Cell<F> {
         let cell = self.query_cell();
         // lookup read, unchecked is safe
-        self.tx_context_lookup_word(id, field_tag, index, Word::from_lo_unchecked(cell.expr()));
+        self.tx_context_lookup(id, field_tag, index, Word::from_lo_unchecked(cell.expr()));
         cell
     }
     pub(crate) fn tx_context_as_word32(
@@ -736,7 +728,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         index: Option<Expression<F>>,
     ) -> Word32Cell<F> {
         let word = self.query_word32();
-        self.tx_context_lookup_word(id, field_tag, index, word.to_word());
+        self.tx_context_lookup(id, field_tag, index, word.to_word());
         word
     }
 
@@ -747,11 +739,11 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         index: Option<Expression<F>>,
     ) -> WordCell<F> {
         let word = self.query_word_unchecked();
-        self.tx_context_lookup_word(id, field_tag, index, word.to_word());
+        self.tx_context_lookup(id, field_tag, index, word.to_word());
         word
     }
 
-    pub(crate) fn tx_context_lookup_word(
+    pub(crate) fn tx_context_lookup(
         &mut self,
         id: Expression<F>,
         field_tag: TxContextFieldTag,
@@ -770,7 +762,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
     }
 
     // block
-    pub(crate) fn block_lookup_word(
+    pub(crate) fn block_lookup(
         &mut self,
         tag: Expression<F>,
         number: Option<Expression<F>>,
@@ -921,7 +913,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
             ),
         );
     }
-    pub(crate) fn account_storage_access_list_write_word(
+    pub(crate) fn account_storage_access_list_write(
         &mut self,
         tx_id: Expression<F>,
         account_address: Word<Expression<F>>,
@@ -946,7 +938,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         );
     }
 
-    pub(crate) fn account_storage_access_list_read_word(
+    pub(crate) fn account_storage_access_list_read(
         &mut self,
         tx_id: Expression<F>,
         account_address: Word<Expression<F>>,
@@ -988,7 +980,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         );
     }
 
-    pub(crate) fn tx_refund_write_word(
+    pub(crate) fn tx_refund_write(
         &mut self,
         tx_id: Expression<F>,
         value: Word<Expression<F>>,
@@ -1012,7 +1004,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
     }
 
     // Account
-    pub(crate) fn account_read_word(
+    pub(crate) fn account_read(
         &mut self,
         account_address: Word<Expression<F>>,
         field_tag: AccountFieldTag,
@@ -1034,7 +1026,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         );
     }
 
-    pub(crate) fn account_write_word(
+    pub(crate) fn account_write(
         &mut self,
         account_address: Word<Expression<F>>,
         field_tag: AccountFieldTag,
@@ -1059,7 +1051,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
     }
 
     // Account Storage
-    pub(crate) fn account_storage_read_word(
+    pub(crate) fn account_storage_read(
         &mut self,
         account_address: Word<Expression<F>>,
         key: Word<Expression<F>>,
@@ -1084,7 +1076,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn account_storage_write_word(
+    pub(crate) fn account_storage_write(
         &mut self,
         account_address: Word<Expression<F>>,
         key: Word<Expression<F>>,
@@ -1238,17 +1230,17 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
     }
 
     // Stack
-    pub(crate) fn stack_pop_word(&mut self, value: Word<Expression<F>>) {
-        self.stack_lookup_word(false.expr(), self.stack_pointer_offset.clone(), value);
+    pub(crate) fn stack_pop(&mut self, value: Word<Expression<F>>) {
+        self.stack_lookup(false.expr(), self.stack_pointer_offset.clone(), value);
         self.stack_pointer_offset = self.stack_pointer_offset.clone() + self.condition_expr();
     }
 
-    pub(crate) fn stack_push_word(&mut self, value: Word<Expression<F>>) {
+    pub(crate) fn stack_push(&mut self, value: Word<Expression<F>>) {
         self.stack_pointer_offset = self.stack_pointer_offset.clone() - self.condition_expr();
-        self.stack_lookup_word(true.expr(), self.stack_pointer_offset.expr(), value);
+        self.stack_lookup(true.expr(), self.stack_pointer_offset.expr(), value);
     }
 
-    pub(crate) fn stack_lookup_word(
+    pub(crate) fn stack_lookup(
         &mut self,
         is_write: Expression<F>,
         stack_pointer_offset: Expression<F>,
@@ -1296,7 +1288,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         );
     }
 
-    pub(crate) fn tx_log_lookup_word(
+    pub(crate) fn tx_log_lookup(
         &mut self,
         tx_id: Expression<F>,
         log_id: Expression<F>,
@@ -1425,7 +1417,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
     }
 
     // Keccak Table
-    pub(crate) fn keccak_table_lookup_word(
+    pub(crate) fn keccak_table_lookup(
         &mut self,
         input_rlc: Expression<F>,
         input_len: Expression<F>,

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/abs_word.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/abs_word.rs
@@ -94,10 +94,10 @@ impl<F: Field> AbsWordGadget<F> {
         &self.is_neg
     }
 
-    pub(crate) fn x_word(&self) -> &Word32Cell<F> {
+    pub(crate) fn x(&self) -> &Word32Cell<F> {
         &self.x
     }
-    pub(crate) fn x_abs_word(&self) -> &Word32Cell<F> {
+    pub(crate) fn x_abs(&self) -> &Word32Cell<F> {
         &self.x_abs
     }
 }

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/rlp.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/rlp.rs
@@ -270,12 +270,6 @@ impl<F: Field, const IS_CREATE2: bool> ContractCreateGadget<F, IS_CREATE2> {
     }
 
     /// Code hash word RLC.
-    #[deprecated(note = "in fav of code_hash_word")]
-    pub(crate) fn code_hash_word_rlc(&self) -> Expression<F> {
-        unimplemented!()
-    }
-
-    /// Code hash word RLC.
     pub(crate) fn code_hash_word(&self) -> word::Word<Expression<F>> {
         self.code_hash.to_word()
     }
@@ -284,20 +278,6 @@ impl<F: Field, const IS_CREATE2: bool> ContractCreateGadget<F, IS_CREATE2> {
     pub(crate) fn code_hash_keccak_rlc(&self, cb: &EVMConstraintBuilder<F>) -> Expression<F> {
         cb.keccak_rlc::<N_BYTES_WORD>(
             self.code_hash
-                .limbs
-                .iter()
-                .map(Expr::expr)
-                .collect::<Vec<_>>()
-                .try_into()
-                .unwrap(),
-        )
-    }
-
-    /// Salt EVM word RLC.
-    #[deprecated(note = "in fav of salt_word")]
-    pub(crate) fn salt_word_rlc(&self, cb: &EVMConstraintBuilder<F>) -> Expression<F> {
-        cb.word_rlc::<N_BYTES_WORD>(
-            self.salt
                 .limbs
                 .iter()
                 .map(Expr::expr)

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/rlp.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/rlp.rs
@@ -260,7 +260,7 @@ impl<F: Field, const IS_CREATE2: bool> ContractCreateGadget<F, IS_CREATE2> {
     }
 
     /// Caller address' value.
-    pub(crate) fn caller_address_word(&self) -> word::Word<Expression<F>> {
+    pub(crate) fn caller_address(&self) -> word::Word<Expression<F>> {
         self.caller_address.to_word()
     }
 
@@ -270,7 +270,7 @@ impl<F: Field, const IS_CREATE2: bool> ContractCreateGadget<F, IS_CREATE2> {
     }
 
     /// Code hash word RLC.
-    pub(crate) fn code_hash_word(&self) -> word::Word<Expression<F>> {
+    pub(crate) fn code_hash(&self) -> word::Word<Expression<F>> {
         self.code_hash.to_word()
     }
 
@@ -287,7 +287,7 @@ impl<F: Field, const IS_CREATE2: bool> ContractCreateGadget<F, IS_CREATE2> {
         )
     }
 
-    pub(crate) fn salt_word(&self) -> word::Word<Expression<F>> {
+    pub(crate) fn salt(&self) -> word::Word<Expression<F>> {
         self.salt.to_word()
     }
 

--- a/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
@@ -24,18 +24,13 @@ use halo2_proofs::{
 pub(crate) mod address_low {
     use crate::{
         evm_circuit::{param::N_BYTES_MEMORY_ADDRESS, util::from_bytes},
-        util::word::{Word32Cell, WordLegacy},
+        util::word::Word32Cell,
     };
     use eth_types::Field;
     use halo2_proofs::plonk::Expression;
 
     pub(crate) fn expr_word<F: Field>(address: &Word32Cell<F>) -> Expression<F> {
         from_bytes::expr(&address.limbs[..N_BYTES_MEMORY_ADDRESS])
-    }
-
-    #[deprecated(note = "expr_word is fav")]
-    pub(crate) fn expr<F: Field>(address: &WordLegacy<F>) -> Expression<F> {
-        from_bytes::expr(&address.cells[..N_BYTES_MEMORY_ADDRESS])
     }
 
     pub(crate) fn value(address: [u8; 32]) -> u64 {
@@ -50,18 +45,13 @@ pub(crate) mod address_low {
 pub(crate) mod address_high {
     use crate::{
         evm_circuit::{param::N_BYTES_MEMORY_ADDRESS, util::sum},
-        util::word::{Word32Cell, WordLegacy},
+        util::word::Word32Cell,
     };
     use eth_types::Field;
     use halo2_proofs::plonk::Expression;
 
     pub(crate) fn expr_word<F: Field>(address: &Word32Cell<F>) -> Expression<F> {
         sum::expr(&address.limbs[N_BYTES_MEMORY_ADDRESS..])
-    }
-
-    #[deprecated(note = "expr_word is fav")]
-    pub(crate) fn expr<F: Field>(address: &WordLegacy<F>) -> Expression<F> {
-        sum::expr(&address.cells[N_BYTES_MEMORY_ADDRESS..])
     }
 
     pub(crate) fn value<F: Field>(address: [u8; 32]) -> F {

--- a/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
@@ -29,7 +29,7 @@ pub(crate) mod address_low {
     use eth_types::Field;
     use halo2_proofs::plonk::Expression;
 
-    pub(crate) fn expr_word<F: Field>(address: &Word32Cell<F>) -> Expression<F> {
+    pub(crate) fn expr<F: Field>(address: &Word32Cell<F>) -> Expression<F> {
         from_bytes::expr(&address.limbs[..N_BYTES_MEMORY_ADDRESS])
     }
 
@@ -50,7 +50,7 @@ pub(crate) mod address_high {
     use eth_types::Field;
     use halo2_proofs::plonk::Expression;
 
-    pub(crate) fn expr_word<F: Field>(address: &Word32Cell<F>) -> Expression<F> {
+    pub(crate) fn expr<F: Field>(address: &Word32Cell<F>) -> Expression<F> {
         sum::expr(&address.limbs[N_BYTES_MEMORY_ADDRESS..])
     }
 

--- a/zkevm-circuits/src/util/word.rs
+++ b/zkevm-circuits/src/util/word.rs
@@ -74,22 +74,6 @@ impl<T: Default, const N: usize> Default for WordLimbs<T, N> {
     }
 }
 
-impl<F: Field> Expr<F> for WordCell<F> {
-    fn expr(&self) -> Expression<F> {
-        unreachable!(
-            "This function is meat to fix the build. Remove once we fixed the word lo-hi refactor"
-        )
-    }
-}
-
-impl<F: Field> Expr<F> for Word32Cell<F> {
-    fn expr(&self) -> Expression<F> {
-        unreachable!(
-            "This function is meat to fix the build. Remove once we fixed the word lo-hi refactor"
-        )
-    }
-}
-
 /// Get the word expression
 pub trait WordExpr<F> {
     /// Get the word expression

--- a/zkevm-circuits/src/util/word.rs
+++ b/zkevm-circuits/src/util/word.rs
@@ -13,7 +13,7 @@ use halo2_proofs::{
 };
 use itertools::Itertools;
 
-use crate::evm_circuit::util::{from_bytes, CachedRegion, Cell, RandomLinearCombination};
+use crate::evm_circuit::util::{from_bytes, CachedRegion, Cell};
 
 /// evm word 32 bytes, half word 16 bytes
 const N_BYTES_HALF_WORD: usize = 16;
@@ -71,14 +71,6 @@ impl<T: Default, const N: usize> Default for WordLimbs<T, N> {
         Self {
             limbs: [(); N].map(|_| T::default()),
         }
-    }
-}
-
-impl<F: Field> From<Word32Cell<F>> for WordLegacy<F> {
-    fn from(_: Word32Cell<F>) -> Self {
-        unreachable!(
-            "This function is meat to fix the build. Remove once we fixed the word lo-hi refactor"
-        )
     }
 }
 
@@ -493,22 +485,6 @@ impl<F: Field, const N1: usize> WordLimbs<Expression<F>, N1> {
 impl<F: Field, const N1: usize> WordExpr<F> for WordLimbs<Expression<F>, N1> {
     fn to_word(&self) -> Word<Expression<F>> {
         Word(self.to_word_n())
-    }
-}
-
-#[deprecated(note = "Word is preferred")]
-/// Support legacy type of RLC word
-pub type WordLegacy<F> = RandomLinearCombination<F, 32>;
-
-impl<F: Field> WordExpr<F> for WordLegacy<F> {
-    fn to_word(&self) -> Word<Expression<F>> {
-        Word::new([self.expr(), 0.expr()])
-    }
-}
-
-impl<F: Field> From<WordLegacy<F>> for Word32Cell<F> {
-    fn from(value: WordLegacy<F>) -> Self {
-        Word32Cell::new(value.cells)
     }
 }
 


### PR DESCRIPTION
### Description

Clean up workaround introduced in https://github.com/privacy-scaling-explorations/zkevm-circuits/pull/1435

### Issue Link

https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/1487

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Contents

- it touch many files just under evm_circuit. Will not cause conflict with other word-lo-hi pr
- all just cleanup/renaming without any logic change