### PR TITLE
[MPT] Add minimal RLP encoding check

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ To run the same tests as the CI, please use: `make test-all`.
 ## Running benchmarks
 
 There are currently several benchmarks to run in the workspace in regards to the circuits.
-All use the `DEGREE` env var to specify the degree of the `K` parameter that you want 
+All use the `DEGREE` env var to specify the degree of the `K` parameter that you want
 to use for your circuit in the bench process.
 -   Keccak Circuit prover benches. -> `DEGREE=16 make packed_multi_keccak_bench`
 -   EVM Circuit prover benches. -> `DEGREE=18 make evm_bench`.
 -   State Circuit prover benches. -> `DEGREE=18 make state_bench`
--   MPT Circuit prover benches. -> `DEGREE=14 make mpt_bench`
+-   MPT Circuit prover benches. -> `DEGREE=15 make mpt_bench`
 
 You can also run all benchmarks by running: `make circuit_benches DEGREE=18`.
 

--- a/zkevm-circuits/src/circuit_tools/cached_region.rs
+++ b/zkevm-circuits/src/circuit_tools/cached_region.rs
@@ -10,7 +10,10 @@ use std::{
     hash::{Hash, Hasher},
 };
 
-use super::{cell_manager::CellType, constraint_builder::ConstraintBuilder};
+use super::{
+    cell_manager::{CellColumn, CellType},
+    constraint_builder::ConstraintBuilder,
+};
 
 pub trait ChallengeSet<F: Field> {
     fn indexed(&self) -> Vec<&Value<F>>;
@@ -64,11 +67,26 @@ impl<'r, 'b, F: Field> CachedRegion<'r, 'b, F> {
     ) -> Result<(), Error> {
         for (offset, region_id) in self.regions.clone() {
             for stored_expression in cb.get_stored_expressions(region_id).iter() {
-                // println!("stored expression: {}", stored_expression.name);
                 stored_expression.assign(self, challenges, offset)?;
             }
         }
         Ok(())
+    }
+
+    pub(crate) fn annotate_columns<C: CellType>(&mut self, cell_columns: &[CellColumn<F, C>]) {
+        for c in cell_columns {
+            self.region.name_column(
+                || {
+                    format!(
+                        "{:?} {:?}: {:?} queried",
+                        c.cell_type.clone(),
+                        c.index,
+                        c.height
+                    )
+                },
+                c.column,
+            );
+        }
     }
 
     /// Assign an advice column value (witness).

--- a/zkevm-circuits/src/circuit_tools/memory.rs
+++ b/zkevm-circuits/src/circuit_tools/memory.rs
@@ -29,21 +29,13 @@ impl<F: Field, C: CellType, MB: MemoryBank<F, C>> Index<C> for Memory<F, C, MB> 
     type Output = MB;
 
     fn index(&self, tag: C) -> &Self::Output {
-        if let Some(bank) = self.banks.get(&tag) {
-            bank
-        } else {
-            unreachable!()
-        }
+        self.banks.get(&tag).expect("bank exists")
     }
 }
 
 impl<F: Field, C: CellType, MB: MemoryBank<F, C>> IndexMut<C> for Memory<F, C, MB> {
     fn index_mut(&mut self, tag: C) -> &mut Self::Output {
-        if let Some(bank) = self.banks.get_mut(&tag) {
-            bank
-        } else {
-            unreachable!()
-        }
+        self.banks.get_mut(&tag).expect("bank exists")
     }
 }
 
@@ -56,7 +48,7 @@ impl<F: Field, C: CellType, MB: MemoryBank<F, C>> Memory<F, C, MB> {
         }
     }
 
