### PR TITLE
Add precompile contracts' addresses to the access list

### DIFF
--- a/bus-mapping/src/evm/opcodes/begin_end_tx.rs
+++ b/bus-mapping/src/evm/opcodes/begin_end_tx.rs
@@ -60,6 +60,19 @@ fn gen_begin_tx_steps(state: &mut CircuitInputStateRef) -> Result<ExecStep, Erro
         false,
     )?;
 
+    // Add precompile contract address to access list
+    for address in 1..=9 {
+        let address = eth_types::Address::from_low_u64_be(address);
+        let is_warm_prev = !state.sdb.add_account_to_access_list(address);
+        state.tx_accesslist_account_write(
+            &mut exec_step,
+            state.tx_ctx.id(),
+            address,
+            true,
+            is_warm_prev,
+        )?;
+    }
+
     // Add caller, callee and coinbase (for EIP-3651) to access list.
     for address in [call.caller_address, call.address, state.block.coinbase] {
         let is_warm_prev = !state.sdb.add_account_to_access_list(address);

--- a/bus-mapping/src/evm/opcodes/begin_end_tx.rs
+++ b/bus-mapping/src/evm/opcodes/begin_end_tx.rs
@@ -6,12 +6,10 @@ use crate::{
     Error,
 };
 use eth_types::{
-    evm_types::{GasCost, MAX_REFUND_QUOTIENT_OF_GAS_USED},
+    evm_types::{GasCost, MAX_REFUND_QUOTIENT_OF_GAS_USED, PRECOMPILE_COUNT},
     evm_unimplemented, ToWord, Word,
 };
 use ethers_core::utils::get_contract_address;
-
-const PRECOMPILE_COUNT: u64 = 9;
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct BeginEndTx;

--- a/bus-mapping/src/evm/opcodes/begin_end_tx.rs
+++ b/bus-mapping/src/evm/opcodes/begin_end_tx.rs
@@ -11,6 +11,8 @@ use eth_types::{
 };
 use ethers_core::utils::get_contract_address;
 
+const PRECOMPILE_COUNT: u64 = 9;
+
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct BeginEndTx;
 
@@ -61,7 +63,7 @@ fn gen_begin_tx_steps(state: &mut CircuitInputStateRef) -> Result<ExecStep, Erro
     )?;
 
     // Add precompile contract address to access list
-    for address in 1..=9 {
+    for address in 1..=PRECOMPILE_COUNT {
         let address = eth_types::Address::from_low_u64_be(address);
         let is_warm_prev = !state.sdb.add_account_to_access_list(address);
         state.tx_accesslist_account_write(

--- a/eth-types/src/evm_types.rs
+++ b/eth-types/src/evm_types.rs
@@ -127,3 +127,6 @@ impl GasCost {
     /// it from 10 to 50.
     pub const EXP_BYTE_TIMES: u64 = 50;
 }
+
+/// This constant is used to iterate through precompile contract addresses 0x01 to 0x09
+pub const PRECOMPILE_COUNT: u64 = 9;

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -28,13 +28,14 @@ use crate::{
     },
 };
 use bus_mapping::state_db::CodeDB;
-use eth_types::{evm_types::GasCost, keccak256, Field, ToWord, U256};
+use eth_types::{
+    evm_types::{GasCost, PRECOMPILE_COUNT},
+    keccak256, Field, ToWord, U256,
+};
 use halo2_proofs::{
     circuit::Value,
     plonk::{Error, Expression},
 };
-
-const PRECOMPILE_COUNT: usize = 9;
 
 #[derive(Clone, Debug)]
 pub(crate) struct BeginTxGadget<F> {
@@ -533,7 +534,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
         let mut rws = StepRws::new(block, step);
         rws.offset_add(7);
 
-        rws.offset_add(PRECOMPILE_COUNT);
+        rws.offset_add(PRECOMPILE_COUNT as usize);
 
         let is_coinbase_warm = rws.next().tx_access_list_value_pair().1;
         let mut callee_code_hash = zero;

--- a/zkevm-circuits/src/evm_circuit/util.rs
+++ b/zkevm-circuits/src/evm_circuit/util.rs
@@ -475,7 +475,7 @@ impl<'a> StepRws<'a> {
     }
     /// Increment the step rw operation offset by `offset`.
     pub(crate) fn offset_add(&mut self, offset: usize) {
-        self.offset = offset
+        self.offset += offset
     }
     /// Return the next rw operation from the step.
     pub(crate) fn next(&mut self) -> Rw {

--- a/zkevm-circuits/src/evm_circuit/util.rs
+++ b/zkevm-circuits/src/evm_circuit/util.rs
@@ -473,9 +473,9 @@ impl<'a> StepRws<'a> {
             offset: 0,
         }
     }
-    /// Increment the step rw operation offset by `offset`.
-    pub(crate) fn offset_add(&mut self, offset: usize) {
-        self.offset += offset
+    /// Increment the step rw operation offset by `inc`.
+    pub(crate) fn offset_add(&mut self, inc: usize) {
+        self.offset += inc
     }
     /// Return the next rw operation from the step.
     pub(crate) fn next(&mut self) -> Rw {

--- a/zkevm-circuits/src/witness/block.rs
+++ b/zkevm-circuits/src/witness/block.rs
@@ -63,7 +63,7 @@ impl<F: Field> Block<F> {
                 println!("> Step {:?}", step.exec_state);
                 for rw_idx in 0..step.bus_mapping_instance.len() {
                     let rw = self.get_rws(step, rw_idx);
-                    let rw_str = if rw.is_write() { "READ" } else { "WRIT" };
+                    let rw_str = if rw.is_write() { "WRIT" } else { "READ" };
                     println!("  {} {} {:?}", rw.rw_counter(), rw_str, rw);
                 }
             }


### PR DESCRIPTION
### Description

We upstream scroll's precompile handling in bus mapping so that the EVM circuit warms the precompile addresses at the beginning of the transaction.

### Issue Link

#1626

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Content

- Warm precompile addresses
- Fix some minor issues in StepRws offset and the Rws debugging messages.
