### PR TITLE
[Presentation] Rw offset debugging

### DIFF
--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -776,6 +776,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         // Otherwise, the rw depends on the condition. Bump only when the condition is true.
         self.rw_counter_offset =
             self.rw_counter_offset.clone() + self.condition_expr_opt().unwrap_or(1.expr());
+        log::debug!(target: "RWC","rwc {:?}  cond {:?}" , self.rw_counter_offset, self.condition_expr_opt());
     }
 
     fn reversible_write(

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -386,13 +386,9 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         query_expression(self.meta, f)
     }
 
+    /// Aggregate conditions by multiplying them together
     fn condition_expr_opt(&self) -> Option<Expression<F>> {
-        let mut iter = self.conditions.iter();
-        let first = match iter.next() {
-            Some(e) => e,
-            None => return None,
-        };
-        Some(iter.fold(first.clone(), |acc, e| acc * e.clone()))
+        self.conditions.iter().cloned().reduce(|acc, e| acc * e)
     }
 
     pub(crate) fn challenges(&self) -> &Challenges<Expression<F>> {

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -294,7 +294,14 @@ pub(crate) struct Constraints<F> {
 #[derive(Clone)]
 /// Track the rw_counter_offset
 struct RwCounterOffset<F> {
+    /// Normal counts are read-write expresisions that have no conditions. We can safely count them
+    /// in compilation time.
     normal: u64,
+    /// Special counts depend on proving time information. We count the number of expressions
+    /// instead of the number of reads and writes. The following expressions belongs to special
+    /// type:
+    /// - read-write expresisions that depend on conditions
+    /// - Variable size read-write like Copy table lookup
     special: u64,
     expr: Expression<F>,
 }


### PR DESCRIPTION
### Description

This PR is an attempt to address #1599. We add a debug log to see the read-write table counters in the constraints.

Unfortunately, the function is still quite limited. I would appreciate some advice on possible improvements.

### Issue Link

#1599

### Type of change

New feature (non-breaking change which adds functionality)

### Contents

- Add a debug log for rw_counter_offset

### Rationale

As @DreamWuGit mentioned in #1599, we'd like to get some insights on what variables affect the read-write counts. An example is `10.expr() - is_first_tx.expr() + coinbase_code_hash_is_zero.expr()`. Using the automatic approach, we abstract away the manual count with `cb.rw_counter_offset()`, but we also lost insight into the affecting variables.

Unlike the bus-mapping RW counter, where we can print the proving time information, the circuit constraints encode possible computation paths in expressions. However, printing expressions is not a good way to solve the problem. Expressions look very messy in the debug message, and it's hard to gain insight from it because it shows only the cell position but not the variable's name. 

We try to separate certain counts and uncertain counts. Expressions that don't depend on proving time conditions can be counted surely. Expressions that have conditions or varying reads writes are categorized in the special counts.

Some other quick problems I see.

- Lack of the call id information
- It's hard to see if some lookups are reads or writes, although they have certain READ/WRITE on setup time. When we use `true.expr()` or `false.expr()` to give the is_write information, that information gets buried in `Expression`. 


### How Has This Been Tested?

Run any test with `RUST_LOG="RWC=debug"`
```
RUST_LOG="RWC=debug" cargo test -p zkevm-circuits evm_circuit::execution::callop::test::callop_simple
```

```
[2023-09-14T16:58:12Z DEBUG RWC] RW count 0 + special 0  bump for Stack lookup
[2023-09-14T16:58:12Z DEBUG RWC] RW count 1 + special 0  bump for Stack lookup
[2023-09-14T16:58:12Z DEBUG RWC] RW count 2 + special 0  bump for Stack lookup
[2023-09-14T16:58:12Z DEBUG RWC] RW count 3 + special 0  bump for CallContext lookup
[2023-09-14T16:58:12Z DEBUG RWC] RW count 4 + special 0  bump for CallContext lookup
[2023-09-14T16:58:12Z DEBUG RWC] RW count 5 + special 0  bump for CallContext lookup
[2023-09-14T16:58:12Z DEBUG RWC] RW count 6 + special 0  bump for CallContext lookup
[2023-09-14T16:58:12Z DEBUG RWC] RW count 7 + special 0  bump for CallContext lookup
[2023-09-14T16:58:12Z DEBUG RWC] RW count 8 + special 0  bump for CallContext lookup
[2023-09-14T16:58:12Z DEBUG RWC] RW count 9 + special 0  bump for CallContext lookup
[2023-09-14T16:58:12Z DEBUG RWC] RW count 10 + special 0  bump for CallContext lookup
[2023-09-14T16:58:12Z DEBUG RWC] RW count 11 + special 0  bump for CallContext lookup
[2023-09-14T16:58:12Z DEBUG RWC] RW count 12 + special 0  bump for CallContext lookup
[2023-09-14T16:58:12Z DEBUG RWC] RW count 13 + special 0  bump for CallContext lookup
[2023-09-14T16:58:12Z DEBUG RWC] RW count 14 + special 0  bump for CallContext lookup
[2023-09-14T16:58:12Z DEBUG RWC] RW count 15 + special 0  bump for CallContext lookup
[2023-09-14T16:58:12Z DEBUG RWC] RW count 16 + special 0  bump for CallContext lookup
[2023-09-14T16:58:12Z DEBUG RWC] RW count 17 + special 0  bump for CallContext lookup
[2023-09-14T16:58:12Z DEBUG RWC] RW count 0 + special 0  bump for Stack lookup
[2023-09-14T16:58:12Z DEBUG RWC] RW count 1 + special 0  bump for Stack lookup
[2023-09-14T16:58:12Z DEBUG RWC] RW count 2 + special 0  bump for Stack lookup
[2023-09-14T16:58:12Z DEBUG RWC] RW count 3 + special 0  bump for CallContext lookup
[2023-09-14T16:58:12Z DEBUG RWC] RW count 4 + special 0  bump for CallContext lookup
[2023-09-14T16:58:12Z DEBUG RWC] RW count 5 + special 0  bump for CallContext lookup
[2023-09-14T16:58:12Z DEBUG RWC] RW count 6 + special 0  bump for CallContext lookup
[2023-09-14T16:58:12Z DEBUG RWC] RW count 7 + special 0  bump for CallContext lookup
[2023-09-14T16:58:12Z DEBUG RWC] RW count 8 + special 0  bump for CallContext lookup
[2023-09-14T16:58:12Z DEBUG RWC] RW count 9 + special 0  bump for CallContext lookup
[2023-09-14T16:58:12Z DEBUG RWC] RW count 10 + special 0  bump for CallContext lookup
[2023-09-14T16:58:12Z DEBUG RWC] RW count 11 + special 0  bump for CallContext lookup
[2023-09-14T16:58:12Z DEBUG RWC] RW count 12 + special 0  bump for CallContext lookup
[2023-09-14T16:58:12Z DEBUG RWC] RW count 13 + special 0  bump for CallContext lookup
[2023-09-14T16:58:12Z DEBUG RWC] RW count 14 + special 0  bump for CallContext lookup
[2023-09-14T16:58:12Z DEBUG RWC] RW count 15 + special 0  bump for CallContext lookup
[2023-09-14T16:58:12Z DEBUG RWC] RW count 16 + special 0  bump for CallContext lookup
[2023-09-14T16:58:12Z DEBUG RWC] RW count 17 + special 0  bump for CallContext lookup
```
