### PR TITLE
optimize few subcircuit synthesis call phase from 3->2 in dev mode

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -1343,11 +1343,9 @@ impl<F: Field> ExecutionConfig<F> {
         block: &Block<F>,
         challenges: &Challenges<Value<F>>,
     ) {
-        let mut evm_randomness = F::ZERO;
-        challenges.evm_word().map(|v| evm_randomness = v);
         let mut lookup_randomness = F::ZERO;
         challenges.lookup_input().map(|v| lookup_randomness = v);
-        if evm_randomness.is_zero_vartime() || lookup_randomness.is_zero_vartime() {
+        if lookup_randomness.is_zero_vartime() {
             // challenges not ready
             return;
         }

--- a/zkevm-circuits/src/evm_circuit/param.rs
+++ b/zkevm-circuits/src/evm_circuit/param.rs
@@ -16,7 +16,7 @@ pub const MAX_STEP_HEIGHT: usize = 19;
 pub(crate) const STEP_STATE_HEIGHT: usize = 1;
 
 /// Number of Advice Phase2 columns in the EVM circuit
-pub const N_PHASE2_COLUMNS: usize = 4;
+pub const N_PHASE2_COLUMNS: usize = 1;
 
 /// Number of Advice Phase1 columns in the EVM circuit
 pub const N_PHASE1_COLUMNS: usize =

--- a/zkevm-circuits/src/evm_circuit/util.rs
+++ b/zkevm-circuits/src/evm_circuit/util.rs
@@ -13,7 +13,7 @@ use crate::{
     util::{cell_manager::CMFixedWidthStrategyDistribution, int_decomposition::IntDecomposition},
     witness::{Block, ExecStep, Rw, RwMap},
 };
-use eth_types::{Address, Field, ToLittleEndian, U256};
+use eth_types::{Address, Field, U256};
 use halo2_proofs::{
     circuit::{AssignedCell, Region, Value},
     plonk::{Advice, Assigned, Column, ConstraintSystem, Error, Expression},
@@ -136,12 +136,6 @@ impl<'r, 'b, F: Field> CachedRegion<'r, 'b, F> {
 
     pub fn challenges(&self) -> &Challenges<Value<F>> {
         self.challenges
-    }
-
-    pub fn word_rlc(&self, n: U256) -> Value<F> {
-        self.challenges
-            .evm_word()
-            .map(|r| rlc::value(&n.to_le_bytes(), r))
     }
 
     pub fn keccak_rlc(&self, le_bytes: &[u8]) -> Value<F> {

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -552,10 +552,6 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         .query_cells(self.meta, cell_type, count)
     }
 
-    pub(crate) fn word_rlc<const N: usize>(&self, bytes: [Expression<F>; N]) -> Expression<F> {
-        rlc::expr(&bytes, self.challenges.evm_word())
-    }
-
     pub(crate) fn keccak_rlc<const N: usize>(&self, bytes: [Expression<F>; N]) -> Expression<F> {
         rlc::expr(&bytes, self.challenges.keccak_input())
     }

--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -144,7 +144,6 @@ impl<F: Field> SubCircuitConfig<F> for SuperCircuitConfig<F> {
         let challenges = Challenges::mock(
             power_of_randomness[0].clone(),
             power_of_randomness[0].clone(),
-            power_of_randomness[0].clone(),
         );
 
         let keccak_circuit = KeccakCircuitConfig::new(
@@ -427,7 +426,6 @@ impl<F: Field> Circuit<F> for SuperCircuit<F> {
     ) -> Result<(), Error> {
         let block = self.evm_circuit.block.as_ref().unwrap();
         let challenges = Challenges::mock(
-            Value::known(block.randomness),
             Value::known(block.randomness),
             Value::known(block.randomness),
         );


### PR DESCRIPTION
### Description

Remove evm_word challenge and optimize from 3->2 phase in dev phase.

### Issue Link

https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/1516

### Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

