### PR TITLE
Address various testool issues

### DIFF
--- a/testool/Config.toml
+++ b/testool/Config.toml
@@ -16,7 +16,12 @@ paths = [
     "EIP1559",
     "EIP2930",
     "stPreCompiledContracts",
-    "stZeroKnowledge"
+    "stZeroKnowledge",
+    "DelegatecallToPrecompile",
+    "RevertPrecompiledTouchExactOOG",
+    "StaticcallToPrecompileFrom",
+    "create_callprecompile_returndatasize_d0_g0_v0",
+    "extCodeHashPrecompiles",
 ]
 
 [[skip_paths]]

--- a/testool/src/utils.rs
+++ b/testool/src/utils.rs
@@ -25,7 +25,7 @@ pub enum MainnetFork {
     Frontier = 1,
 }
 
-pub const TEST_FORK: MainnetFork = MainnetFork::Merge;
+pub const TEST_FORK: MainnetFork = MainnetFork::Shanghai;
 
 impl FromStr for MainnetFork {
     type Err = anyhow::Error;


### PR DESCRIPTION
### Description

- [x] `SkipTestDifficulty` and `SkipTestBalanceOverflow` should not be ignored.
- [ ] `creationTxInitCodeSizeLimit_d1(invalid)_g0_v0` should be parsed as exception and return ok.
- [x]  skip precompile tests
- [x] Use shanghai fork

Not addressed

- Fix "circuit was not satisfied"

### Issue Link

#1622

### Type of change

Bug fix (non-breaking change which fixes an issue)

