### PR TITLE
fix return/revert offset/len in handle_return for err cases

### DIFF
--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -1044,7 +1044,7 @@ impl<'a> CircuitInputStateRef<'a> {
             if !self.call()?.is_root {
                 let (offset, length) = match step.op {
                     OpcodeId::RETURN | OpcodeId::REVERT => {
-                        let (offset, length) = if step.error.is_some()
+                        let (offset, length) = if exec_step.error.is_some()
                             || (self.call()?.is_create() && self.call()?.is_success)
                         {
                             (0, 0)


### PR DESCRIPTION
### Description

geth_step.error is not enough. It only contains error inside geth trace, only stack err and oog err. Exec_step.error contains all types of err we recovered during parsing trace.

This pr will fix some failures of testool, like `CreateOOGFromCallRefunds_d1(SStore_Refund_OoG)_g0_v0`

### Issue Link

[_link issue here_]

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
