### PR TITLE
add error pruning on step_first/step_last to avoid use against lookup

### DIFF
--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -1430,17 +1430,18 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         self.constraints_location = ConstraintLocation::Step;
         ret
     }
-    /// TODO: Doc
+
+    /// register constraints to be applied `step_first` selector
     pub(crate) fn step_first<R>(&mut self, constraint: impl FnOnce(&mut Self) -> R) -> R {
         self.constraint_at_location(ConstraintLocation::StepFirst, constraint)
     }
 
-    /// TODO: Doc
+    /// register constraints to be applied on step other than first step
     pub(crate) fn not_step_last<R>(&mut self, constraint: impl FnOnce(&mut Self) -> R) -> R {
         self.constraint_at_location(ConstraintLocation::NotStepLast, constraint)
     }
 
-    /// TODO: Doc
+    /// register constraints to be applied on respective selector later
     fn push_constraint(&mut self, name: &'static str, constraint: Expression<F>) {
         match self.constraints_location {
             ConstraintLocation::Step => self.constraints.step.push((name, constraint)),
@@ -1452,6 +1453,11 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
     }
 
     pub(crate) fn add_lookup(&mut self, name: &str, lookup: Lookup<F>) {
+        debug_assert_eq!(
+            self.constraints_location,
+            ConstraintLocation::Step,
+            "lookup do not support conditional on constraint location other than `ConstraintLocation::Step`"
+        );
         let lookup = match self.condition_expr_opt() {
             Some(condition) => lookup.conditional(condition),
             None => lookup,


### PR DESCRIPTION
### Description

This works
```rust
cb.step_first(|cb| {
            cb.require_equal("xxxxx", A, B); // it works!
});
```

However it doesnt works on any lookup wrap by step, e.g.
```rust
cb.step_first(|cb| {
       cb.call_context_lookup_write(Some(call_id.expr()), field_tag, value); // lookup will happen on any step other than step 1
});
```

The reason is because lookup constraints expression not including location selector when query lookup cell.
https://github.com/privacy-scaling-explorations/zkevm-circuits/blob/main/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs#L1489-L1496
While the location selector are created in execution.rs at later phase 

https://github.com/privacy-scaling-explorations/zkevm-circuits/blob/09651d40afc59462fd943e9789be8f8b0ccb90d9/zkevm-circuits/src/evm_circuit/execution.rs#L731-L757

when converting constraints to custom gate. This works for normal constraints but not works for lookup expression.

This PR add error pruning step to avoid lookup usage against step_first/step_last 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update