### PR TITLE
Remove minimal_rows in the Bytecode circuit

### DIFF
--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -70,7 +70,10 @@ pub struct FixedCParams {
     pub max_keccak_rows: usize,
 }
 
-/// Unset Circuits Parameters, computed dynamically together with circuit witness generation.
+/// Unset Circuits Parameters
+///
+/// To reduce the testing overhead, we determine the parameters by the testing inputs.
+/// A new [`FixedCParams`] will be computed from the generated circuit witness.
 #[derive(Debug, Clone, Copy)]
 pub struct DynamicCParams {}
 

--- a/circuit-benchmarks/src/bytecode_circuit.rs
+++ b/circuit-benchmarks/src/bytecode_circuit.rs
@@ -47,10 +47,8 @@ mod tests {
         let bytecodes_num: usize = max_bytecode_row_num / bytecode_len;
 
         // Create the circuit
-        let bytecode_circuit = TestBytecodeCircuit::<Fr>::new(
-            fillup_codebytes(bytecodes_num, bytecode_len),
-            2usize.pow(degree),
-        );
+        let bytecode_circuit =
+            TestBytecodeCircuit::<Fr>::new(fillup_codebytes(bytecodes_num, bytecode_len), degree);
 
         // Initialize the polynomial commitment parameters
         let mut rng = XorShiftRng::from_seed([

--- a/circuit-benchmarks/src/bytecode_circuit.rs
+++ b/circuit-benchmarks/src/bytecode_circuit.rs
@@ -47,8 +47,10 @@ mod tests {
         let bytecodes_num: usize = max_bytecode_row_num / bytecode_len;
 
         // Create the circuit
-        let bytecode_circuit =
-            TestBytecodeCircuit::<Fr>::new(fillup_codebytes(bytecodes_num, bytecode_len), degree);
+        let bytecode_circuit = TestBytecodeCircuit::<Fr>::new(
+            fillup_codebytes(bytecodes_num, bytecode_len),
+            2usize.pow(degree),
+        );
 
         // Initialize the polynomial commitment parameters
         let mut rng = XorShiftRng::from_seed([

--- a/zkevm-circuits/src/bytecode_circuit/test.rs
+++ b/zkevm-circuits/src/bytecode_circuit/test.rs
@@ -1,5 +1,5 @@
 use super::{BytecodeCircuit, BytecodeCircuitRow};
-use crate::util::{unusable_rows, SubCircuit};
+use crate::util::{log2_ceil, unusable_rows, SubCircuit};
 use bus_mapping::{evm::OpcodeId, state_db::CodeDB};
 use eth_types::Field;
 use halo2_proofs::{arithmetic::Field as Halo2Field, dev::MockProver, halo2curves::bn256::Fr};
@@ -20,11 +20,11 @@ impl<F: Field> BytecodeCircuit<F> {
     }
 
     fn from_bytes(bytecodes: impl Into<CodeDB>, k: u32) -> Self {
-        Self::new(bytecodes.into(), k)
+        Self::new(bytecodes.into(), 2usize.pow(k))
     }
 
     fn verify(&self, success: bool) {
-        let prover = MockProver::<F>::run(self.degree, self, Vec::new()).unwrap();
+        let prover = MockProver::<F>::run(log2_ceil(self.max_rows), self, Vec::new()).unwrap();
         let result = prover.verify_par();
         if success {
             if let Err(failures) = &result {

--- a/zkevm-circuits/src/bytecode_circuit/test.rs
+++ b/zkevm-circuits/src/bytecode_circuit/test.rs
@@ -1,5 +1,5 @@
 use super::{BytecodeCircuit, BytecodeCircuitRow};
-use crate::util::{log2_ceil, unusable_rows, SubCircuit};
+use crate::util::{unusable_rows, SubCircuit};
 use bus_mapping::{evm::OpcodeId, state_db::CodeDB};
 use eth_types::Field;
 use halo2_proofs::{arithmetic::Field as Halo2Field, dev::MockProver, halo2curves::bn256::Fr};
@@ -20,11 +20,11 @@ impl<F: Field> BytecodeCircuit<F> {
     }
 
     fn from_bytes(bytecodes: impl Into<CodeDB>, k: u32) -> Self {
-        Self::new(bytecodes.into(), 2usize.pow(k))
+        Self::new(bytecodes.into(), k)
     }
 
     fn verify(&self, success: bool) {
-        let prover = MockProver::<F>::run(log2_ceil(self.size), self, Vec::new()).unwrap();
+        let prover = MockProver::<F>::run(self.degree, self, Vec::new()).unwrap();
         let result = prover.verify_par();
         if success {
             if let Err(failures) = &result {

--- a/zkevm-circuits/src/bytecode_circuit/test.rs
+++ b/zkevm-circuits/src/bytecode_circuit/test.rs
@@ -20,7 +20,7 @@ impl<F: Field> BytecodeCircuit<F> {
     }
 
     fn from_bytes(bytecodes: impl Into<CodeDB>, k: u32) -> Self {
-        Self::new(bytecodes.into(), 2usize.pow(k))
+        Self::new(bytecodes.into(), 2usize.pow(k) - Self::unusable_rows())
     }
 
     fn verify(&self, success: bool) {


### PR DESCRIPTION
### Description

- Remove minimal_rows 
- Configure the bytecode circuit with the circuit degree instead of size.

### Issue Link

#1607

### Type of change

[x] Bug fix (non-breaking change which fixes an issue)

### Note

Please review this after #1632 is merged.
