### PR TITLE
[word-lo-hi] fine tune copy circuit to reduce degree

### DIFF
--- a/zkevm-circuits/src/copy_circuit.rs
+++ b/zkevm-circuits/src/copy_circuit.rs
@@ -419,14 +419,33 @@ impl<F: Field> SubCircuitConfig<F> for CopyCircuitConfig<F> {
             .collect()
         });
 
-        meta.create_gate("id_hi === 0 when Momory, TxLog, and TxCalldata", |meta| {
+        meta.create_gate("id_hi === 0 when Momory", |meta| {
             let mut cb = BaseConstraintBuilder::default();
 
-            let cond = or::expr([
-                tag.value_equals(CopyDataType::Memory, Rotation::cur())(meta),
-                tag.value_equals(CopyDataType::TxLog, Rotation::cur())(meta),
-                tag.value_equals(CopyDataType::TxCalldata, Rotation::cur())(meta),
-            ]) * not::expr(meta.query_advice(is_pad, Rotation::cur()));
+            let cond = tag.value_equals(CopyDataType::Memory, Rotation::cur())(meta)
+                * not::expr(meta.query_advice(is_pad, Rotation::cur()));
+            cb.condition(cond, |cb| {
+                cb.require_zero("id_hi === 0", meta.query_advice(id.hi(), Rotation::cur()))
+            });
+            cb.gate(meta.query_fixed(q_enable, Rotation::cur()))
+        });
+
+        meta.create_gate("id_hi === 0 when TxLog", |meta| {
+            let mut cb = BaseConstraintBuilder::default();
+
+            let cond = tag.value_equals(CopyDataType::TxLog, Rotation::cur())(meta)
+                * not::expr(meta.query_advice(is_pad, Rotation::cur()));
+            cb.condition(cond, |cb| {
+                cb.require_zero("id_hi === 0", meta.query_advice(id.hi(), Rotation::cur()))
+            });
+            cb.gate(meta.query_fixed(q_enable, Rotation::cur()))
+        });
+
+        meta.create_gate("id_hi === 0 when TxCalldata", |meta| {
+            let mut cb = BaseConstraintBuilder::default();
+
+            let cond = tag.value_equals(CopyDataType::TxCalldata, Rotation::cur())(meta)
+                * not::expr(meta.query_advice(is_pad, Rotation::cur()));
             cb.condition(cond, |cb| {
                 cb.require_zero("id_hi === 0", meta.query_advice(id.hi(), Rotation::cur()))
             });

--- a/zkevm-circuits/src/super_circuit/test.rs
+++ b/zkevm-circuits/src/super_circuit/test.rs
@@ -20,7 +20,7 @@ fn super_circuit_degree() {
     SuperCircuit::configure_with_params(&mut cs, params);
     log::info!("super circuit degree: {}", cs.degree());
     log::info!("super circuit minimum_rows: {}", cs.minimum_rows());
-    assert!(cs.degree() <= 12);
+    assert!(cs.degree() <= 10);
 }
 
 fn test_super_circuit(block: GethData, circuits_params: CircuitsParams, mock_randomness: Fr) {


### PR DESCRIPTION
### Description

[_PR description_]

### Issue Link

https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/1499

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Contents
This pr is to rewrite/split copy circuit constrains to trade more gates with less degree.
copy table `tag` field is binary number decomposition with degree N (N represent number of bits, in copy table case N = 3). Once put in `or::expr([#num_or_condition])`, gate degrees will be exploded quickly by `N*#num_or_condition`.  

Before PR, copy circuit max is degree 12, 
After PR,  copy circuit max 6 degree with 2 more gates. 

However, circuit degree upper bound still increase by 1 (9 -> 10) for word-lo-hi refactor, due to state-circuit `batch_is_zero-"is_zero is 1 if values are all zero">`  gate degrees from 6 -> 10 Due to we fold 2 extra column, each contribute 2 degrees
https://github.com/privacy-scaling-explorations/zkevm-circuits/blob/word-lo-hi/zkevm-circuits/src/state_circuit.rs#L129-L141.

State circuit need some discussion, as I thought rewrite it might be a bit over-engineering.

