### PR TITLE
[proof chunk] root circuit consistency between chunk

### DIFF
--- a/circuit-benchmarks/src/state_circuit.rs
+++ b/circuit-benchmarks/src/state_circuit.rs
@@ -23,6 +23,7 @@ mod tests {
     use std::env::var;
     use zkevm_circuits::{
         evm_circuit::witness::RwMap, state_circuit::StateCircuit, util::SubCircuit,
+        witness::rw::RwTablePermutationFingerprints,
     };
 
     #[cfg_attr(not(feature = "benches"), ignore)]
@@ -44,8 +45,7 @@ mod tests {
             1 << 16,
             Fr::from(1),
             Fr::from(1),
-            Fr::from(1),
-            Fr::from(1),
+            RwTablePermutationFingerprints::new(Fr::from(1), Fr::from(1), Fr::from(1), Fr::from(1)),
             0,
         );
 

--- a/gadgets/src/permutation.rs
+++ b/gadgets/src/permutation.rs
@@ -30,7 +30,8 @@ pub struct PermutationChipConfig<F> {
     power_of_gamma: Vec<Column<Advice>>,
     /// q_row_non_first
     pub q_row_non_first: Selector, // 1 between (first, end], exclude first
-    q_row_enable: Selector, // 1 for all rows (including first)
+    /// q_row_enable
+    pub q_row_enable: Selector, // 1 for all rows (including first)
     /// q_row_last
     pub q_row_last: Selector, // 1 in the last row
 
@@ -211,7 +212,7 @@ impl<F: Field> PermutationChip<F> {
             .collect::<Vec<Column<Advice>>>(); // first element is gamma**1
 
         let q_row_non_first = meta.complex_selector();
-        let q_row_enable = meta.selector();
+        let q_row_enable = meta.complex_selector();
         let q_row_last = meta.selector();
 
         meta.enable_equality(acc_fingerprints);

--- a/gadgets/src/permutation.rs
+++ b/gadgets/src/permutation.rs
@@ -210,7 +210,7 @@ impl<F: Field> PermutationChip<F> {
             .map(|_| meta.advice_column())
             .collect::<Vec<Column<Advice>>>(); // first element is gamma**1
 
-        let q_row_non_first = meta.selector();
+        let q_row_non_first = meta.complex_selector();
         let q_row_enable = meta.selector();
         let q_row_last = meta.selector();
 

--- a/gadgets/src/permutation.rs
+++ b/gadgets/src/permutation.rs
@@ -215,6 +215,7 @@ impl<F: Field> PermutationChip<F> {
         let q_row_last = meta.selector();
 
         meta.enable_equality(acc_fingerprints);
+        meta.enable_equality(row_fingerprints);
         meta.enable_equality(alpha);
         meta.enable_equality(power_of_gamma[0]);
 

--- a/integration-tests/src/integration_test_circuits.rs
+++ b/integration-tests/src/integration_test_circuits.rs
@@ -40,6 +40,7 @@ use zkevm_circuits::{
     pi_circuit::TestPiCircuit,
     root_circuit::{
         compile, Config, EvmTranscript, NativeLoader, PoseidonTranscript, RootCircuit, Shplonk,
+        UserChallenge,
     },
     state_circuit::TestStateCircuit,
     super_circuit::SuperCircuit,
@@ -320,7 +321,7 @@ impl<C: SubCircuit<Fr> + Circuit<Fr>> IntegrationTest<C> {
                     &protocol,
                     Value::unknown(),
                     Value::unknown(),
-                    vec![],
+                    None,
                 )
                 .unwrap();
 
@@ -450,12 +451,16 @@ impl<C: SubCircuit<Fr> + Circuit<Fr>> IntegrationTest<C> {
             };
 
             log::info!("root circuit new");
+            let user_challenge = &UserChallenge {
+                column_indexes: rwtable_columns,
+                num_challenges: 2, // alpha, gamma
+            };
             let root_circuit = RootCircuit::<Bn256, Shplonk<_>>::new(
                 &params,
                 &protocol,
                 Value::known(&instance),
                 Value::known(&proof),
-                rwtable_columns,
+                Some(user_challenge),
             )
             .unwrap();
 

--- a/integration-tests/src/integration_test_circuits.rs
+++ b/integration-tests/src/integration_test_circuits.rs
@@ -40,7 +40,7 @@ use zkevm_circuits::{
     pi_circuit::TestPiCircuit,
     root_circuit::{
         compile, Config, EvmTranscript, NativeLoader, PoseidonTranscript, RootCircuit, Shplonk,
-        UserChallenge,
+        SnarkWitness, UserChallenge,
     },
     state_circuit::TestStateCircuit,
     super_circuit::SuperCircuit,
@@ -319,8 +319,11 @@ impl<C: SubCircuit<Fr> + Circuit<Fr>> IntegrationTest<C> {
                 let circuit = RootCircuit::<Bn256, Shplonk<_>>::new(
                     &params,
                     &protocol,
-                    Value::unknown(),
-                    Value::unknown(),
+                    vec![SnarkWitness::new(
+                        &protocol,
+                        Value::unknown(),
+                        Value::unknown(),
+                    )],
                     None,
                 )
                 .unwrap();
@@ -458,8 +461,11 @@ impl<C: SubCircuit<Fr> + Circuit<Fr>> IntegrationTest<C> {
             let root_circuit = RootCircuit::<Bn256, Shplonk<_>>::new(
                 &params,
                 &protocol,
-                Value::known(&instance),
-                Value::known(&proof),
+                vec![SnarkWitness::new(
+                    &protocol,
+                    Value::known(&instance),
+                    Value::known(&proof),
+                )],
                 Some(user_challenge),
             )
             .unwrap();

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -46,7 +46,7 @@ pub struct EvmCircuitConfig<F> {
     pub execution: Box<ExecutionConfig<F>>,
     // External tables
     tx_table: TxTable,
-    rw_table: RwTable,
+    pub(crate) rw_table: RwTable,
     bytecode_table: BytecodeTable,
     block_table: BlockTable,
     copy_table: CopyTable,

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -389,7 +389,7 @@ impl<F: Field> SubCircuit<F> for EvmCircuit<F> {
                 .row_pre_fingerprints,
             block
                 .permu_chronological_rwtable_fingerprints
-                .row_pre_fingerprints,
+                .row_next_fingerprints,
             block
                 .permu_chronological_rwtable_fingerprints
                 .acc_prev_fingerprints,

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -263,18 +263,13 @@ impl<F: Field> EvmCircuit<F> {
             block.chunk_context.total_chunks,
         );
 
-        let mut instance = vec![
-            vec![
-                F::from(rw_table_chunked_index as u64),
-                F::from(rw_table_total_chunks as u64),
-                F::from(block.chunk_context.initial_rwc as u64),
-            ],
-            vec![
-                F::from(rw_table_chunked_index as u64) + F::ONE,
-                F::from(rw_table_total_chunks as u64),
-                F::from(block.chunk_context.end_rwc as u64),
-            ],
-        ];
+        let mut instance = vec![vec![
+            F::from(rw_table_chunked_index as u64),
+            F::from(rw_table_chunked_index as u64) + F::ONE,
+            F::from(rw_table_total_chunks as u64),
+            F::from(block.chunk_context.initial_rwc as u64),
+            F::from(block.chunk_context.end_rwc as u64),
+        ]];
 
         instance.extend(self.instance());
 

--- a/zkevm-circuits/src/root_circuit.rs
+++ b/zkevm-circuits/src/root_circuit.rs
@@ -43,6 +43,8 @@ pub use snark_verifier::{
     system::halo2::{compile, transcript::evm::EvmTranscript, Config},
 };
 
+const NUM_OF_SUPERCIRCUIT_INSTANCES: usize = 2;
+
 /// SuperCircuitInstance is to demystifying supercircuit instance to meaningful name.
 #[derive(Clone)]
 struct SuperCircuitInstance<T> {
@@ -77,28 +79,27 @@ struct SuperCircuitInstance<T> {
 impl<T: Clone + Copy> SuperCircuitInstance<T> {
     /// Construct `SnarkInstance` with vector
     pub fn new(instances: impl IntoIterator<Item = T>) -> Self {
-        let raw_instances = instances.into_iter().collect_vec();
-        assert_eq!(raw_instances.len(), 19);
+        let mut iter_instances = instances.into_iter();
         Self {
-            chunk_index: raw_instances[0],
-            total_chunk: raw_instances[1],
-            initial_rwc: raw_instances[2],
-            chunk_index_next: raw_instances[3],
-            end_rwc: raw_instances[4],
-            pi_digest_lo: raw_instances[5],
-            pi_digest_hi: raw_instances[6],
-            sc_permu_alpha: raw_instances[7],
-            sc_permu_gamma: raw_instances[8],
-            sc_rwtable_row_prev_fingerprint: raw_instances[9],
-            sc_rwtable_row_next_fingerprint: raw_instances[10],
-            sc_rwtable_prev_fingerprint: raw_instances[11],
-            sc_rwtable_next_fingerprint: raw_instances[12],
-            ec_permu_alpha: raw_instances[13],
-            ec_permu_gamma: raw_instances[14],
-            ec_rwtable_row_prev_fingerprint: raw_instances[15],
-            ec_rwtable_row_next_fingerprint: raw_instances[16],
-            ec_rwtable_prev_fingerprint: raw_instances[17],
-            ec_rwtable_next_fingerprint: raw_instances[18],
+            chunk_index: iter_instances.next().unwrap(),
+            total_chunk: iter_instances.next().unwrap(),
+            initial_rwc: iter_instances.next().unwrap(),
+            chunk_index_next: iter_instances.next().unwrap(),
+            end_rwc: iter_instances.next().unwrap(),
+            pi_digest_lo: iter_instances.next().unwrap(),
+            pi_digest_hi: iter_instances.next().unwrap(),
+            sc_permu_alpha: iter_instances.next().unwrap(),
+            sc_permu_gamma: iter_instances.next().unwrap(),
+            sc_rwtable_row_prev_fingerprint: iter_instances.next().unwrap(),
+            sc_rwtable_row_next_fingerprint: iter_instances.next().unwrap(),
+            sc_rwtable_prev_fingerprint: iter_instances.next().unwrap(),
+            sc_rwtable_next_fingerprint: iter_instances.next().unwrap(),
+            ec_permu_alpha: iter_instances.next().unwrap(),
+            ec_permu_gamma: iter_instances.next().unwrap(),
+            ec_rwtable_row_prev_fingerprint: iter_instances.next().unwrap(),
+            ec_rwtable_row_next_fingerprint: iter_instances.next().unwrap(),
+            ec_rwtable_prev_fingerprint: iter_instances.next().unwrap(),
+            ec_rwtable_next_fingerprint: iter_instances.next().unwrap(),
         }
     }
 }
@@ -207,8 +208,10 @@ where
     /// Returns accumulator indices in instance columns, which will be in
     /// the last `4 * LIMBS` rows of instance column in `MainGate`.
     pub fn accumulator_indices(&self) -> Vec<(usize, usize)> {
-        let offset = self.protocol.num_instance.iter().sum::<usize>();
-        (offset..).map(|idx| (0, idx)).take(4 * LIMBS).collect()
+        (NUM_OF_SUPERCIRCUIT_INSTANCES..)
+            .map(|idx| (0, idx))
+            .take(4 * LIMBS)
+            .collect()
     }
 
     /// Returns number of instance
@@ -452,9 +455,11 @@ where
 
 /// get instances to expose
 fn exposed_instances<T: Copy>(supercircuit_instances: &SuperCircuitInstance<T>) -> Vec<T> {
-    vec![
+    let instances = vec![
         // pi circuit
         supercircuit_instances.pi_digest_lo,
         supercircuit_instances.pi_digest_hi,
-    ]
+    ];
+    assert_eq!(NUM_OF_SUPERCIRCUIT_INSTANCES, instances.len());
+    instances
 }

--- a/zkevm-circuits/src/root_circuit.rs
+++ b/zkevm-circuits/src/root_circuit.rs
@@ -277,7 +277,7 @@ where
                         // `last.sc_rwtable_next_fingerprint ==
                         // last.ec_rwtable_next_fingerprint` will be checked inside super circuit so
                         // here no need to checked
-                        // Other field in last instances already be checked in below chunk
+                        // Other field in last instances already be checked in chunk
                         // continuity
 
                         // define 0, 1, total_chunk as constant
@@ -335,7 +335,7 @@ where
                     .expect("error");
 
                 // constraint consistency between chunk
-                let _ = supercircuit_instances.iter().tuple_windows().inspect(
+                supercircuit_instances.iter().tuple_windows().for_each(
                     |(instance_i, instance_i_plus_one)| {
                         vec![
                             (

--- a/zkevm-circuits/src/root_circuit/aggregation.rs
+++ b/zkevm-circuits/src/root_circuit/aggregation.rs
@@ -66,8 +66,8 @@ const R_P: usize = 60;
 pub type EccChip<C> = halo2_wrong_ecc::BaseFieldEccChip<C, LIMBS, BITS>;
 /// `Halo2Loader` with hardcoded `EccChip`.
 pub type Halo2Loader<'a, C> = loader::halo2::Halo2Loader<'a, C, EccChip<C>>;
-/// `LoaderedScalar` with hardcoded `EccChip`.
-pub type LoaderedScalar<'a, C> = Scalar<'a, C, EccChip<C>>;
+/// `LoadedScalar` with hardcoded `EccChip`.
+pub type LoadedScalar<'a, C> = Scalar<'a, C, EccChip<C>>;
 /// `PoseidonTranscript` with hardcoded parameter with 128-bits security.
 pub type PoseidonTranscript<C, S> =
     transcript::halo2::PoseidonTranscript<C, NativeLoader, S, T, RATE, R_F, R_P>;
@@ -240,7 +240,7 @@ impl AggregationConfig {
         loader: Rc<Halo2Loader<'c, M::G1Affine>>,
         user_challenges: Option<&UserChallenge>,
         proofs: Vec<PlonkProof<M::G1Affine, Rc<Halo2Loader<'c, M::G1Affine>>, As>>,
-    ) -> Result<Vec<LoaderedScalar<'c, M::G1Affine>>, Error>
+    ) -> Result<Vec<LoadedScalar<'c, M::G1Affine>>, Error>
     where
         M: MultiMillerLoop,
         M::Scalar: Field,

--- a/zkevm-circuits/src/root_circuit/aggregation.rs
+++ b/zkevm-circuits/src/root_circuit/aggregation.rs
@@ -70,11 +70,9 @@ pub type PoseidonTranscript<C, S> =
 #[derive(Clone)]
 pub struct SuperCircuitInstance<T> {
     pub chunk_index: T,
+    pub chunk_index_next: T,
     pub total_chunk: T,
     pub initial_rwc: T,
-    pub chunk_index_next: T,
-    // TODO remove total_chunk_2
-    pub total_chunk_2: T,
     pub end_rwc: T,
     pub pi_digest_lo: T,
     pub pi_digest_hi: T,
@@ -102,29 +100,27 @@ impl<T: Clone + Copy> SuperCircuitInstance<T> {
     /// Construct `SnarkInstance` with vector
     pub fn new(instances: impl IntoIterator<Item = T>) -> Self {
         let raw_instances = instances.into_iter().collect_vec();
-        assert_eq!(raw_instances.len(), 20);
+        assert_eq!(raw_instances.len(), 19);
         Self {
             chunk_index: raw_instances[0],
             total_chunk: raw_instances[1],
             initial_rwc: raw_instances[2],
             chunk_index_next: raw_instances[3],
-            // TODO remove total_chunk_2
-            total_chunk_2: raw_instances[4],
-            end_rwc: raw_instances[5],
-            pi_digest_lo: raw_instances[6],
-            pi_digest_hi: raw_instances[7],
-            sc_permu_alpha: raw_instances[8],
-            sc_permu_gamma: raw_instances[9],
-            sc_rwtable_row_prev_fingerprint: raw_instances[10],
-            sc_rwtable_row_next_fingerprint: raw_instances[11],
-            sc_rwtable_prev_fingerprint: raw_instances[12],
-            sc_rwtable_next_fingerprint: raw_instances[13],
-            ec_permu_alpha: raw_instances[14],
-            ec_permu_gamma: raw_instances[15],
-            ec_rwtable_row_prev_fingerprint: raw_instances[16],
-            ec_rwtable_row_next_fingerprint: raw_instances[17],
-            ec_rwtable_prev_fingerprint: raw_instances[18],
-            ec_rwtable_next_fingerprint: raw_instances[19],
+            end_rwc: raw_instances[4],
+            pi_digest_lo: raw_instances[5],
+            pi_digest_hi: raw_instances[6],
+            sc_permu_alpha: raw_instances[7],
+            sc_permu_gamma: raw_instances[8],
+            sc_rwtable_row_prev_fingerprint: raw_instances[9],
+            sc_rwtable_row_next_fingerprint: raw_instances[10],
+            sc_rwtable_prev_fingerprint: raw_instances[11],
+            sc_rwtable_next_fingerprint: raw_instances[12],
+            ec_permu_alpha: raw_instances[13],
+            ec_permu_gamma: raw_instances[14],
+            ec_rwtable_row_prev_fingerprint: raw_instances[15],
+            ec_rwtable_row_next_fingerprint: raw_instances[16],
+            ec_rwtable_prev_fingerprint: raw_instances[17],
+            ec_rwtable_next_fingerprint: raw_instances[18],
             raw_instances,
         }
     }
@@ -501,11 +497,6 @@ impl AggregationConfig {
                             (
                                 instance_i.total_chunk.assigned().to_owned(),
                                 instance_i_plus_one.total_chunk.assigned().to_owned(),
-                            ),
-                            (
-                                // TODO remove me
-                                instance_i.total_chunk_2.assigned().to_owned(),
-                                instance_i_plus_one.total_chunk_2.assigned().to_owned(),
                             ),
                             (
                                 instance_i.end_rwc.assigned().to_owned(),

--- a/zkevm-circuits/src/root_circuit/dev.rs
+++ b/zkevm-circuits/src/root_circuit/dev.rs
@@ -144,8 +144,11 @@ where
                     config.aggregate::<M, As>(ctx, &self.svk, self.snarks.clone())?;
                 let instances = instances
                     .iter()
-                    .flatten()
-                    .map(|instance| instance.assigned().to_owned())
+                    .flat_map(|instances| {
+                        instances
+                            .iter()
+                            .map(|instance| instance.assigned().to_owned())
+                    })
                     .collect_vec();
                 Ok((instances, accumulator_limbs))
             },

--- a/zkevm-circuits/src/root_circuit/dev.rs
+++ b/zkevm-circuits/src/root_circuit/dev.rs
@@ -135,17 +135,11 @@ where
     ) -> Result<(), Error> {
         config.load_table(&mut layouter)?;
         let (instances, accumulator_limbs) =
-            config.aggregate::<M, As>(&mut layouter, &self.svk, self.snarks.clone())?;
+            config.aggregate::<M, As>(&mut layouter, &self.svk, self.snarks.clone(), vec![])?;
 
         // Constrain equality to instance values
         let main_gate = config.main_gate();
-        for (row, limb) in instances
-            .into_iter()
-            .flatten()
-            .flatten()
-            .chain(accumulator_limbs)
-            .enumerate()
-        {
+        for (row, limb) in instances.into_iter().chain(accumulator_limbs).enumerate() {
             main_gate.expose_public(layouter.namespace(|| ""), limb, row)?;
         }
 

--- a/zkevm-circuits/src/root_circuit/dev.rs
+++ b/zkevm-circuits/src/root_circuit/dev.rs
@@ -141,7 +141,7 @@ where
                 config.named_column_in_region(&mut region);
                 let ctx = RegionCtx::new(region, 0);
                 let (instances, accumulator_limbs, _, _) =
-                    config.aggregate::<M, As>(ctx, &self.svk, self.snarks.clone())?;
+                    config.aggregate::<M, As>(ctx, &self.svk, &self.snarks)?;
                 let instances = instances
                     .iter()
                     .flat_map(|instances| {

--- a/zkevm-circuits/src/root_circuit/test.rs
+++ b/zkevm-circuits/src/root_circuit/test.rs
@@ -73,6 +73,7 @@ fn test_root_circuit() {
         &protocol,
         Value::known(&instance),
         Value::known(&proof),
+        rwtable_columns,
     )
     .unwrap();
     assert_eq!(

--- a/zkevm-circuits/src/root_circuit/test.rs
+++ b/zkevm-circuits/src/root_circuit/test.rs
@@ -1,5 +1,5 @@
 use crate::{
-    root_circuit::{compile, Config, Gwc, PoseidonTranscript, RootCircuit},
+    root_circuit::{compile, Config, Gwc, PoseidonTranscript, RootCircuit, UserChallenge},
     super_circuit::{test::block_1tx, SuperCircuit},
 };
 use bus_mapping::circuit_input_builder::FixedCParams;
@@ -68,12 +68,16 @@ fn test_root_circuit() {
         (params, protocol, proof, instance, rwtable_columns)
     };
 
+    let user_challenge = UserChallenge {
+        column_indexes: rwtable_columns,
+        num_challenges: 2, // alpha, gamma
+    };
     let root_circuit = RootCircuit::<Bn256, Gwc<_>>::new(
         &params,
         &protocol,
         Value::known(&instance),
         Value::known(&proof),
-        rwtable_columns,
+        Some(&user_challenge),
     )
     .unwrap();
     assert_eq!(

--- a/zkevm-circuits/src/root_circuit/test.rs
+++ b/zkevm-circuits/src/root_circuit/test.rs
@@ -1,5 +1,7 @@
 use crate::{
-    root_circuit::{compile, Config, Gwc, PoseidonTranscript, RootCircuit, UserChallenge},
+    root_circuit::{
+        compile, Config, Gwc, PoseidonTranscript, RootCircuit, SnarkWitness, UserChallenge,
+    },
     super_circuit::{test::block_1tx, SuperCircuit},
 };
 use bus_mapping::circuit_input_builder::FixedCParams;
@@ -75,8 +77,11 @@ fn test_root_circuit() {
     let root_circuit = RootCircuit::<Bn256, Gwc<_>>::new(
         &params,
         &protocol,
-        Value::known(&instance),
-        Value::known(&proof),
+        vec![SnarkWitness::new(
+            &protocol,
+            Value::known(&instance),
+            Value::known(&proof),
+        )],
         Some(&user_challenge),
     )
     .unwrap();

--- a/zkevm-circuits/src/root_circuit/test.rs
+++ b/zkevm-circuits/src/root_circuit/test.rs
@@ -36,7 +36,7 @@ fn test_root_circuit() {
             SuperCircuit::<_>::build(block_1tx(), circuits_params, TEST_MOCK_RANDOMNESS.into())
                 .unwrap();
 
-        // get bytime_rwtable and by_addr_rwtable columns index
+        // get chronological_rwtable and byaddr_rwtable columns index
         let mut cs = ConstraintSystem::default();
         let config = SuperCircuit::configure_with_params(&mut cs, circuit.params());
         let rwtable_columns = config.get_rwtable_columns();

--- a/zkevm-circuits/src/state_circuit.rs
+++ b/zkevm-circuits/src/state_circuit.rs
@@ -74,12 +74,9 @@ pub struct StateCircuitConfig<F> {
     /// rw permutation config
     pub rw_permutation_config: PermutationChipConfig<F>,
 
-    // pi for carry over previous chunk context
-    pi_pre_continuity: Column<Instance>,
-    // pi for carry over chunk context to the next chunk
-    pi_next_continuity: Column<Instance>,
-    // pi for permutation challenge
-    pi_permutation_challenges: Column<Instance>,
+    // pi for chunk context continuity
+    pi_chunk_continuity: Column<Instance>,
+
     _marker: PhantomData<F>,
 }
 
@@ -172,13 +169,8 @@ impl<F: Field> SubCircuitConfig<F> for StateCircuitConfig<F> {
         u10_table.annotate_columns(meta);
         u16_table.annotate_columns(meta);
 
-        let pi_pre_continuity = meta.instance_column();
-        let pi_next_continuity = meta.instance_column();
-        let pi_permutation_challenges = meta.instance_column();
-
-        meta.enable_equality(pi_pre_continuity);
-        meta.enable_equality(pi_next_continuity);
-        meta.enable_equality(pi_permutation_challenges);
+        let pi_chunk_continuity = meta.instance_column();
+        meta.enable_equality(pi_chunk_continuity);
 
         let config = Self {
             selector,
@@ -193,9 +185,7 @@ impl<F: Field> SubCircuitConfig<F> for StateCircuitConfig<F> {
             rw_table,
             mpt_table,
             rw_permutation_config,
-            pi_pre_continuity,
-            pi_next_continuity,
-            pi_permutation_challenges,
+            pi_chunk_continuity,
             _marker: PhantomData::default(),
         };
 
@@ -424,12 +414,7 @@ impl<F: Field> StateCircuitConfig<F> {
         region.name_column(|| "STATE_mpt_proof_type", self.mpt_proof_type);
         region.name_column(|| "STATE_state_root lo", self.state_root.lo());
         region.name_column(|| "STATE_state_root hi", self.state_root.hi());
-        region.name_column(|| "STATE_pi_pre_continuity", self.pi_pre_continuity);
-        region.name_column(|| "STATE_pi_next_continuity", self.pi_next_continuity);
-        region.name_column(
-            || "STATE_pi_permutation_challenges",
-            self.pi_permutation_challenges,
-        );
+        region.name_column(|| "STATE_pi_chunk_continuity", self.pi_chunk_continuity);
     }
 }
 
@@ -637,32 +622,27 @@ impl<F: Field> SubCircuit<F> for StateCircuit<F> {
             },
         )?;
         // constrain permutation challenges
-        [alpha_cell, gamma_cell]
-            .iter()
-            .enumerate()
-            .try_for_each(|(i, cell)| {
-                layouter.constrain_instance(cell.cell(), config.pi_permutation_challenges, i)
-            })?;
-        // constraints prev,next fingerprints
-        layouter.constrain_instance(
-            prev_continuous_fingerprint_cell.cell(),
-            config.pi_pre_continuity,
-            0,
-        )?;
-        layouter.constrain_instance(
-            next_continuous_fingerprint_cell.cell(),
-            config.pi_next_continuity,
-            0,
-        )?;
+        [
+            alpha_cell,
+            gamma_cell,
+            prev_continuous_fingerprint_cell,
+            next_continuous_fingerprint_cell,
+        ]
+        .iter()
+        .enumerate()
+        .try_for_each(|(i, cell)| {
+            layouter.constrain_instance(cell.cell(), config.pi_chunk_continuity, i)
+        })?;
         Ok(())
     }
 
     fn instance(&self) -> Vec<Vec<F>> {
-        vec![
-            vec![self.permu_prev_continuous_fingerprint],
-            vec![self.permu_next_continuous_fingerprint],
-            vec![self.permu_alpha, self.permu_gamma],
-        ]
+        vec![vec![
+            self.permu_alpha,
+            self.permu_gamma,
+            self.permu_prev_continuous_fingerprint,
+            self.permu_next_continuous_fingerprint,
+        ]]
     }
 }
 

--- a/zkevm-circuits/src/state_circuit.rs
+++ b/zkevm-circuits/src/state_circuit.rs
@@ -52,7 +52,7 @@ pub struct StateCircuitConfig<F> {
     // Figure out why you get errors when this is Selector.
     selector: Column<Fixed>,
     // https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/407
-    rw_table: RwTable,
+    pub rw_table: RwTable,
     sort_keys: SortKeysConfig,
     // Assigned value at the start of the block. For Rw::Account and
     // Rw::AccountStorage rows this is the committed value in the MPT, for

--- a/zkevm-circuits/src/state_circuit.rs
+++ b/zkevm-circuits/src/state_circuit.rs
@@ -52,6 +52,7 @@ pub struct StateCircuitConfig<F> {
     // Figure out why you get errors when this is Selector.
     selector: Column<Fixed>,
     // https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/407
+    /// rw table
     pub rw_table: RwTable,
     sort_keys: SortKeysConfig,
     // Assigned value at the start of the block. For Rw::Account and

--- a/zkevm-circuits/src/state_circuit/test.rs
+++ b/zkevm-circuits/src/state_circuit/test.rs
@@ -46,7 +46,7 @@ fn test_state_circuit_ok(
         ..Default::default()
     });
 
-    let next_permutation_fingerprints = get_permutation_fingerprint_of_rwmap(
+    let rwtable_fingerprints = get_permutation_fingerprint_of_rwmap(
         &rw_map,
         N_ROWS,
         Fr::from(1),
@@ -58,8 +58,7 @@ fn test_state_circuit_ok(
         N_ROWS,
         Fr::from(1),
         Fr::from(1),
-        Fr::from(1),
-        next_permutation_fingerprints,
+        rwtable_fingerprints,
         0,
     );
     let instance = circuit.instance();
@@ -85,7 +84,6 @@ fn verifying_key_independent_of_rw_length() {
         N_ROWS,
         Fr::from(1),
         Fr::from(1),
-        Fr::from(1),
         get_permutation_fingerprint_of_rwmap(
             &RwMap::default(),
             N_ROWS,
@@ -106,7 +104,6 @@ fn verifying_key_independent_of_rw_length() {
             ..Default::default()
         }),
         N_ROWS,
-        Fr::from(1),
         Fr::from(1),
         Fr::from(1),
         get_permutation_fingerprint_of_rwmap(
@@ -1000,8 +997,7 @@ fn variadic_size_check() {
         n_rows: N_ROWS,
         permu_alpha: Fr::from(1),
         permu_gamma: Fr::from(1),
-        permu_prev_continuous_fingerprint: Fr::from(1),
-        permu_next_continuous_fingerprint: get_permutation_fingerprint_of_rwvec(
+        rw_table_permu_fingerprints: get_permutation_fingerprint_of_rwvec(
             &rows,
             N_ROWS,
             Fr::from(1),
@@ -1032,7 +1028,7 @@ fn variadic_size_check() {
     ]);
 
     let updates = MptUpdates::mock_from(&rows);
-    let permu_next_continuous_fingerprint =
+    let rwtable_fingerprints =
         get_permutation_fingerprint_of_rwvec(&rows, N_ROWS, Fr::from(1), Fr::from(1), Fr::from(1));
 
     let circuit = StateCircuit::<Fr> {
@@ -1043,8 +1039,7 @@ fn variadic_size_check() {
         n_rows: N_ROWS,
         permu_alpha: Fr::from(1),
         permu_gamma: Fr::from(1),
-        permu_prev_continuous_fingerprint: Fr::from(1),
-        permu_next_continuous_fingerprint,
+        rw_table_permu_fingerprints: rwtable_fingerprints,
         rw_table_chunked_index: 0,
         _marker: std::marker::PhantomData::default(),
     };
@@ -1085,7 +1080,7 @@ fn prover(rows: Vec<Rw>, overrides: HashMap<(AdviceColumn, isize), Fr>) -> MockP
     let (rw_rows, _) = RwMap::table_assignments_padding(&rows, N_ROWS, true);
     let rw_rows: Vec<witness::RwRow<Value<Fr>>> =
         rw_overrides_skip_first_padding(&rw_rows, &overrides);
-    let permu_next_continuous_fingerprint =
+    let rwtable_fingerprints =
         get_permutation_fingerprint_of_rwrowvec(&rw_rows, N_ROWS, Fr::ONE, Fr::ONE, Fr::ONE);
     let row_padding_and_overridess = rw_rows.to2dvec();
 
@@ -1098,8 +1093,7 @@ fn prover(rows: Vec<Rw>, overrides: HashMap<(AdviceColumn, isize), Fr>) -> MockP
         n_rows: N_ROWS,
         permu_alpha: Fr::from(1),
         permu_gamma: Fr::from(1),
-        permu_prev_continuous_fingerprint: Fr::from(1),
-        permu_next_continuous_fingerprint,
+        rw_table_permu_fingerprints: rwtable_fingerprints,
         rw_table_chunked_index: 0,
         _marker: std::marker::PhantomData::default(),
     };

--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -264,8 +264,12 @@ impl<F: Field> SubCircuitConfig<F> for SuperCircuitConfig<F> {
             },
         );
 
-        // constraint chronological/by address rwtable row fingerprint must be the same in first
+        // constraint chronological/by address rwtable `row fingerprint` must be the same in first
         // chunk first row.
+        // `row fingerprint` is not a constant so root circuit can NOT constraint it.
+        // so we constraints here by gate
+        // Furthermore, first row in rw_table should be `Rw::Start`, which will be lookup by
+        // `BeginChunk` at first chunk
         meta.create_gate(
             "chronological rwtable row fingerprint == by address rwtable row fingerprint",
             |meta| {

--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -396,18 +396,13 @@ impl<F: Field> SubCircuit<F> for SuperCircuit<F> {
 
         let block = self.block.as_ref().unwrap();
 
-        instance.extend_from_slice(&[
-            vec![
-                F::from(block.chunk_context.chunk_index as u64),
-                F::from(block.chunk_context.total_chunks as u64),
-                F::from(block.chunk_context.initial_rwc as u64),
-            ],
-            vec![
-                F::from(block.chunk_context.chunk_index as u64) + F::ONE,
-                F::from(block.chunk_context.total_chunks as u64),
-                F::from(block.chunk_context.end_rwc as u64),
-            ],
-        ]);
+        instance.extend_from_slice(&[vec![
+            F::from(block.chunk_context.chunk_index as u64),
+            F::from(block.chunk_context.chunk_index as u64) + F::ONE,
+            F::from(block.chunk_context.total_chunks as u64),
+            F::from(block.chunk_context.initial_rwc as u64),
+            F::from(block.chunk_context.end_rwc as u64),
+        ]]);
 
         instance.extend_from_slice(&self.keccak_circuit.instance());
         instance.extend_from_slice(&self.pi_circuit.instance());

--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -78,7 +78,7 @@ use bus_mapping::{
 use eth_types::{geth_types::GethData, Field};
 use halo2_proofs::{
     circuit::{Layouter, SimpleFloorPlanner, Value},
-    plonk::{Advice, Any, Circuit, Column, ConstraintSystem, Error, Expression},
+    plonk::{Any, Circuit, Column, ConstraintSystem, Error, Expression},
 };
 
 use std::array;

--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -284,9 +284,13 @@ impl<F: Field> SubCircuitConfig<F> for SuperCircuitConfig<F> {
                 let q_row_first = 1.expr()
                     - meta.query_selector(evm_circuit.rw_permutation_config.q_row_non_first);
 
+                let q_row_enable =
+                    meta.query_selector(evm_circuit.rw_permutation_config.q_row_enable);
+
                 vec![
                     is_first_chunk
                         * q_row_first
+                        * q_row_enable
                         * (chronological_rwtable_row_fingerprint
                             - by_address_rwtable_row_fingerprint),
                 ]

--- a/zkevm-circuits/src/test_util.rs
+++ b/zkevm-circuits/src/test_util.rs
@@ -237,8 +237,7 @@ impl<const NACC: usize, const NTX: usize> CircuitTestBuilder<NACC, NTX> {
                 params.max_rws,
                 block.permu_alpha,
                 block.permu_gamma,
-                block.permu_rwtable_prev_continuous_fingerprint,
-                block.permu_rwtable_next_continuous_fingerprint,
+                block.permu_rwtable_fingerprints,
                 block.chunk_context.chunk_index,
             );
             let instance = state_circuit.instance();

--- a/zkevm-circuits/src/util/chunkctx_config.rs
+++ b/zkevm-circuits/src/util/chunkctx_config.rs
@@ -40,9 +40,8 @@ pub struct ChunkContextConfig<F> {
     /// instance column for chunk context
     pub pi_chunkctx: Column<Instance>,
 
-    /// Lt chip to check: src_addr < src_addr_end.
-    /// Since `src_addr` and `src_addr_end` are u64, 8 bytes are sufficient for
-    /// the Lt chip.
+    /// Lt chip to check: chunk_index < total_chunks.
+    /// Assume `total_chunks` < 2**8 = 256
     pub is_chunk_index_lt_total_chunks: LtConfig<F, 1>,
 }
 

--- a/zkevm-circuits/src/witness/block.rs
+++ b/zkevm-circuits/src/witness/block.rs
@@ -330,8 +330,6 @@ fn get_rwtable_fingerprints<F: Field>(
     prev_continuous_fingerprint: F,
     rows: &Vec<Rw>,
 ) -> RwTablePermutationFingerprints<F> {
-    // &<dyn ToVec<Value<F>>>::to2dvec(&chronological_rws_rows)
-
     let x = rows.to2dvec();
     let fingerprints = get_permutation_fingerprints(
         &x,

--- a/zkevm-circuits/src/witness/block.rs
+++ b/zkevm-circuits/src/witness/block.rs
@@ -1,4 +1,7 @@
-use super::{rw::ToVec, ExecStep, Rw, RwMap, Transaction};
+use super::{
+    rw::{RwTablePermutationFingerprints, ToVec},
+    ExecStep, Rw, RwMap, Transaction,
+};
 use crate::{
     evm_circuit::{detect_fixed_table_tags, EvmCircuit},
     exp_circuit::param::OFFSET_INCREMENT,
@@ -62,14 +65,10 @@ pub struct Block<F> {
     pub permu_alpha: F,
     /// permutation challenge gamma
     pub permu_gamma: F,
-    /// pre rw_table permutation fingerprint
-    pub permu_rwtable_prev_continuous_fingerprint: F,
-    /// next rw_table permutation fingerprint
-    pub permu_rwtable_next_continuous_fingerprint: F,
-    /// pre chronological rw_table permutation fingerprint
-    pub permu_chronological_rwtable_prev_continuous_fingerprint: F,
-    /// next chronological rw_table permutation fingerprint
-    pub permu_chronological_rwtable_next_continuous_fingerprint: F,
+    /// rw_table fingerprints
+    pub permu_rwtable_fingerprints: RwTablePermutationFingerprints<F>,
+    /// chronological rw_table fingerprints
+    pub permu_chronological_rwtable_fingerprints: RwTablePermutationFingerprints<F>,
 
     /// prev_chunk_last_call
     pub prev_block: Box<Option<Block<F>>>,
@@ -283,10 +282,6 @@ pub fn block_convert<F: Field>(
         // TODO get permutation fingerprint & challenges
         permu_alpha: F::from(103),
         permu_gamma: F::from(101),
-        permu_rwtable_prev_continuous_fingerprint: F::from(1),
-        permu_rwtable_next_continuous_fingerprint: F::from(1),
-        permu_chronological_rwtable_prev_continuous_fingerprint: F::from(1),
-        permu_chronological_rwtable_next_continuous_fingerprint: F::from(1),
         end_block_not_last: block.block_steps.end_block_not_last.clone(),
         end_block_last: block.block_steps.end_block_last.clone(),
         // TODO refactor chunk related field to chunk structure
@@ -297,6 +292,7 @@ pub fn block_convert<F: Field>(
             .clone()
             .unwrap_or_else(ChunkContext::new_one_chunk),
         prev_block: Box::new(None),
+        ..Default::default()
     };
     let public_data = public_data_convert(&block);
     let rpi_bytes = public_data.get_pi_bytes(
@@ -317,29 +313,43 @@ pub fn block_convert<F: Field>(
         block.circuits_params.max_rws,
         block.chunk_context.is_first_chunk(),
     );
-    block.permu_rwtable_next_continuous_fingerprint = unwrap_value(
-        get_permutation_fingerprints(
-            &<dyn ToVec<Value<F>>>::to2dvec(&rws_rows),
-            Value::known(block.permu_alpha),
-            Value::known(block.permu_gamma),
-            Value::known(block.permu_rwtable_prev_continuous_fingerprint),
-        )
-        .last()
-        .cloned()
-        .unwrap()
-        .0,
-    );
-    block.permu_chronological_rwtable_next_continuous_fingerprint = unwrap_value(
-        get_permutation_fingerprints(
-            &<dyn ToVec<Value<F>>>::to2dvec(&chronological_rws_rows),
-            Value::known(block.permu_alpha),
-            Value::known(block.permu_gamma),
-            Value::known(block.permu_chronological_rwtable_prev_continuous_fingerprint),
-        )
-        .last()
-        .cloned()
-        .unwrap()
-        .0,
+    block.permu_rwtable_fingerprints =
+        get_rwtable_fingerprints(block.permu_alpha, block.permu_gamma, F::from(1), &rws_rows);
+    block.permu_chronological_rwtable_fingerprints = get_rwtable_fingerprints(
+        block.permu_alpha,
+        block.permu_gamma,
+        F::from(1),
+        &chronological_rws_rows,
     );
     Ok(block)
+}
+
+fn get_rwtable_fingerprints<F: Field>(
+    alpha: F,
+    gamma: F,
+    prev_continuous_fingerprint: F,
+    rows: &Vec<Rw>,
+) -> RwTablePermutationFingerprints<F> {
+    // &<dyn ToVec<Value<F>>>::to2dvec(&chronological_rws_rows)
+
+    let x = rows.to2dvec();
+    let fingerprints = get_permutation_fingerprints(
+        &x,
+        Value::known(alpha),
+        Value::known(gamma),
+        Value::known(prev_continuous_fingerprint),
+    );
+
+    fingerprints
+        .first()
+        .zip(fingerprints.last())
+        .map(|((first_acc, first_row), (last_acc, last_row))| {
+            RwTablePermutationFingerprints::new(
+                unwrap_value(*first_row),
+                unwrap_value(*last_row),
+                unwrap_value(*first_acc),
+                unwrap_value(*last_acc),
+            )
+        })
+        .unwrap_or_default()
 }

--- a/zkevm-circuits/src/witness/rw.rs
+++ b/zkevm-circuits/src/witness/rw.rs
@@ -1071,3 +1071,28 @@ impl From<&operation::OperationContainer> for RwMap {
         Self(rws)
     }
 }
+
+/// RwTablePermutationFingerprints
+#[derive(Debug, Default, Clone)]
+pub struct RwTablePermutationFingerprints<F> {
+    /// acc_prev_fingerprints
+    pub acc_prev_fingerprints: F,
+    /// acc_next_fingerprints
+    pub acc_next_fingerprints: F,
+    /// row_pre_fingerprints
+    pub row_pre_fingerprints: F,
+    /// row_next_fingerprints
+    pub row_next_fingerprints: F,
+}
+
+impl<F: Field> RwTablePermutationFingerprints<F> {
+    /// new by value
+    pub fn new(row_prev: F, row_next: F, acc_pref: F, acc_next: F) -> Self {
+        Self {
+            acc_prev_fingerprints: acc_pref,
+            acc_next_fingerprints: acc_next,
+            row_pre_fingerprints: row_prev,
+            row_next_fingerprints: row_next,
+        }
+    }
+}


### PR DESCRIPTION
### Description

covered item
- [x] supercircuit simplify instance columns related to chunkctx to just one column
- [x] first chunk instance: chunk continuity related fields should be constraints as constant.
- [x] aggregate multiple super circuit proof chunk with chunk consistency check .
- [x] compute permutation fingerprint challenges `alpha,gamma` from rw_table advices commitments and assert its equality
- [x] generalized `challenge([column_indexs], challenge_column_index)` to a new protocol structure so more challenges in the future can be added. 

TODO
- [ ] verify multiple chunk from bus_mapping => rely on https://github.com/privacy-scaling-explorations/zkevm-circuits/pull/1690
 
### Issue Link

https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/1603

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Tests

Light tests pass.
integration test failed due to challenge computation in witness not implemented yet, which will be done in bus mapping chunk PR.

