### PR TITLE
fix soundness: block_table tag/index should be fixed column

### DIFF
--- a/zkevm-circuits/src/table/block_table.rs
+++ b/zkevm-circuits/src/table/block_table.rs
@@ -1,3 +1,5 @@
+use std::iter;
+
 use super::*;
 
 /// Tag to identify the field in a Block Table row
@@ -30,9 +32,9 @@ impl_expr!(BlockContextFieldTag);
 #[derive(Clone, Debug)]
 pub struct BlockTable {
     /// Tag
-    pub tag: Column<Advice>,
+    pub tag: Column<Fixed>,
     /// Index
-    pub index: Column<Advice>,
+    pub index: Column<Fixed>,
     /// Value
     pub value: word::Word<Column<Advice>>,
 }
@@ -41,8 +43,8 @@ impl BlockTable {
     /// Construct a new BlockTable
     pub fn construct<F: Field>(meta: &mut ConstraintSystem<F>) -> Self {
         Self {
-            tag: meta.advice_column(),
-            index: meta.advice_column(),
+            tag: meta.fixed_column(),
+            index: meta.fixed_column(),
             value: word::Word::new([meta.advice_column(), meta.advice_column()]),
         }
     }
@@ -56,30 +58,30 @@ impl BlockTable {
         layouter.assign_region(
             || "block table",
             |mut region| {
-                let mut offset = 0;
-                for column in <BlockTable as LookupTable<F>>::advice_columns(self) {
-                    region.assign_advice(
-                        || "block table all-zero row",
-                        column,
+                for (offset, row) in iter::once([Value::known(F::ZERO); 4])
+                    .chain(block.table_assignments::<F>())
+                    .enumerate()
+                {
+                    region.assign_fixed(
+                        || format!("block table tag {}", offset),
+                        self.tag,
                         offset,
-                        || Value::known(F::ZERO),
+                        || row[0],
+                    )?;
+                    region.assign_fixed(
+                        || format!("block table index {}", offset),
+                        self.index,
+                        offset,
+                        || row[1],
+                    )?;
+
+                    word::Word::new([row[2], row[3]]).assign_advice(
+                        &mut region,
+                        || format!("block table value {}", offset),
+                        self.value,
+                        offset,
                     )?;
                 }
-                offset += 1;
-
-                let block_table_columns = <BlockTable as LookupTable<F>>::advice_columns(self);
-                for row in block.table_assignments::<F>() {
-                    for (&column, value) in block_table_columns.iter().zip_eq(row) {
-                        region.assign_advice(
-                            || format!("block table row {}", offset),
-                            column,
-                            offset,
-                            || value,
-                        )?;
-                    }
-                    offset += 1;
-                }
-
                 Ok(())
             },
         )


### PR DESCRIPTION
### Description

block_table `tag`, `index` those 2 value are not only non-constrained but also be advice column, which means the `tag`, `index` can be witness in any value/order and lead to a situation of lookup blocktag under wrong value. E.g. use `timestamp` value to represent `base_fee`. 

Block_table `value` column is constrained by public input so there is no such issue.

Since `block_table` per row are pre-defined, this PR fixed soundness by move `tag`, `index` to fixed column, so value will be encoded in verify key and avoid malicious manipulation.

Folk Scroll previously has similar fixed https://github.com/scroll-tech/zkevm-circuits/commit/d3922e1d2b3188a04b39d90cdacd22f83cb4dde0#diff-632aa6def09f1668ecdf89781dbf23c2c3cf3bc379209b19cce79abd0a1d0bfe

### Issue Link

N/A

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
