### PR TITLE
[ZK-74] Add Go install to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ Check out the work in progress [specification](https://github.com/privacy-scalin
 
 ## Getting started
 
+### Install Dependencies
+```
+# install Golang
+# https://go.dev/doc/install
+```
+
+### Testing
 To run the same tests as the CI, please use: `make test-all`.
 
 ## Running benchmarks


### PR DESCRIPTION
Changes:
- Go install instructions
- Without go, make test-all will fail

Test Plan:
- Readme only