### PR TITLE
[proof-chunk] check rwtable fingerprint equality in last chunk

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -28,7 +28,7 @@ use crate::{
 };
 use bus_mapping::operation::Target;
 use eth_types::{evm_unimplemented, Field};
-use gadgets::{is_zero::IsZeroConfig, util::not};
+use gadgets::util::not;
 use halo2_proofs::{
     circuit::{Layouter, Region, Value},
     plonk::{
@@ -236,7 +236,7 @@ pub struct ExecutionConfig<F> {
     // Selector enabled in the row where the first execution step starts.
     q_step_first: Selector,
     // Selector enabled in the row where the last execution step starts.
-    q_step_last: Selector,
+    pub q_step_last: Selector,
     advices: [Column<Advice>; STEP_WIDTH],
     step: Step<F>,
     pub(crate) height_map: HashMap<ExecutionState, usize>,
@@ -352,8 +352,8 @@ impl<F: Field> ExecutionConfig<F> {
         keccak_table: &dyn LookupTable<F>,
         exp_table: &dyn LookupTable<F>,
         chunkctx_table: &dyn LookupTable<F>,
-        is_first_chunk: &IsZeroConfig<F>,
-        is_last_chunk: &IsZeroConfig<F>,
+        is_first_chunk: Expression<F>,
+        is_last_chunk: Expression<F>,
     ) -> Self {
         let mut instrument = Instrument::default();
         let q_usable = meta.complex_selector();
@@ -1031,7 +1031,7 @@ impl<F: Field> ExecutionConfig<F> {
         layouter: &mut impl Layouter<F>,
         block: &Block<F>,
         challenges: &Challenges<Value<F>>,
-    ) -> Result<usize, Error> {
+    ) -> Result<(), Error> {
         // Track number of calls to `layouter.assign_region` as layouter assignment passes.
         let mut assign_pass = 0;
         layouter.assign_region(
@@ -1208,7 +1208,8 @@ impl<F: Field> ExecutionConfig<F> {
                 )?;
 
                 assign_pass += 1;
-                Ok(offset)
+
+                Ok(())
             },
         )
     }

--- a/zkevm-circuits/src/state_circuit.rs
+++ b/zkevm-circuits/src/state_circuit.rs
@@ -71,8 +71,8 @@ pub struct StateCircuitConfig<F> {
     // External tables
     mpt_table: MptTable,
 
-    // rw permutation config
-    rw_permutation_config: PermutationChipConfig<F>,
+    /// rw permutation config
+    pub rw_permutation_config: PermutationChipConfig<F>,
 
     // pi for carry over previous chunk context
     pi_pre_continuity: Column<Instance>,
@@ -610,7 +610,7 @@ impl<F: Field> SubCircuit<F> for StateCircuit<F> {
                     Value::known(self.permu_gamma),
                     Value::known(self.permu_prev_continuous_fingerprint),
                     &rows,
-                    "state_circuit",
+                    "state_circuit-rw_permutation",
                 )?;
                 #[cfg(test)]
                 {

--- a/zkevm-circuits/src/state_circuit/test.rs
+++ b/zkevm-circuits/src/state_circuit/test.rs
@@ -720,18 +720,21 @@ fn all_padding() {
 }
 
 #[test]
-fn skipped_start_rw_counter() {
+fn invalid_padding_rw_counter_change() {
     let overrides = HashMap::from([
         (
-            (AdviceColumn::RwCounter, -1),
+            (AdviceColumn::RwCounter, 0),
             // The original assignment is 1 << 16.
             Fr::from((1 << 16) + 1),
         ),
-        ((AdviceColumn::RwCounterLimb0, -1), Fr::ONE),
+        ((AdviceColumn::RwCounterLimb0, 0), Fr::ONE),
     ]);
 
-    let result = prover(vec![], overrides).verify_at_rows(1..2, 1..2);
-    assert_error_matches(result, "rw_counter increases by 1 for every non-first row");
+    let result = prover(vec![], overrides).verify_at_rows(2..3, 2..3);
+    assert_error_matches(
+        result,
+        "if previous row is also Padding. rw counter change is 0 or 1",
+    );
 }
 
 #[test]

--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -79,7 +79,6 @@ use eth_types::{geth_types::GethData, Field};
 use halo2_proofs::{
     circuit::{Layouter, SimpleFloorPlanner, Value},
     plonk::{Circuit, ConstraintSystem, Error, Expression},
-    poly::Rotation,
 };
 
 use std::array;
@@ -233,14 +232,12 @@ impl<F: Field> SubCircuitConfig<F> for SuperCircuitConfig<F> {
             "chronological rwtable fingerprint == by address rwtable fingerprint",
             |meta| {
                 let is_last_chunk = chunkctx_config.is_last_chunk.expr();
-                let chronological_rwtable_acc_fingerprint = meta.query_advice(
-                    evm_circuit.rw_permutation_config.acc_fingerprints,
-                    Rotation::cur(),
-                );
-                let by_address_rwtable_acc_fingerprint = meta.query_advice(
-                    state_circuit.rw_permutation_config.acc_fingerprints,
-                    Rotation::cur(),
-                );
+                let chronological_rwtable_acc_fingerprint = evm_circuit
+                    .rw_permutation_config
+                    .acc_fingerprints_cur_expr();
+                let by_address_rwtable_acc_fingerprint = state_circuit
+                    .rw_permutation_config
+                    .acc_fingerprints_cur_expr();
 
                 let q_row_last = meta.query_selector(evm_circuit.rw_permutation_config.q_row_last);
 

--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -66,7 +66,9 @@ use crate::{
         UXTable,
     },
     tx_circuit::{TxCircuit, TxCircuitConfig, TxCircuitConfigArgs},
-    util::{log2_ceil, Challenges, SubCircuit, SubCircuitConfig},
+    util::{
+        chunkctx_config::ChunkContextConfig, log2_ceil, Challenges, SubCircuit, SubCircuitConfig,
+    },
     witness::{block_convert, Block, MptUpdates},
 };
 use bus_mapping::{
@@ -77,6 +79,7 @@ use eth_types::{geth_types::GethData, Field};
 use halo2_proofs::{
     circuit::{Layouter, SimpleFloorPlanner, Value},
     plonk::{Circuit, ConstraintSystem, Error, Expression},
+    poly::Rotation,
 };
 
 use std::array;
@@ -97,6 +100,7 @@ pub struct SuperCircuitConfig<F: Field> {
     keccak_circuit: KeccakCircuitConfig<F>,
     pi_circuit: PiCircuitConfig<F>,
     exp_circuit: ExpCircuitConfig<F>,
+    chunkctx_config: ChunkContextConfig<F>,
 }
 
 /// Circuit configuration arguments
@@ -108,7 +112,6 @@ pub struct SuperCircuitConfigArgs<F: Field> {
     /// Mock randomness
     pub mock_randomness: F,
 }
-
 impl<F: Field> SubCircuitConfig<F> for SuperCircuitConfig<F> {
     type ConfigArgs = SuperCircuitConfigArgs<F>;
 
@@ -146,6 +149,8 @@ impl<F: Field> SubCircuitConfig<F> for SuperCircuitConfig<F> {
             power_of_randomness[0].clone(),
             power_of_randomness[0].clone(),
         );
+
+        let chunkctx_config = ChunkContextConfig::new(meta, &challenges);
 
         let keccak_circuit = KeccakCircuitConfig::new(
             meta,
@@ -208,7 +213,7 @@ impl<F: Field> SubCircuitConfig<F> for SuperCircuitConfig<F> {
         let evm_circuit = EvmCircuitConfig::new(
             meta,
             EvmCircuitConfigArgs {
-                challenges,
+                challenges: challenges.clone(),
                 tx_table,
                 rw_table: chronological_rw_table,
                 bytecode_table,
@@ -218,6 +223,33 @@ impl<F: Field> SubCircuitConfig<F> for SuperCircuitConfig<F> {
                 exp_table,
                 u8_table,
                 u16_table,
+                chunkctx_config: chunkctx_config.clone(),
+            },
+        );
+
+        // constraint chronological/by address rwtable fingerprint must be the same in last chunk
+        // last row.
+        meta.create_gate(
+            "chronological rwtable fingerprint == by address rwtable fingerprint",
+            |meta| {
+                let is_last_chunk = chunkctx_config.is_last_chunk.expr();
+                let chronological_rwtable_acc_fingerprint = meta.query_advice(
+                    evm_circuit.rw_permutation_config.acc_fingerprints,
+                    Rotation::cur(),
+                );
+                let by_address_rwtable_acc_fingerprint = meta.query_advice(
+                    state_circuit.rw_permutation_config.acc_fingerprints,
+                    Rotation::cur(),
+                );
+
+                let q_row_last = meta.query_selector(evm_circuit.rw_permutation_config.q_row_last);
+
+                vec![
+                    is_last_chunk
+                        * q_row_last
+                        * (chronological_rwtable_acc_fingerprint
+                            - by_address_rwtable_acc_fingerprint),
+                ]
             },
         );
 
@@ -235,6 +267,7 @@ impl<F: Field> SubCircuitConfig<F> for SuperCircuitConfig<F> {
             keccak_circuit,
             pi_circuit,
             exp_circuit,
+            chunkctx_config,
         }
     }
 }
@@ -242,6 +275,8 @@ impl<F: Field> SubCircuitConfig<F> for SuperCircuitConfig<F> {
 /// The Super Circuit contains all the zkEVM circuits
 #[derive(Clone, Default, Debug)]
 pub struct SuperCircuit<F: Field> {
+    /// Block
+    pub block: Option<Block<F>>,
     /// EVM Circuit
     pub evm_circuit: EvmCircuit<F>,
     /// State Circuit
@@ -305,6 +340,7 @@ impl<F: Field> SubCircuit<F> for SuperCircuit<F> {
         let keccak_circuit = KeccakCircuit::new_from_block(block);
 
         SuperCircuit::<_> {
+            block: Some(block.clone()),
             evm_circuit,
             state_circuit,
             tx_circuit,
@@ -321,6 +357,22 @@ impl<F: Field> SubCircuit<F> for SuperCircuit<F> {
     /// Returns suitable inputs for the SuperCircuit.
     fn instance(&self) -> Vec<Vec<F>> {
         let mut instance = Vec::new();
+
+        let block = self.block.as_ref().unwrap();
+
+        instance.extend_from_slice(&[
+            vec![
+                F::from(block.chunk_context.chunk_index as u64),
+                F::from(block.chunk_context.total_chunks as u64),
+                F::from(block.chunk_context.initial_rwc as u64),
+            ],
+            vec![
+                F::from(block.chunk_context.chunk_index as u64) + F::ONE,
+                F::from(block.chunk_context.total_chunks as u64),
+                F::from(block.chunk_context.end_rwc as u64),
+            ],
+        ]);
+
         instance.extend_from_slice(&self.keccak_circuit.instance());
         instance.extend_from_slice(&self.pi_circuit.instance());
         instance.extend_from_slice(&self.tx_circuit.instance());
@@ -360,6 +412,13 @@ impl<F: Field> SubCircuit<F> for SuperCircuit<F> {
         challenges: &Challenges<Value<F>>,
         layouter: &mut impl Layouter<F>,
     ) -> Result<(), Error> {
+        // synthesize chunk context
+        config.chunkctx_config.assign_chunk_context(
+            layouter,
+            &self.block.as_ref().unwrap().chunk_context,
+            self.block.as_ref().unwrap().circuits_params.max_rws - 1,
+        )?;
+
         self.keccak_circuit
             .synthesize_sub(&config.keccak_circuit, challenges, layouter)?;
         self.bytecode_circuit

--- a/zkevm-circuits/src/util.rs
+++ b/zkevm-circuits/src/util.rs
@@ -20,6 +20,9 @@ pub mod cell_manager;
 /// Cell Placement strategies
 pub mod cell_placement_strategy;
 
+/// Chunk Ctx Config
+pub mod chunkctx_config;
+
 /// Steal the expression from gate
 pub fn query_expression<F: Field, T>(
     meta: &mut ConstraintSystem<F>,

--- a/zkevm-circuits/src/util/chunkctx_config.rs
+++ b/zkevm-circuits/src/util/chunkctx_config.rs
@@ -1,0 +1,203 @@
+use bus_mapping::circuit_input_builder::ChunkContext;
+use gadgets::{
+    is_zero::{IsZeroChip, IsZeroConfig, IsZeroInstruction},
+    util::Expr,
+};
+use halo2_proofs::{
+    circuit::{Layouter, Value},
+    plonk::{Advice, Column, ConstraintSystem, Error, Expression, Instance, Selector},
+    poly::Rotation,
+};
+
+use crate::{
+    evm_circuit::util::rlc,
+    table::{
+        chunkctx_table::{ChunkCtxFieldTag, ChunkCtxTable},
+        LookupTable,
+    },
+};
+use eth_types::Field;
+
+use super::Challenges;
+
+/// chunk context config
+#[derive(Clone, Debug)]
+pub struct ChunkContextConfig<F> {
+    chunk_index: Column<Advice>,
+    chunk_index_next: Column<Advice>,
+    total_chunks: Column<Advice>,
+    q_chunk_context: Selector,
+
+    /// is_first_chunk config
+    pub is_first_chunk: IsZeroConfig<F>,
+    /// is_last_chunk config
+    pub is_last_chunk: IsZeroConfig<F>,
+
+    /// ChunkCtxTable
+    pub chunkctx_table: ChunkCtxTable,
+    /// instance column for prev chunk context
+    pub pi_pre_chunkctx: Column<Instance>,
+    /// instance column for next chunk context
+    pub pi_next_chunkctx: Column<Instance>,
+}
+
+impl<F: Field> ChunkContextConfig<F> {
+    /// new a chunk context config
+    pub fn new(meta: &mut ConstraintSystem<F>, challenges: &Challenges<Expression<F>>) -> Self {
+        let q_chunk_context = meta.complex_selector();
+        let chunk_index = meta.advice_column();
+        let chunk_index_inv = meta.advice_column();
+        let chunk_index_next = meta.advice_column();
+        let chunk_diff = meta.advice_column();
+        let total_chunks = meta.advice_column();
+
+        let pi_pre_chunkctx = meta.instance_column();
+        let pi_next_chunkctx = meta.instance_column();
+        meta.enable_equality(pi_pre_chunkctx);
+        meta.enable_equality(pi_next_chunkctx);
+
+        let chunkctx_table = ChunkCtxTable::construct(meta);
+        chunkctx_table.annotate_columns(meta);
+
+        [
+            (ChunkCtxFieldTag::CurrentChunkIndex.expr(), chunk_index),
+            (ChunkCtxFieldTag::NextChunkIndex.expr(), chunk_index_next),
+            (ChunkCtxFieldTag::TotalChunks.expr(), total_chunks),
+        ]
+        .iter()
+        .for_each(|(tag_expr, value_col)| {
+            meta.lookup_any("chunk context lookup", |meta| {
+                let q_chunk_context = meta.query_selector(q_chunk_context);
+                let value_col_expr = meta.query_advice(*value_col, Rotation::cur());
+
+                vec![(
+                    q_chunk_context
+                        * rlc::expr(
+                            &[tag_expr.clone(), value_col_expr],
+                            challenges.lookup_input(),
+                        ),
+                    rlc::expr(&chunkctx_table.table_exprs(meta), challenges.lookup_input()),
+                )]
+            });
+        });
+
+        let is_first_chunk = IsZeroChip::configure(
+            meta,
+            |meta| meta.query_selector(q_chunk_context),
+            |meta| meta.query_advice(chunk_index, Rotation::cur()),
+            chunk_index_inv,
+        );
+
+        let is_last_chunk = IsZeroChip::configure(
+            meta,
+            |meta| meta.query_selector(q_chunk_context),
+            |meta| {
+                let chunk_index = meta.query_advice(chunk_index, Rotation::cur());
+                let total_chunks = meta.query_advice(total_chunks, Rotation::cur());
+
+                total_chunks - chunk_index - 1.expr()
+            },
+            chunk_diff,
+        );
+
+        Self {
+            q_chunk_context,
+            chunk_index,
+            chunk_index_next,
+            total_chunks,
+            is_first_chunk,
+            is_last_chunk,
+            chunkctx_table,
+            pi_pre_chunkctx,
+            pi_next_chunkctx,
+        }
+    }
+
+    /// assign chunk context
+    pub fn assign_chunk_context(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        chunk_context: &ChunkContext,
+        max_offset_index: usize,
+    ) -> Result<(), Error> {
+        let (
+            chunk_index_cell,
+            chunk_index_next_cell,
+            total_chunk_cell,
+            initial_rwc_cell,
+            end_rwc_cell,
+        ) = self.chunkctx_table.load(layouter, chunk_context)?;
+
+        let is_first_chunk = IsZeroChip::construct(self.is_first_chunk.clone());
+        let is_last_chunk = IsZeroChip::construct(self.is_last_chunk.clone());
+        layouter.assign_region(
+            || "chunk context",
+            |mut region| {
+                region.name_column(|| "chunk_index", self.chunk_index);
+                region.name_column(|| "chunk_index_next", self.chunk_index_next);
+                region.name_column(|| "total_chunks", self.total_chunks);
+                region.name_column(|| "pi_pre_chunkctx", self.pi_pre_chunkctx);
+                region.name_column(|| "pi_next_chunkctx", self.pi_next_chunkctx);
+                self.is_first_chunk
+                    .annotate_columns_in_region(&mut region, "is_first_chunk");
+                self.is_last_chunk
+                    .annotate_columns_in_region(&mut region, "is_last_chunk");
+                self.chunkctx_table.annotate_columns_in_region(&mut region);
+
+                for offset in 0..max_offset_index + 1 {
+                    self.q_chunk_context.enable(&mut region, offset)?;
+
+                    region.assign_advice(
+                        || "chunk_index",
+                        self.chunk_index,
+                        offset,
+                        || Value::known(F::from(chunk_context.chunk_index as u64)),
+                    )?;
+
+                    region.assign_advice(
+                        || "chunk_index_next",
+                        self.chunk_index_next,
+                        offset,
+                        || Value::known(F::from(chunk_context.chunk_index as u64 + 1u64)),
+                    )?;
+
+                    region.assign_advice(
+                        || "total_chunks",
+                        self.total_chunks,
+                        offset,
+                        || Value::known(F::from(chunk_context.total_chunks as u64)),
+                    )?;
+
+                    is_first_chunk.assign(
+                        &mut region,
+                        offset,
+                        Value::known(F::from(chunk_context.chunk_index as u64)),
+                    )?;
+                    is_last_chunk.assign(
+                        &mut region,
+                        offset,
+                        Value::known(F::from(
+                            (chunk_context.total_chunks - chunk_context.chunk_index - 1) as u64,
+                        )),
+                    )?;
+                }
+                Ok(())
+            },
+        )?;
+
+        vec![chunk_index_cell, total_chunk_cell.clone(), initial_rwc_cell]
+            .iter()
+            .enumerate()
+            .try_for_each(|(i, cell)| {
+                layouter.constrain_instance(cell.cell(), self.pi_pre_chunkctx, i)
+            })?;
+        [chunk_index_next_cell, total_chunk_cell, end_rwc_cell]
+            .iter()
+            .enumerate()
+            .try_for_each(|(i, cell)| {
+                layouter.constrain_instance(cell.cell(), self.pi_next_chunkctx, i)
+            })?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
### Description

Depends on #1641 with extra commit: adding fingerprint equality check on chronological/by address rw_table
Fingerprint check gate will be enable in last chunk last row

### instance columns, top down order match instance array order

chunk ctx
- [current chunk index, total chunk, initial rwc] // equal with chunk_{i-1}
- [next chunk index, total chunk, next rwc] equal with chunk_{i+1}

pi circuit
- [pi digest lo, pi digest hi] // same across all chunks

state circuit
- [prev permutation fingerprint] // equal with chunk_{i-1}
- [next permutation fingerprint] // equal with chunk_{i+1}
- [alpha, gamma] // same across all chunks

evm circuit
- [prev permutation fingerprint] // equal with chunk_{i-1}
- [next permutation fingerprint] // equal with chunk_{i+1}
- [alpha, gamma] // same across all chunks

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
