### PR TITLE
fix calldatalen in calldata{copy,load} for contract deployment

### DIFF
--- a/bus-mapping/src/circuit_input_builder/transaction.rs
+++ b/bus-mapping/src/circuit_input_builder/transaction.rs
@@ -241,7 +241,7 @@ impl Transaction {
                 code_hash,
                 depth: 1,
                 value: eth_tx.value,
-                call_data_length: eth_tx.input.len().try_into().unwrap(),
+                call_data_length: 0,
                 ..Default::default()
             }
         };

--- a/zkevm-circuits/src/evm_circuit/execution/calldatacopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldatacopy.rs
@@ -199,7 +199,14 @@ impl<F: Field> ExecutionGadget<F> for CallDataCopyGadget<F> {
 
         // Call data length and call data offset
         let (call_data_length, call_data_offset) = if call.is_root {
-            (tx.call_data.len() as u64, 0_u64)
+            (
+                if tx.is_create() {
+                    0
+                } else {
+                    tx.call_data.len() as u64
+                },
+                0_u64,
+            )
         } else {
             (call.call_data_length, call.call_data_offset)
         };

--- a/zkevm-circuits/src/evm_circuit/execution/calldataload.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldataload.rs
@@ -213,7 +213,15 @@ impl<F: Field> ExecutionGadget<F> for CallDataLoadGadget<F> {
 
         // Assign to the buffer reader gadget.
         let (src_id, call_data_offset, call_data_length) = if call.is_root {
-            (tx.id, 0, tx.call_data.len() as u64)
+            (
+                tx.id,
+                0,
+                if tx.is_create() {
+                    0
+                } else {
+                    tx.call_data.len() as u64
+                },
+            )
         } else {
             (
                 call.caller_id as u64,
@@ -249,7 +257,7 @@ impl<F: Field> ExecutionGadget<F> for CallDataLoadGadget<F> {
             for (i, byte) in calldata_bytes.iter_mut().enumerate() {
                 if call.is_root {
                     // Fetch from tx call data.
-                    if src_addr + (i as u64) < tx.call_data.len() as u64 {
+                    if src_addr + (i as u64) < call_data_length {
                         *byte = tx.call_data[src_addr as usize + i];
                     }
                 } else {


### PR DESCRIPTION
### Description

The 'calldata' for a call with Kind::Create/Ceate2, should always be empty. We handled this correctly for create/create2 opcode. But for tx.to == None deployment, it was wrong.  This PR fixes this problem.

### Issue Link

[_link issue here_]

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Contents

- [_item_]

### Rationale

[_design decisions and extended information_]

### How Has This Been Tested?

[_explanation_]

<hr>

## How to fill a PR description 

Please give a concise description of your PR.

The target readers could be future developers, reviewers, and auditors. By reading your description, they should easily understand the changes proposed in this pull request.

MUST: Reference the issue to resolve

### Single responsability

Is RECOMMENDED to create single responsibility commits, but not mandatory.

Anyway, you MUST enumerate the changes in a unitary way, e.g.

```
This PR contains:
- Cleanup of xxxx, yyyy
- Changed xxxx to yyyy in order to bla bla
- Added xxxx function to ...
- Refactored ....
```

### Design choices

RECOMMENDED to:
- What types of design choices did you face?
- What decisions you have made?
- Any valuable information that could help reviewers to think critically
