### PR TITLE
Fix circuit failure output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4682,6 +4682,7 @@ dependencies = [
  "snark-verifier",
  "strum",
  "strum_macros",
+ "thiserror",
 ]
 
 [[package]]

--- a/testool/src/statetest/executor.rs
+++ b/testool/src/statetest/executor.rs
@@ -334,7 +334,7 @@ pub fn run_test(
             zkevm_circuits::evm_circuit::witness::block_convert(&builder).unwrap();
 
         CircuitTestBuilder::<1, 1>::new_from_block(block)
-            .run()
+            .run_with_result()
             .map_err(|err| match err {
                 CircuitTestError::VerificationFailed { reasons, .. } => {
                     StateTestError::CircuitUnsatisfied {

--- a/testool/src/statetest/executor.rs
+++ b/testool/src/statetest/executor.rs
@@ -14,7 +14,11 @@ use external_tracer::TraceConfig;
 use halo2_proofs::{dev::MockProver, halo2curves::bn256::Fr};
 use std::{collections::HashMap, str::FromStr};
 use thiserror::Error;
-use zkevm_circuits::{super_circuit::SuperCircuit, test_util::CircuitTestBuilder, witness::Block};
+use zkevm_circuits::{
+    super_circuit::SuperCircuit,
+    test_util::{CircuitTestBuilder, CircuitTestError},
+    witness::Block,
+};
 
 #[derive(PartialEq, Eq, Error, Debug)]
 pub enum StateTestError {
@@ -329,7 +333,20 @@ pub fn run_test(
         let block: Block<Fr> =
             zkevm_circuits::evm_circuit::witness::block_convert(&builder).unwrap();
 
-        CircuitTestBuilder::<1, 1>::new_from_block(block).run();
+        CircuitTestBuilder::<1, 1>::new_from_block(block)
+            .run()
+            .map_err(|err| match err {
+                CircuitTestError::VerificationFailed { reasons, .. } => {
+                    StateTestError::CircuitUnsatisfied {
+                        num_failure: reasons.len(),
+                        first_failure: reasons[0].to_string(),
+                    }
+                }
+                err => StateTestError::Exception {
+                    expected: false,
+                    found: err.to_string(),
+                },
+            })?;
     } else {
         geth_data.sign(&wallets);
 

--- a/zkevm-circuits/Cargo.toml
+++ b/zkevm-circuits/Cargo.toml
@@ -38,6 +38,7 @@ cli-table = { version = "0.4", optional = true }
 num_enum = "0.5.7"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.78"
+thiserror = "1.0"
 
 [dev-dependencies]
 bus-mapping = { path = "../bus-mapping", features = ["test"] }

--- a/zkevm-circuits/src/evm_circuit/execution/addmod.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/addmod.rs
@@ -228,7 +228,7 @@ impl<F: Field> ExecutionGadget<F> for AddModGadget<F> {
 
 #[cfg(test)]
 mod test {
-    use crate::test_util::{CircuitTestBuilder, CircuitTestError};
+    use crate::test_util::CircuitTestBuilder;
     use eth_types::{bytecode, evm_types::Stack, Word};
     use mock::TestContext;
 
@@ -252,8 +252,7 @@ mod test {
                 .unwrap();
             last.stack = Stack::from_vec(vec![r]);
         }
-        let mut ctb = CircuitTestBuilder::new_from_test_ctx(ctx);
-        let result = ctb.run();
+        let result = CircuitTestBuilder::new_from_test_ctx(ctx).run_with_result();
         if ok {
             assert!(result.is_ok());
         } else {

--- a/zkevm-circuits/src/evm_circuit/execution/gas.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/gas.rs
@@ -147,11 +147,8 @@ mod test {
                 assert_eq!(block.txs[0].steps().len(), 4);
                 block.txs[0].steps_mut()[2].gas_left -= 1;
             }))
-            .evm_checks(Box::new(|prover, gate_rows, lookup_rows| {
-                assert!(prover
-                    .verify_at_rows_par(gate_rows.iter().cloned(), lookup_rows.iter().cloned())
-                    .is_err())
-            }))
-            .run();
+            .run()
+            .unwrap_err()
+            .assert_evm_failure()
     }
 }

--- a/zkevm-circuits/src/evm_circuit/execution/gas.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/gas.rs
@@ -147,7 +147,7 @@ mod test {
                 assert_eq!(block.txs[0].steps().len(), 4);
                 block.txs[0].steps_mut()[2].gas_left -= 1;
             }))
-            .run()
+            .run_with_result()
             .unwrap_err()
             .assert_evm_failure()
     }

--- a/zkevm-circuits/src/evm_circuit/execution/mulmod.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/mulmod.rs
@@ -189,8 +189,7 @@ mod test {
             last.stack = Stack::from_vec(vec![r]);
         }
 
-        let mut ctb = CircuitTestBuilder::new_from_test_ctx(ctx);
-        let result = ctb.run();
+        let result = CircuitTestBuilder::new_from_test_ctx(ctx).run_with_result();
         if ok {
             assert!(result.is_ok())
         } else {

--- a/zkevm-circuits/src/evm_circuit/execution/mulmod.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/mulmod.rs
@@ -190,14 +190,12 @@ mod test {
         }
 
         let mut ctb = CircuitTestBuilder::new_from_test_ctx(ctx);
-        if !ok {
-            ctb = ctb.evm_checks(Box::new(|prover, gate_rows, lookup_rows| {
-                assert!(prover
-                    .verify_at_rows_par(gate_rows.iter().cloned(), lookup_rows.iter().cloned())
-                    .is_err())
-            }));
-        };
-        ctb.run()
+        let result = ctb.run();
+        if ok {
+            assert!(result.is_ok())
+        } else {
+            result.unwrap_err().assert_evm_failure()
+        }
     }
 
     fn test_ok_u32(a: u32, b: u32, n: u32, r: Option<u32>) {

--- a/zkevm-circuits/src/test_util.rs
+++ b/zkevm-circuits/src/test_util.rs
@@ -216,8 +216,8 @@ impl<const NACC: usize, const NTX: usize> CircuitTestBuilder<NACC, NTX> {
     fn run_state_circuit_test(&self, block: Block<Fr>) {
         let rows_needed = StateCircuit::<Fr>::min_num_rows_block(&block).1;
         let k = cmp::max(log2_ceil(rows_needed + NUM_BLINDING_ROWS), 18);
-        let params = block.circuits_params;
-        let state_circuit = StateCircuit::<Fr>::new(block.rws, params.max_rws);
+        let max_rws = block.circuits_params.max_rws;
+        let state_circuit = StateCircuit::<Fr>::new(block.rws, max_rws);
         let instance = state_circuit.instance();
         let prover = MockProver::<Fr>::run(k, &state_circuit, instance).unwrap();
         // Skip verification of Start rows to accelerate testing
@@ -226,7 +226,7 @@ impl<const NACC: usize, const NTX: usize> CircuitTestBuilder<NACC, NTX> {
             .iter()
             .filter(|rw| !matches!(rw, Rw::Start { .. }))
             .count();
-        let rows = (params.max_rws - non_start_rows_len..params.max_rws).collect();
+        let rows = (max_rws - non_start_rows_len..max_rws).collect();
 
         self.state_checks.as_ref()(prover, &rows, &rows);
     }

--- a/zkevm-circuits/src/test_util.rs
+++ b/zkevm-circuits/src/test_util.rs
@@ -223,11 +223,16 @@ impl<const NACC: usize, const NTX: usize> CircuitTestBuilder<NACC, NTX> {
     /// Triggers the `CircuitTestBuilder` to convert the [`TestContext`] if any,
     /// into a [`Block`] and apply the default or provided block_modifiers or
     /// circuit checks to the provers generated for the State and EVM circuits.
-    pub fn run(self) -> Result<(), CircuitTestError> {
+    pub fn run_with_result(self) -> Result<(), CircuitTestError> {
         let block = self.build_block()?;
 
         self.run_evm_circuit_test(block.clone())?;
         self.run_state_circuit_test(block)
+    }
+
+    /// Convenient method to run in test cases that error handling is not required.
+    pub fn run(self) {
+        self.run_with_result().unwrap()
     }
 }
 

--- a/zkevm-circuits/src/test_util.rs
+++ b/zkevm-circuits/src/test_util.rs
@@ -153,15 +153,15 @@ impl<const NACC: usize, const NTX: usize> CircuitTestBuilder<NACC, NTX> {
         let block = self
             .test_ctx
             .as_ref()
-            .ok_or(CircuitTestError::NoBlockSpecified)?;
+            .ok_or(CircuitTestError::NotEnoughAttributes)?;
         let block: GethData = block.clone().into();
         let builder = BlockData::new_from_geth_data(block.clone()).new_circuit_input_builder();
         let builder = builder
             .handle_block(&block.eth_block, &block.geth_traces)
-            .map_err(|err| CircuitTestError::CanNotHandleBlock(err.to_string()))?;
+            .map_err(|err| CircuitTestError::CannotHandleBlock(err.to_string()))?;
         // Build a witness block from trace result.
         let mut block = crate::witness::block_convert(&builder)
-            .map_err(|err| CircuitTestError::CanNotConvertBlock(err.to_string()))?;
+            .map_err(|err| CircuitTestError::CannotConvertBlock(err.to_string()))?;
 
         for modifier_fn in &self.block_modifiers {
             modifier_fn.as_ref()(&mut block);
@@ -249,14 +249,14 @@ pub enum Circuit {
 /// Errors for Circuit test
 pub enum CircuitTestError {
     /// We didn't specify enough attibutes to define a block for the circuit test
-    #[error("NoBlockSpecified")]
-    NoBlockSpecified,
+    #[error("NotEnoughAttributes")]
+    NotEnoughAttributes,
     /// Something wrong in the handle_block
-    #[error("CanNotHandleBlock({0})")]
-    CanNotHandleBlock(String),
+    #[error("CannotHandleBlock({0})")]
+    CannotHandleBlock(String),
     /// Something worng in the block_convert
-    #[error("CanNotConvertBlock({0})")]
-    CanNotConvertBlock(String),
+    #[error("CannotConvertBlock({0})")]
+    CannotConvertBlock(String),
     /// Problem constructing MockProver
     #[error("SynthesisFailure({circuit:?}, reason: {reason:?})")]
     SynthesisFailure {

--- a/zkevm-circuits/src/test_util.rs
+++ b/zkevm-circuits/src/test_util.rs
@@ -290,7 +290,7 @@ impl CircuitTestError {
                     VerifyFailure::ConstraintNotSatisfied { .. } | VerifyFailure::Lookup { .. }
                 )));
             }
-            _ => panic!("Not a EVM circuit failure {}", self.to_string()),
+            _ => panic!("Not a EVM circuit failure {self:?}"),
         }
     }
 }

--- a/zkevm-circuits/src/test_util.rs
+++ b/zkevm-circuits/src/test_util.rs
@@ -181,10 +181,10 @@ impl<const NACC: usize, const NTX: usize> CircuitTestBuilder<NACC, NTX> {
     /// into a [`Block`] and apply the default or provided block_modifiers or
     /// circuit checks to the provers generated for the State and EVM circuits.
     pub fn run(self) {
-        let block: Block<Fr> = if self.block.is_some() {
-            self.block.unwrap()
-        } else if self.test_ctx.is_some() {
-            let block: GethData = self.test_ctx.unwrap().into();
+        let block = if let Some(block) = self.block {
+            block
+        } else if let Some(block) = self.test_ctx {
+            let block: GethData = block.into();
             let builder = BlockData::new_from_geth_data(block.clone()).new_circuit_input_builder();
             let builder = builder
                 .handle_block(&block.eth_block, &block.geth_traces)


### PR DESCRIPTION
### Description

1. Capture the error detail of the unsatisfied circuit from CircuitTestBuilder 
2. Split the body of CircuitTestBuilder::run() into 3 methods for readability.
3. Revamp the error handling in CircuitTestBuilder

### Issue Link

#1637  

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)



### Design choices

The error handling has been a pain point for us for a long time. 
The design of error handling in this PR is heavily inspired by [this blog post](https://mmapped.blog/posts/12-rust-error-handling.html).

