### PR TITLE
Fully implement PUSHn

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution/stop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/stop.rs
@@ -1,6 +1,7 @@
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
+        param::N_BYTES_PROGRAM_COUNTER,
         step::ExecutionState,
         util::{
             common_gadget::RestoreContextGadget,
@@ -8,7 +9,7 @@ use crate::{
                 ConstrainBuilderCommon, EVMConstraintBuilder, StepStateTransition,
                 Transition::{Delta, Same},
             },
-            math_gadget::IsZeroGadget,
+            math_gadget::ComparisonGadget,
             CachedRegion, Cell,
         },
         witness::{Block, Call, ExecStep, Transaction},
@@ -26,7 +27,7 @@ use halo2_proofs::{circuit::Value, plonk::Error};
 #[derive(Clone, Debug)]
 pub(crate) struct StopGadget<F> {
     code_length: Cell<F>,
-    is_out_of_range: IsZeroGadget<F>,
+    out_of_range: ComparisonGadget<F, N_BYTES_PROGRAM_COUNTER>,
     opcode: Cell<F>,
     restore_context: RestoreContextGadget<F>,
 }
@@ -39,12 +40,17 @@ impl<F: Field> ExecutionGadget<F> for StopGadget<F> {
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
         let code_length = cb.query_cell();
         cb.bytecode_length(cb.curr.state.code_hash.to_word(), code_length.expr());
-        let is_out_of_range = IsZeroGadget::construct(
+
+        let out_of_range = ComparisonGadget::construct(
             cb,
-            code_length.expr() - cb.curr.state.program_counter.expr(),
+            code_length.expr(),
+            cb.curr.state.program_counter.expr(),
         );
+        let (lt, eq) = out_of_range.expr();
+        let is_out_of_range = lt + eq;
+
         let opcode = cb.query_cell();
-        cb.condition(1.expr() - is_out_of_range.expr(), |cb| {
+        cb.condition(1.expr() - is_out_of_range, |cb| {
             cb.opcode_lookup(opcode.expr(), 1.expr());
         });
 
@@ -91,7 +97,7 @@ impl<F: Field> ExecutionGadget<F> for StopGadget<F> {
 
         Self {
             code_length,
-            is_out_of_range,
+            out_of_range,
             opcode,
             restore_context,
         }
@@ -110,17 +116,13 @@ impl<F: Field> ExecutionGadget<F> for StopGadget<F> {
             .bytecodes
             .get_from_h256(&call.code_hash)
             .expect("could not find current environment's bytecode");
-        self.code_length.assign(
-            region,
-            offset,
-            Value::known(F::from(code.codesize() as u64)),
-        )?;
 
-        self.is_out_of_range.assign(
-            region,
-            offset,
-            F::from(code.codesize() as u64) - F::from(step.pc),
-        )?;
+        let code_length = code.codesize() as u64;
+        self.code_length
+            .assign(region, offset, Value::known(F::from(code_length)))?;
+
+        self.out_of_range
+            .assign(region, offset, F::from(code_length), F::from(step.pc))?;
 
         let opcode = step.opcode().unwrap();
         self.opcode


### PR DESCRIPTION
### Description
We intend here to support PUSHn with bytecode length inferior to n.

### Issue Link
Issue #633 
Linked to specs issue https://github.com/privacy-scaling-explorations/zkevm-specs/issues/463

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Contents

- Update push.rs to support bytecode of size smaller than n
- Update stop.rs similarly

### Rationale

In pushn, "selectors" are switches to enable or disable lookup arguments on the bytcode bytes as well as to check whether these are non-null if needs be. They directly depend on "n" of PUSHn.
We add to these "selectors", "counters" which have similar role but are a subset of them depending on the bytecode length. We added these extra switches to be able to easily check the various identities at the risk of some redundancy.

To support these changes, modifications in stop.py also had to be done. More precisely, the check "is_out_of_range had to be extended to support small bytecodes.

### How Has This Been Tested?

Extra tests have been added in push.rs (only).

