### PR TITLE
fix: remove unnecessary match

### DIFF
--- a/zkevm-circuits/src/evm_circuit/step.rs
+++ b/zkevm-circuits/src/evm_circuit/step.rs
@@ -247,7 +247,6 @@ impl From<&ExecStep> for ExecutionState {
                     OpcodeId::NOT => ExecutionState::NOT,
                     OpcodeId::EXP => ExecutionState::EXP,
                     OpcodeId::POP => ExecutionState::POP,
-                    OpcodeId::PUSH32 => ExecutionState::PUSH,
                     OpcodeId::BYTE => ExecutionState::BYTE,
                     OpcodeId::MLOAD => ExecutionState::MEMORY,
                     OpcodeId::MSTORE => ExecutionState::MEMORY,


### PR DESCRIPTION
### Description

We don't need to match `OpcodeId::PUSH32` again, because it has been contained in previous code.
https://github.com/privacy-scaling-explorations/zkevm-circuits/blob/b36da2a4047f8811990c6d928bb1e1864f88328b/zkevm-circuits/src/evm_circuit/step.rs#L215-L216
https://github.com/privacy-scaling-explorations/zkevm-circuits/blob/b36da2a4047f8811990c6d928bb1e1864f88328b/eth-types/src/evm_types/opcode_ids.rs#L319-L321

The `is_push` contains the `PUSH32` opcode. So, let's remove the duplicate match.

### Issue Link

No

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update