### PR TITLE
fix: parse "TLOAD/TSTORE" correctly in trace

### DIFF
--- a/eth-types/src/evm_types/opcode_ids.rs
+++ b/eth-types/src/evm_types/opcode_ids.rs
@@ -1206,6 +1206,8 @@ impl FromStr for OpcodeId {
             "SELFDESTRUCT" => OpcodeId::SELFDESTRUCT,
             "CHAINID" => OpcodeId::CHAINID,
             "BASEFEE" => OpcodeId::BASEFEE,
+            "TLOAD" => OpcodeId::INVALID(0xb3),
+            "TSTORE" => OpcodeId::INVALID(0xb4),
             _ => {
                 // Parse an invalid opcode value as reported by geth
                 lazy_static! {


### PR DESCRIPTION
### Description

0xb3 / 0xb4 are rendered as "TLOAD/TSTORE" in geth trace json.

### Issue Link

[_link issue here_]

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
