### PR TITLE
Hardcode build target in workflow

### DIFF
--- a/.github/workflows/main-tests.yml
+++ b/.github/workflows/main-tests.yml
@@ -127,12 +127,8 @@ jobs:
       github.event.pull_request.draft == false &&
       (github.event.action == 'ready_for_review' || needs.skip_check.outputs.should_skip != 'true')
 
-    name: Build target ${{ matrix.target }}
+    name: Linux Build
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        target:
-          - x86_64-unknown-linux-gnu
 
     steps:
       - uses: actions/checkout@v2
@@ -140,7 +136,7 @@ jobs:
         with:
           override: false
       - name: Add target
-        run: rustup target add ${{ matrix.target }}
+        run: rustup target add x86_64-unknown-linux-gnu
       # Go cache for building geth-utils
       - name: Go cache
         uses: actions/cache@v3
@@ -160,7 +156,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: build-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: cargo build
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
### Description

Remove the matrix strategy in the build job and instead hardcode the build target.  Since we only have 1 target we don't need the matrix strategy.

This is a small PR aimed to clean up the output of jobs running from commits merged to main.  Our configuration skips jobs that have already run, and when this happens, the matrix strategy is not resolved and we see this:
![image](https://github.com/privacy-scaling-explorations/zkevm-circuits/assets/24987329/e90fc7ae-841b-4adb-8956-5b4fa6539fe4)

By removing the matrix strategy we should see a cleaner output.