-    pub(crate) fn add_rw(
+    pub(crate) fn add_memory_bank(
         &mut self,
         meta: &mut ConstraintSystem<F>,
         cb: &mut ConstraintBuilder<F, C>,

--- a/zkevm-circuits/src/circuit_tools/memory.rs
+++ b/zkevm-circuits/src/circuit_tools/memory.rs
@@ -6,230 +6,261 @@ use halo2_proofs::{
     plonk::{Advice, Column, ConstraintSystem, Error, Expression},
     poly::Rotation,
 };
-use std::ops::{Index, IndexMut};
+use std::{
+    collections::HashMap,
+    marker::PhantomData,
+    ops::{Index, IndexMut},
+};
 
 use super::{
-    cached_region::CachedRegion, cell_manager::CellType, constraint_builder::ConstraintBuilder,
+    cached_region::CachedRegion,
+    cell_manager::{CellManager, CellType},
+    constraint_builder::ConstraintBuilder,
 };
 
 #[derive(Clone, Debug, Default)]
-pub(crate) struct Memory<F, C> {
-    columns: Vec<Column<Advice>>,
-    banks: Vec<MemoryBank<F, C>>,
+pub(crate) struct Memory<F: Field, C: CellType, MB: MemoryBank<F, C>> {
+    banks: HashMap<C, MB>,
+    _phantom: PhantomData<F>,
+    tag_counter: usize,
 }
 
-impl<F: Field, C: CellType> Memory<F, C> {
-    pub(crate) fn new(columns: Vec<Column<Advice>>) -> Self {
+impl<F: Field, C: CellType, MB: MemoryBank<F, C>> Index<C> for Memory<F, C, MB> {
+    type Output = MB;
+
+    fn index(&self, tag: C) -> &Self::Output {
+        if let Some(bank) = self.banks.get(&tag) {
+            bank
+        } else {
+            unreachable!()
+        }
+    }
+}
+
+impl<F: Field, C: CellType, MB: MemoryBank<F, C>> IndexMut<C> for Memory<F, C, MB> {
+    fn index_mut(&mut self, tag: C) -> &mut Self::Output {
+        if let Some(bank) = self.banks.get_mut(&tag) {
+            bank
+        } else {
+            unreachable!()
+        }
+    }
+}
+
+impl<F: Field, C: CellType, MB: MemoryBank<F, C>> Memory<F, C, MB> {
+    pub(crate) fn new() -> Self {
         Self {
-            columns,
-            banks: Vec::new(),
+            banks: HashMap::new(),
+            _phantom: PhantomData,
+            tag_counter: 0,
         }
     }
 
-    pub(crate) fn allocate(
+    pub(crate) fn add_rw(
         &mut self,
         meta: &mut ConstraintSystem<F>,
+        cb: &mut ConstraintBuilder<F, C>,
+        cm: &mut CellManager<F, C>,
         tag: C,
-        table_tag: C,
-    ) -> &MemoryBank<F, C> {
-        self.banks.push(MemoryBank::new(
-            meta,
-            self.columns[self.banks.len()],
-            tag,
-            table_tag,
-        ));
-        self.banks.last().unwrap()
+        phase: u8,
+    ) -> &MB {
+        let table_tag = self.allocate_tag();
+        let bank = MB::new(meta, cb, cm, (tag, table_tag), phase);
+        self.add(bank)
     }
 
-    pub(crate) fn get(&self, tag: C) -> &MemoryBank<F, C> {
-        for bank in self.banks.iter() {
-            if bank.tag() == tag {
-                return bank;
-            }
-        }
-        unreachable!()
-    }
-
-    pub(crate) fn get_mut(&mut self, tag: C) -> &mut MemoryBank<F, C> {
-        for bank in self.banks.iter_mut() {
-            if bank.tag() == tag {
-                return bank;
-            }
-        }
-        unreachable!()
+    pub(crate) fn add(&mut self, memory_bank: MB) -> &MB {
+        let tag = memory_bank.tag();
+        self.banks.insert(tag, memory_bank);
+        &self.banks[&tag]
     }
 
     pub(crate) fn get_columns(&self) -> Vec<Column<Advice>> {
-        self.columns.clone()
+        self.banks.values().fold(Vec::new(), |mut acc, bank| {
+            acc.extend(bank.columns().iter());
+            acc
+        })
     }
 
     pub(crate) fn build_constraints(
         &self,
         cb: &mut ConstraintBuilder<F, C>,
-        is_first_row: Expression<F>,
+        q_start: Expression<F>,
     ) {
-        for bank in self.banks.iter() {
-            bank.build_constraints(cb, is_first_row.expr());
-            // cb.generate_lookup_table_checks(bank.tag());
-        }
-    }
-
-    pub(crate) fn clear_witness_data(&mut self) {
-        for bank in self.banks.iter_mut() {
-            bank.clear_witness_data();
+        for (_, bank) in self.banks.iter() {
+            bank.build_constraints(cb, q_start.expr());
         }
     }
 
     pub(crate) fn assign(
-        &self,
+        &mut self,
         region: &mut CachedRegion<'_, '_, F>,
         height: usize,
     ) -> Result<(), Error> {
-        for bank in self.banks.iter() {
+        for (_, bank) in self.banks.iter_mut() {
             bank.assign(region, height)?;
         }
         Ok(())
     }
 
-    pub(crate) fn tags(&self) -> Vec<C> {
-        self.banks.iter().map(|bank| bank.tag()).collect()
+    pub(crate) fn allocate_tag(&mut self) -> C {
+        let tag = C::create_type(self.tag_counter);
+        self.tag_counter += 1;
+        tag
     }
 }
 
-impl<F: Field, C: CellType> Index<C> for Memory<F, C> {
-    type Output = MemoryBank<F, C>;
-
-    fn index(&self, tag: C) -> &Self::Output {
-        for bank in self.banks.iter() {
-            if bank.tag() == tag {
-                return bank;
-            }
-        }
-        unreachable!()
-    }
+pub(crate) trait MemoryBank<F: Field, C: CellType>: Clone {
+    fn new(
+        meta: &mut ConstraintSystem<F>,
+        cb: &mut ConstraintBuilder<F, C>,
+        cm: &mut CellManager<F, C>,
+        tag: (C, C),
+        phase: u8,
+    ) -> Self;
+    fn store(
+        &mut self,
+        cb: &mut ConstraintBuilder<F, C>,
+        values: &[Expression<F>],
+    ) -> Expression<F>;
+    fn load(
+        &mut self,
+        cb: &mut ConstraintBuilder<F, C>,
+        load_offset: Expression<F>,
+        values: &[Expression<F>],
+    );
+    fn columns(&self) -> Vec<Column<Advice>>;
+    fn tag(&self) -> C;
+    fn witness_store(&mut self, offset: usize, values: &[F]);
+    fn witness_load(&self, offset: usize) -> Vec<F>;
+    fn build_constraints(&self, cb: &mut ConstraintBuilder<F, C>, q_start: Expression<F>);
+    fn assign(&mut self, region: &mut CachedRegion<'_, '_, F>, height: usize) -> Result<(), Error>;
 }
 
-impl<F: Field, C: CellType> IndexMut<C> for Memory<F, C> {
-    fn index_mut(&mut self, tag: C) -> &mut Self::Output {
-        for bank in self.banks.iter_mut() {
-            if bank.tag() == tag {
-                return bank;
-            }
-        }
-        unreachable!()
-    }
+pub(crate) fn insert_key<V: Clone>(key: V, values: &[V]) -> Vec<V> {
+    [vec![key], values.to_owned()].concat().to_vec()
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct MemoryBank<F, C> {
-    column: Column<Advice>,
-    tag: C,
-    table_tag: C,
-    cur: Expression<F>,
-    next: Expression<F>,
+pub(crate) struct RwBank<F, C> {
+    tag: (C, C),
+    key: Column<Advice>,
+    reads: Column<Advice>,
+    writes: Column<Advice>,
     store_offsets: Vec<usize>,
     stored_values: Vec<Vec<F>>,
+    cur: Expression<F>,
+    next: Expression<F>,
+    local_conditions: Vec<(usize, Expression<F>)>,
+    last_assigned_offset: usize,
 }
 
-impl<F: Field, C: CellType> MemoryBank<F, C> {
-    pub(crate) fn new(
-        meta: &mut ConstraintSystem<F>,
-        column: Column<Advice>,
-        tag: C,
-        table_tag: C,
-    ) -> Self {
-        let mut cur = 0.expr();
-        let mut next = 0.expr();
-        query_expression(meta, |meta| {
-            cur = meta.query_advice(column, Rotation::cur());
-            next = meta.query_advice(column, Rotation::next());
-        });
-        Self {
-            column,
-            tag,
-            table_tag,
-            cur,
-            next,
-            store_offsets: Vec::new(),
-            stored_values: Vec::new(),
-        }
-    }
-
+impl<F: Field, C: CellType> RwBank<F, C> {
     pub(crate) fn key(&self) -> Expression<F> {
         self.cur.expr()
     }
+    pub(crate) fn prepend_key(&self, values: &[Expression<F>]) -> Vec<Expression<F>> {
+        [&[self.cur.expr() + 1.expr()], values].concat().to_vec()
+    }
 
-    pub(crate) fn load(
+    pub(crate) fn prepend_offset(
         &self,
-        description: &'static str,
-        cb: &mut ConstraintBuilder<F, C>,
+        values: &[Expression<F>],
         offset: Expression<F>,
-        values: &[Expression<F>],
-    ) {
-        self.load_with_key(description, cb, self.key() - offset, values);
+    ) -> Vec<Expression<F>> {
+        [&[self.cur.expr() - offset], values].concat().to_vec()
     }
+}
 
-    pub(crate) fn load_with_key(
-        &self,
-        description: &'static str,
+impl<F: Field, C: CellType> MemoryBank<F, C> for RwBank<F, C> {
+    fn new(
+        meta: &mut ConstraintSystem<F>,
         cb: &mut ConstraintBuilder<F, C>,
-        key: Expression<F>,
-        values: &[Expression<F>],
-    ) {
-        cb.add_lookup(description, self.tag(), self.insert_key(key, values));
+        cm: &mut CellManager<F, C>,
+        tag: (C, C),
+        phase: u8,
+    ) -> Self {
+        let rw: Vec<Column<Advice>> = [tag.0, tag.1]
+            .iter()
+            .map(|t| {
+                cm.add_columns(meta, cb, *t, phase, false, 1);
+                cm.get_typed_columns(*t)[0].column
+            })
+            .collect();
+        let key = meta.advice_column();
+        let (cur, next, input, table) = query_expression(meta, |meta| {
+            (
+                meta.query_advice(key, Rotation::cur()),
+                meta.query_advice(key, Rotation::next()),
+                meta.query_advice(rw[0], Rotation::cur()),
+                meta.query_advice(rw[1], Rotation::cur()),
+            )
+        });
+
+        // Generate the memory lookup
+        crate::circuit!([meta, cb], {
+            require!((input) => @vec![table]);
+        });
+
+        Self {
+            tag,
+            key,
+            reads: rw[0],
+            writes: rw[1],
+            store_offsets: Vec::new(),
+            stored_values: Vec::new(),
+            cur,
+            next,
+            local_conditions: Vec::new(),
+            last_assigned_offset: 0,
+        }
     }
 
-    pub(crate) fn store(
-        &self,
+    fn store(
+        &mut self,
         cb: &mut ConstraintBuilder<F, C>,
         values: &[Expression<F>],
     ) -> Expression<F> {
         let key = self.key() + 1.expr();
-        self.store_with_key(cb, key.expr(), values);
+        cb.store_tuple(
+            Box::leak(format!("{:?} store", self.tag.1).into_boxed_str()),
+            self.tag.1,
+            insert_key(key.expr(), values),
+        );
+        self.local_conditions
+            .push((cb.region_id, cb.get_condition_expr()));
         key
     }
 
-    pub(crate) fn store_with_key(
-        &self,
+    fn load(
+        &mut self,
         cb: &mut ConstraintBuilder<F, C>,
-        key: Expression<F>,
+        load_offset: Expression<F>,
         values: &[Expression<F>],
     ) {
-        cb.add_lookup(
-            "memory store",
-            self.table_tag(),
-            self.insert_key(key, values),
+        cb.store_tuple(
+            Box::leak(format!("{:?} load", self.tag.0).into_boxed_str()),
+            self.tag.0,
+            insert_key(self.key() - load_offset.expr(), values),
         );
     }
 
-    pub(crate) fn witness_store(&mut self, offset: usize, values: &[F]) {
-        self.stored_values.push(values.to_vec());
-        self.store_offsets.push(offset);
+    fn tag(&self) -> C {
+        self.tag.0
     }
 
-    pub(crate) fn witness_load(&self, offset: usize) -> Vec<F> {
-        self.stored_values[self.stored_values.len() - 1 - offset].clone()
+    fn columns(&self) -> Vec<Column<Advice>> {
+        vec![self.key, self.reads, self.writes]
     }
 
-    pub(crate) fn clear_witness_data(&mut self) {
-        self.store_offsets.clear();
-    }
-
-    pub(crate) fn build_constraints(
-        &self,
-        cb: &mut ConstraintBuilder<F, C>,
-        is_first_row: Expression<F>,
-    ) {
-        let lookups = cb.lookups.get(&self.table_tag()).unwrap();
-        let lookups = lookups
+    fn build_constraints(&self, cb: &mut ConstraintBuilder<F, C>, q_start: Expression<F>) {
+        let condition = self
+            .local_conditions
             .iter()
-            .filter(|l| l.region_id == cb.region_id)
-            .collect::<Vec<_>>();
-        let condition = lookups
-            .iter()
-            .fold(0.expr(), |acc, c| acc + c.condition.expr());
+            .filter(|tc| tc.0 == cb.region_id)
+            .fold(0.expr(), |acc, tc| acc + tc.1.expr());
         crate::circuit!([meta, cb], {
-            ifx! {is_first_row => {
+            ifx! {q_start => {
                 require!(self.cur.expr() => 0);
             }}
             let description = format!("Dynamic lookup table {:?}", self.tag());
@@ -238,40 +269,33 @@ impl<F: Field, C: CellType> MemoryBank<F, C> {
         });
     }
 
-    pub(crate) fn assign(
-        &self,
-        region: &mut CachedRegion<'_, '_, F>,
-        height: usize,
-    ) -> Result<(), Error> {
+    fn witness_store(&mut self, offset: usize, values: &[F]) {
+        self.stored_values.push(values.to_vec());
+        self.store_offsets.push(offset);
+    }
+
+    fn witness_load(&self, offset: usize) -> Vec<F> {
+        self.stored_values[self.stored_values.len() - 1 - offset].clone()
+    }
+
+    fn assign(&mut self, region: &mut CachedRegion<'_, '_, F>, height: usize) -> Result<(), Error> {
         // Pad to the full circuit (necessary for reads)
         let mut store_offsets = self.store_offsets.clone();
         store_offsets.push(height);
 
-        // TODO(Brecht): partial updates
-        let mut offset = 0;
+        let mut offset = self.last_assigned_offset;
         for (store_index, &stored_offset) in store_offsets.iter().enumerate() {
             while offset <= stored_offset {
                 region.assign_advice(
                     || "assign memory index".to_string(),
-                    self.column,
+                    self.key,
                     offset,
                     || Value::known(F::from(store_index as u64)),
                 )?;
                 offset += 1;
             }
         }
+        self.last_assigned_offset = height;
         Ok(())
-    }
-
-    pub(crate) fn tag(&self) -> C {
-        self.tag
-    }
-
-    pub(crate) fn table_tag(&self) -> C {
-        self.table_tag
-    }
-
-    pub(crate) fn insert_key<V: Clone>(&self, key: V, values: &[V]) -> Vec<V> {
-        [vec![key], values.to_owned()].concat().to_vec()
     }
 }

--- a/zkevm-circuits/src/mpt_circuit.rs
+++ b/zkevm-circuits/src/mpt_circuit.rs
@@ -258,23 +258,23 @@ impl<F: Field> MPTConfig<F> {
         state_cm.add_columns(meta, &mut cb.base, lu(MptTableType::Mult), 2, false, 2);
 
         let mut memory = Memory::new();
-        memory.add_rw(meta, &mut cb.base, &mut state_cm, MptCellType::MemKeyC, 2);
-        memory.add_rw(meta, &mut cb.base, &mut state_cm, MptCellType::MemKeyS, 2);
-        memory.add_rw(
+        memory.add_memory_bank(meta, &mut cb.base, &mut state_cm, MptCellType::MemKeyC, 2);
+        memory.add_memory_bank(meta, &mut cb.base, &mut state_cm, MptCellType::MemKeyS, 2);
+        memory.add_memory_bank(
             meta,
             &mut cb.base,
             &mut state_cm,
             MptCellType::MemParentC,
             2,
         );
-        memory.add_rw(
+        memory.add_memory_bank(
             meta,
             &mut cb.base,
             &mut state_cm,
             MptCellType::MemParentS,
             2,
         );
-        memory.add_rw(meta, &mut cb.base, &mut state_cm, MptCellType::MemMain, 2);
+        memory.add_memory_bank(meta, &mut cb.base, &mut state_cm, MptCellType::MemMain, 2);
 
         let mut ctx = MPTContext {
             mpt_table,

--- a/zkevm-circuits/src/mpt_circuit/account_leaf.rs
+++ b/zkevm-circuits/src/mpt_circuit/account_leaf.rs
@@ -26,7 +26,7 @@ use crate::{
             KECCAK,
         },
         param::{KEY_LEN_IN_NIBBLES, RLP_LIST_LONG, RLP_LONG},
-        MPTConfig, MPTContext, MPTState, RlpItemType,
+        MPTConfig, MPTContext, MptMemory, RlpItemType,
     },
     table::MPTProofType,
     util::word::{self, Word},
@@ -56,13 +56,8 @@ impl<F: Field> AccountLeafConfig<F> {
     pub fn configure(
         meta: &mut VirtualCells<'_, F>,
         cb: &mut MPTConstraintBuilder<F>,
-        ctx: MPTContext<F>,
+        ctx: &mut MPTContext<F>,
     ) -> Self {
-        cb.base
-            .cell_manager
-            .as_mut()
-            .unwrap()
-            .reset(AccountRowType::Count as usize);
         let mut config = AccountLeafConfig::default();
 
         circuit!([meta, cb], {
@@ -136,12 +131,11 @@ impl<F: Field> AccountLeafConfig<F> {
                 meta,
                 cb,
                 AccountRowType::Address as usize,
-                RlpItemType::Value,
+                RlpItemType::Address,
             );
             let key_item = ctx.rlp_item(meta, cb, AccountRowType::Key as usize, RlpItemType::Hash);
 
-            config.main_data =
-                MainData::load("main storage", cb, &ctx.memory[main_memory()], 0.expr());
+            config.main_data = MainData::load(cb, &mut ctx.memory[main_memory()], 0.expr());
 
             // Don't allow an account node to follow an account node
             require!(config.main_data.is_below_account => false);
@@ -157,16 +151,11 @@ impl<F: Field> AccountLeafConfig<F> {
             for is_s in [true, false] {
                 // Key data
                 let key_data = &mut config.key_data[is_s.idx()];
-                *key_data = KeyData::load(cb, &ctx.memory[key_memory(is_s)], 0.expr());
+                *key_data = KeyData::load(cb, &mut ctx.memory[key_memory(is_s)], 0.expr());
 
                 // Parent data
                 let parent_data = &mut config.parent_data[is_s.idx()];
-                *parent_data = ParentData::load(
-                    "account load",
-                    cb,
-                    &ctx.memory[parent_memory(is_s)],
-                    0.expr(),
-                );
+                *parent_data = ParentData::load(cb, &mut ctx.memory[parent_memory(is_s)], 0.expr());
 
                 // Placeholder leaf checks
                 config.is_placeholder_leaf[is_s.idx()] =
@@ -239,7 +228,7 @@ impl<F: Field> AccountLeafConfig<F> {
                 // Check is skipped for placeholder leaves which are dummy leaves
                 ifx! {not!(and::expr(&[not!(parent_data.is_placeholder), config.is_placeholder_leaf[is_s.idx()].expr()])) => {
                     let hash = parent_data.hash.expr();
-                    require!(vec![1.expr(), leaf_rlc, rlp_key.rlp_list.num_bytes(), hash.lo(), hash.hi()] => @KECCAK);
+                    require!((1.expr(), leaf_rlc, rlp_key.rlp_list.num_bytes(), hash.lo(), hash.hi()) =>> @KECCAK);
                 }}
 
                 // Check the RLP encoding consistency.
@@ -260,11 +249,11 @@ impl<F: Field> AccountLeafConfig<F> {
                 require!(config.rlp_key[is_s.idx()].rlp_list.len() => config.rlp_key[is_s.idx()].key_value.num_bytes() + value_list_num_bytes[is_s.idx()].expr());
 
                 // Key done, set the starting values
-                KeyData::store_defaults(cb, &ctx.memory[key_memory(is_s)]);
+                KeyData::store_defaults(cb, &mut ctx.memory[key_memory(is_s)]);
                 // Store the new parent
                 ParentData::store(
                     cb,
-                    &ctx.memory[parent_memory(is_s)],
+                    &mut ctx.memory[parent_memory(is_s)],
                     storage_items[is_s.idx()].word(),
                     0.expr(),
                     true.expr(),
@@ -335,7 +324,7 @@ impl<F: Field> AccountLeafConfig<F> {
             // storage leaves unless it's also a non-existing proof?
             MainData::store(
                 cb,
-                &ctx.memory[main_memory()],
+                &mut ctx.memory[main_memory()],
                 [
                     config.main_data.proof_type.expr(),
                     true.expr(),
@@ -387,7 +376,7 @@ impl<F: Field> AccountLeafConfig<F> {
             }}
 
             // Put the data in the lookup table
-            let (proof_type, old_value_lo, old_value_hi, new_value_lo, new_value_hi) = _matchx! {cb,
+            let (proof_type, old_value_lo, old_value_hi, new_value_lo, new_value_hi) = _matchx! {cb, (
                 config.is_nonce_mod => (MPTProofType::NonceChanged.expr(), nonce[true.idx()].lo(), nonce[true.idx()].hi(), nonce[false.idx()].lo(), nonce[false.idx()].hi()),
                 config.is_balance_mod => (MPTProofType::BalanceChanged.expr(), balance[true.idx()].lo(), balance[true.idx()].hi(), balance[false.idx()].lo(), balance[false.idx()].hi()),
                 config.is_storage_mod => (MPTProofType::StorageChanged.expr(), storage[true.idx()].lo(), storage[true.idx()].hi(), storage[false.idx()].lo(), storage[false.idx()].hi()),
@@ -395,7 +384,7 @@ impl<F: Field> AccountLeafConfig<F> {
                 config.is_account_delete_mod => (MPTProofType::AccountDestructed.expr(), 0.expr(), 0.expr(), 0.expr(), 0.expr()),
                 config.is_non_existing_account_proof => (MPTProofType::AccountDoesNotExist.expr(), 0.expr(), 0.expr(), 0.expr(), 0.expr()),
                 _ => (MPTProofType::Disabled.expr(), 0.expr(), 0.expr(), 0.expr(), 0.expr()),
-            };
+            )};
             ifx! {not!(config.is_non_existing_account_proof) => {
                 let key_rlc = ifx!{not!(config.parent_data[true.idx()].is_placeholder) => {
                     key_rlc[true.idx()].expr()
@@ -407,7 +396,7 @@ impl<F: Field> AccountLeafConfig<F> {
                 // Check if the key is correct for the given address
                 if ctx.params.is_preimage_check_enabled() {
                     let key = key_item.word();
-                    require!(vec![1.expr(), address_item.bytes_le()[1..21].rlc(&cb.keccak_r), 20.expr(), key.lo(), key.hi()] => @KECCAK);
+                    require!((1.expr(), address_item.bytes_le()[1..21].rlc(&cb.keccak_r), 20.expr(), key.lo(), key.hi()) =>> @KECCAK);
                 }
             }};
             let to_hi = Expression::<F>::Constant(pow::value::<F>(256.scalar(), 16));
@@ -435,7 +424,7 @@ impl<F: Field> AccountLeafConfig<F> {
         &self,
         region: &mut CachedRegion<'_, '_, F>,
         mpt_config: &MPTConfig<F>,
-        pv: &mut MPTState<F>,
+        memory: &mut MptMemory<F>,
         offset: usize,
         node: &Node,
         rlp_values: &[RLPItemWitness],
@@ -469,7 +458,7 @@ impl<F: Field> AccountLeafConfig<F> {
 
         let main_data =
             self.main_data
-                .witness_load(region, offset, &pv.memory[main_memory()], 0)?;
+                .witness_load(region, offset, &mut memory[main_memory()], 0)?;
 
         // Key
         let mut key_rlc = vec![0.scalar(); 2];
@@ -497,14 +486,14 @@ impl<F: Field> AccountLeafConfig<F> {
             key_data[is_s.idx()] = self.key_data[is_s.idx()].witness_load(
                 region,
                 offset,
-                &pv.memory[key_memory(is_s)],
+                &mut memory[key_memory(is_s)],
                 0,
             )?;
 
             parent_data[is_s.idx()] = self.parent_data[is_s.idx()].witness_load(
                 region,
                 offset,
-                &pv.memory[parent_memory(is_s)],
+                &mut memory[parent_memory(is_s)],
                 0,
             )?;
 
@@ -538,7 +527,7 @@ impl<F: Field> AccountLeafConfig<F> {
             KeyData::witness_store(
                 region,
                 offset,
-                &mut pv.memory[key_memory(is_s)],
+                &mut memory[key_memory(is_s)],
                 F::ZERO,
                 F::ONE,
                 0,
@@ -549,7 +538,7 @@ impl<F: Field> AccountLeafConfig<F> {
             ParentData::witness_store(
                 region,
                 offset,
-                &mut pv.memory[parent_memory(is_s)],
+                &mut memory[parent_memory(is_s)],
                 storage_items[is_s.idx()].word(),
                 0.scalar(),
                 true,
@@ -625,7 +614,7 @@ impl<F: Field> AccountLeafConfig<F> {
         MainData::witness_store(
             region,
             offset,
-            &mut pv.memory[main_memory()],
+            &mut memory[main_memory()],
             main_data.proof_type,
             true,
             address,

--- a/zkevm-circuits/src/mpt_circuit/branch.rs
+++ b/zkevm-circuits/src/mpt_circuit/branch.rs
@@ -20,7 +20,7 @@ use crate::{
     mpt_circuit::{
         helpers::{nibble_rlc, Indexable, MptCellType, KECCAK},
         param::{HASH_WIDTH, RLP_NIL},
-        MPTConfig, MPTState, RlpItemType,
+        MPTConfig, MptMemory, RlpItemType,
     },
     util::word::{self, Word},
 };
@@ -197,7 +197,7 @@ impl<F: Field> BranchGadget<F> {
                     ifx!{or::expr(&[is_root[is_s.idx()].expr(), not!(is_not_hashed)]) => {
                         // Hashed branch hash in parent branch
                         let hash = &parent_hash[is_s.idx()];
-                        require!(vec![1.expr(), rlc.expr(), num_bytes, hash.lo(), hash.hi()] => @KECCAK);
+                        require!((1.expr(), rlc.expr(), num_bytes, hash.lo(), hash.hi()) =>> @KECCAK);
                     } elsex {
                         // Non-hashed branch hash in parent branch
                         require!(rlc => parent_rlc[is_s.idx()].expr());
@@ -290,7 +290,7 @@ impl<F: Field> BranchGadget<F> {
         &self,
         region: &mut CachedRegion<'_, '_, F>,
         _mpt_config: &MPTConfig<F>,
-        _pv: &mut MPTState<F>,
+        _memory: &mut MptMemory<F>,
         offset: usize,
         is_placeholder: &[bool; 2],
         key_rlc: &mut F,

--- a/zkevm-circuits/src/mpt_circuit/extension.rs
+++ b/zkevm-circuits/src/mpt_circuit/extension.rs
@@ -20,7 +20,7 @@ use crate::{
             ParentData, FIXED, KECCAK, MULT,
         },
         param::HASH_WIDTH,
-        FixedTableTag, MPTConfig, MPTState, RlpItemType,
+        FixedTableTag, MPTConfig, MptMemory, RlpItemType,
     },
     util::word::Word,
 };
@@ -92,12 +92,12 @@ impl<F: Field> ExtensionGadget<F> {
 
             config.rlp_key = ListKeyGadget::construct(cb, &key_items[0]);
             config.is_key_part_odd = cb.query_cell();
-            let first_byte = matchx! {
+            let first_byte = matchx! {(
                 key_items[true.idx()].is_short() => key_items[true.idx()].bytes_be()[0].expr(),
                 key_items[true.idx()].is_long() => key_items[true.idx()].bytes_be()[1].expr(),
                 key_items[true.idx()].is_very_long() => key_items[true.idx()].bytes_be()[2].expr(),
-            };
-            require!((FixedTableTag::ExtOddKey.expr(), first_byte, config.is_key_part_odd.expr()) => @FIXED);
+            )};
+            require!((FixedTableTag::ExtOddKey.expr(), first_byte, config.is_key_part_odd.expr()) =>> @FIXED);
 
             let mut branch_rlp_rlc = vec![0.expr(); 2];
             let mut branch_rlp_word = vec![Word::<Expression<F>>::new([0.expr(), 0.expr()]); 2];
@@ -137,7 +137,7 @@ impl<F: Field> ExtensionGadget<F> {
                 ifx! {not!(is_placeholder[is_s.idx()]) => {
                     ifx!{or::expr(&[parent_data[is_s.idx()].is_root.expr(), not!(is_not_hashed)]) => {
                         // Hashed branch hash in parent branch
-                        require!(vec![1.expr(), rlc.expr(), num_bytes.expr(), parent_data[is_s.idx()].hash.lo().expr(), parent_data[is_s.idx()].hash.hi().expr()] => @KECCAK);
+                        require!((1.expr(), rlc.expr(), num_bytes.expr(), parent_data[is_s.idx()].hash.lo().expr(), parent_data[is_s.idx()].hash.hi().expr()) =>> @KECCAK);
                     } elsex {
                         // Non-hashed branch hash in parent branch
                         require!(rlc => parent_data[is_s.idx()].rlc);
@@ -188,7 +188,7 @@ impl<F: Field> ExtensionGadget<F> {
                 - ifx! {not!(key_data.is_odd.expr() * config.is_key_part_odd.expr()) => { 1.expr() }};
             // Get the multiplier for this key length
             config.mult_key = cb.query_cell_with_type(MptCellType::StoragePhase2);
-            require!((key_num_bytes_for_mult, config.mult_key.expr()) => @MULT);
+            require!((key_num_bytes_for_mult, config.mult_key.expr()) =>> @MULT);
 
             // Store the post ext state
             config.post_state = Some(ExtState {
@@ -213,7 +213,7 @@ impl<F: Field> ExtensionGadget<F> {
         &self,
         region: &mut CachedRegion<'_, '_, F>,
         _mpt_config: &MPTConfig<F>,
-        _pv: &mut MPTState<F>,
+        _memory: &mut MptMemory<F>,
         offset: usize,
         key_data: &KeyDataWitness<F>,
         key_rlc: &mut F,

--- a/zkevm-circuits/src/mpt_circuit/param.rs
+++ b/zkevm-circuits/src/mpt_circuit/param.rs
@@ -1,7 +1,6 @@
 pub const ARITY: usize = 16;
-// Currently using 32 - each hash byte goes into its own cell, this might be
-// compressed for optimization purposes in the future.
-pub const HASH_WIDTH: usize = 32; // number of columns used for hash output
+pub const HASH_WIDTH: usize = 32;
+pub const ADDRESS_WIDTH: usize = 20;
 
 // Compact encoding key prefixes
 pub const KEY_PREFIX_EVEN: u8 = 0b0000_0000;

--- a/zkevm-circuits/src/mpt_circuit/rlp_gadgets.rs
+++ b/zkevm-circuits/src/mpt_circuit/rlp_gadgets.rs
@@ -83,14 +83,15 @@ impl<F: Field> RLPListGadget<F> {
             let is_very_long = cb.query_cell();
             let is_string = cb.query_cell();
 
-            require!(vec![
-                FixedTableTag::RLP.expr(),
-                bytes[0].expr(),
-                not!(is_string),
-                is_short.expr(),
-                is_long.expr(),
-                is_very_long.expr(),
-                ] => @FIXED
+            require!(
+                (
+                    FixedTableTag::RLP.expr(),
+                    bytes[0].expr(),
+                    not!(is_string),
+                    is_short.expr(),
+                    is_long.expr(),
+                    is_very_long.expr()
+                ) =>> @FIXED
             );
 
             RLPListGadget {
@@ -157,11 +158,11 @@ impl<F: Field> RLPListGadget<F> {
     /// Number of RLP bytes
     pub(crate) fn num_rlp_bytes(&self) -> Expression<F> {
         circuit!([meta, _cb!()], {
-            matchx! {
+            matchx! {(
                 self.is_short() => 1.expr(),
                 self.is_long() => 2.expr(),
                 self.is_very_long() => 3.expr(),
-            }
+            )}
         })
     }
 
@@ -173,11 +174,11 @@ impl<F: Field> RLPListGadget<F> {
     /// Returns the length of the list (excluding RLP bytes)
     pub(crate) fn len(&self) -> Expression<F> {
         circuit!([meta, _cb!()], {
-            matchx! {
+            matchx! {(
                 self.is_short() => get_len_list_short::expr(self.bytes[0].expr()),
                 self.is_long() => self.bytes[1].expr(),
                 self.is_very_long() => self.bytes[1].expr() * 256.expr() + self.bytes[2].expr(),
-            }
+            )}
         })
     }
 
@@ -194,21 +195,21 @@ impl<F: Field> RLPListGadget<F> {
     /// Returns the rlc of only the RLP bytes
     pub(crate) fn rlc_rlp_only(&self, r: &Expression<F>) -> (Expression<F>, Expression<F>) {
         circuit!([meta, _cb!()], {
-            matchx! {
+            matchx! {(
                 self.is_short() => (self.bytes[..1].rlc(r), pow::expr(r.expr(), 1)),
                 self.is_long() => (self.bytes[..2].rlc(r), pow::expr(r.expr(), 2)),
                 self.is_very_long() => (self.bytes[..3].rlc(r), pow::expr(r.expr(), 3)),
-            }
+            )}
         })
     }
 
     pub(crate) fn rlc_rlp_only_rev(&self, r: &Expression<F>) -> (Expression<F>, Expression<F>) {
         circuit!([meta, _cb!()], {
-            matchx! {
+            matchx! {(
                 self.is_short() => (self.bytes[..1].rlc_rev(r), pow::expr(r.expr(), 1)),
                 self.is_long() => (self.bytes[..2].rlc_rev(r), pow::expr(r.expr(), 2)),
                 self.is_very_long() => (self.bytes[..3].rlc_rev(r), pow::expr(r.expr(), 3)),
-            }
+            )}
         })
     }
 }
@@ -340,14 +341,15 @@ impl<F: Field> RLPValueGadget<F> {
             let is_very_long = cb.query_cell();
             let is_list = cb.query_cell();
 
-            require!(vec![
-                FixedTableTag::RLP.expr(),
-                bytes[0].expr(),
-                is_list.expr(),
-                is_short.expr(),
-                is_long.expr(),
-                is_very_long.expr(),
-                ] => @FIXED
+            require!(
+                (
+                    FixedTableTag::RLP.expr(),
+                    bytes[0].expr(),
+                    is_list.expr(),
+                    is_short.expr(),
+                    is_long.expr(),
+                    is_very_long.expr()
+                ) =>> @FIXED
             );
 
             RLPValueGadget {
@@ -415,39 +417,39 @@ impl<F: Field> RLPValueGadget<F> {
     /// Number of RLP bytes
     pub(crate) fn num_rlp_bytes(&self) -> Expression<F> {
         circuit!([meta, _cb!()], {
-            matchx! {
+            matchx! {(
                 self.is_short() => 0.expr(),
                 self.is_long() => 1.expr(),
                 self.is_very_long() => 2.expr(),
-            }
+            )}
         })
     }
 
     /// Number of bytes in total (including RLP bytes)
     pub(crate) fn num_bytes(&self) -> Expression<F> {
         circuit!([meta, _cb!()], {
-            matchx! {
+            matchx! {(
                 self.is_short() => 1.expr(),
                 self.is_long() => get_num_bytes_short::expr(self.bytes[0].expr()),
                 self.is_very_long() => {
                     unreachablex!();
                     0.expr()
                 },
-            }
+            )}
         })
     }
 
     /// Length of the value (excluding RLP bytes)
     pub(crate) fn len(&self) -> Expression<F> {
         circuit!([meta, _cb!()], {
-            matchx! {
+            matchx! {(
                 self.is_short() => 1.expr(),
                 self.is_long() => get_len_short::expr(self.bytes[0].expr()),
                 self.is_very_long() => {
                     unreachablex!();
                     0.expr()
                 },
-            }
+            )}
         })
     }
 
@@ -461,20 +463,20 @@ impl<F: Field> RLPValueGadget<F> {
 
     pub(crate) fn rlc_rlp_only_rev(&self, r: &Expression<F>) -> (Expression<F>, Expression<F>) {
         circuit!([meta, _cb!()], {
-            matchx! {
+            matchx! {(
                 self.is_short() => (self.bytes[..1].rlc_rev(r), pow::expr(r.expr(), 1)),
                 self.is_long() => (self.bytes[..1].rlc_rev(r), pow::expr(r.expr(), 1)),
                 self.is_very_long() => {
                     unreachablex!();
                     (0.expr(), 0.expr())
                 },
-            }
+            )}
         })
     }
 
     pub(crate) fn rlc_value(&self, r: &Expression<F>) -> Expression<F> {
         circuit!([meta, _cb!()], {
-            matchx! {
+            matchx! {(
                 self.is_short() => {
                     self.bytes[0].expr()
                 },
@@ -485,7 +487,7 @@ impl<F: Field> RLPValueGadget<F> {
                     unreachablex!();
                     0.expr()
                 },
-            }
+            )}
         })
     }
 }
@@ -687,30 +689,30 @@ impl<F: Field> RLPItemGadget<F> {
     // Single RLP byte containing the byte value
     pub(crate) fn is_short(&self) -> Expression<F> {
         circuit!([meta, _cb!()], {
-            matchx! {
+            matchx! {(
                 self.value.is_string() => self.value.is_short(),
                 self.list.is_list() => self.list.is_short(),
-            }
+            )}
         })
     }
 
     // Single RLP byte containing the length of the value
     pub(crate) fn is_long(&self) -> Expression<F> {
         circuit!([meta, _cb!()], {
-            matchx! {
+            matchx! {(
                 self.value.is_string() => self.value.is_long(),
                 self.list.is_list() => self.list.is_long(),
-            }
+            )}
         })
     }
 
     // Single RLP byte containing the length of the value
     pub(crate) fn is_long_at(&self, meta: &mut VirtualCells<F>, rot: usize) -> Expression<F> {
         circuit!([meta, _cb!()], {
-            matchx! {
+            matchx! {(
                 self.value.is_string() => self.value.is_long_at(meta, rot),
                 self.list.is_list() => self.list.is_long_at(meta, rot),
-            }
+            )}
         })
     }
 
@@ -718,51 +720,50 @@ impl<F: Field> RLPItemGadget<F> {
     // followed by the length, followed by the actual data
     pub(crate) fn is_very_long(&self) -> Expression<F> {
         circuit!([meta, _cb!()], {
-            matchx! {
+            matchx! {(
                 self.value.is_string() => self.value.is_very_long(),
                 self.list.is_list() => self.list.is_very_long(),
-            }
+            )}
         })
     }
 
     /// Number of RLP bytes
     pub(crate) fn num_rlp_bytes(&self) -> Expression<F> {
         circuit!([meta, _cb!()], {
-            matchx! {
+            matchx! {(
                 self.value.is_string() => self.value.num_rlp_bytes(),
                 self.list.is_list() => self.list.num_rlp_bytes(),
-            }
+            )}
         })
     }
 
     /// Number of bytes in total (including RLP bytes)
     pub(crate) fn num_bytes(&self) -> Expression<F> {
         circuit!([meta, _cb!()], {
-            matchx! {
+            matchx! {(
                 self.value.is_string() => self.value.num_bytes(),
                 self.list.is_list() => self.list.num_bytes(),
-            }
+            )}
         })
     }
 
     /// Length of the value (excluding RLP bytes)
     pub(crate) fn len(&self) -> Expression<F> {
         circuit!([meta, _cb!()], {
-            matchx! {
+            matchx! {(
                 self.value.is_string() => self.value.len(),
                 self.list.is_list() => self.list.len(),
-            }
+            )}
         })
     }
 
-    // Returns the RLC of the value if the RLP is a string,
     // returns the RLC of the full string if the RLP is a list.
     pub(crate) fn rlc_content(&self, r: &Expression<F>) -> Expression<F> {
         circuit!([meta, _cb!()], {
-            matchx! {
+            matchx! {(
                 self.value.is_string() => self.value.rlc_value(r),
                 self.list.is_list() => self.list.rlc_rlp(r),
-            }
+            )}
         })
     }
 }

--- a/zkevm-circuits/src/mpt_circuit/witness_row.rs
+++ b/zkevm-circuits/src/mpt_circuit/witness_row.rs
@@ -178,7 +178,7 @@ pub const NODE_RLP_TYPES_ACCOUNT: [RlpItemType; AccountRowType::Count as usize] 
     RlpItemType::Hash,
     RlpItemType::Key,
     RlpItemType::Key,
-    RlpItemType::Value,
+    RlpItemType::Address,
     RlpItemType::Hash,
 ];
 
@@ -190,6 +190,6 @@ pub const NODE_RLP_TYPES_STORAGE: [RlpItemType; StorageRowType::Count as usize] 
     RlpItemType::Value,
     RlpItemType::Key,
     RlpItemType::Key,
-    RlpItemType::Value,
+    RlpItemType::Hash,
     RlpItemType::Hash,
 ];


### PR DESCRIPTION
### Description

Some small improvements to the MPT circuit. Most notably:
- Added a check that the RLP encoding of the RLP values are minimal (no leading zeros) in the main RLP value decoding unit
- Fixed bug: byte lookups were not generated correctly
- Some other misc small improvements

### Issue Link

[_link issue here_]

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Contents

- [_item_]

### Rationale

[_design decisions and extended information_]

### How Has This Been Tested?

- All MPT tests run
- make test-all
