### PR TITLE
fix nondeterministic constraint generation

### DIFF
--- a/zkevm-circuits/src/circuit_tools/memory.rs
+++ b/zkevm-circuits/src/circuit_tools/memory.rs
@@ -7,7 +7,7 @@ use halo2_proofs::{
     poly::Rotation,
 };
 use std::{
-    collections::HashMap,
+    collections::BTreeMap,
     marker::PhantomData,
     ops::{Index, IndexMut},
 };
@@ -20,7 +20,7 @@ use super::{
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct Memory<F: Field, C: CellType, MB: MemoryBank<F, C>> {
-    banks: HashMap<C, MB>,
+    banks: BTreeMap<C, MB>,
     _phantom: PhantomData<F>,
     tag_counter: usize,
 }
@@ -42,7 +42,7 @@ impl<F: Field, C: CellType, MB: MemoryBank<F, C>> IndexMut<C> for Memory<F, C, M
 impl<F: Field, C: CellType, MB: MemoryBank<F, C>> Memory<F, C, MB> {
     pub(crate) fn new() -> Self {
         Self {
-            banks: HashMap::new(),
+            banks: BTreeMap::new(),
             _phantom: PhantomData,
             tag_counter: 0,
         }

--- a/zkevm-circuits/src/mpt_circuit.rs
+++ b/zkevm-circuits/src/mpt_circuit.rs
@@ -766,6 +766,7 @@ pub fn load_proof_from_file(path: &str) -> Vec<Node> {
 mod tests {
     use super::*;
     use halo2_proofs::{dev::MockProver, halo2curves::bn256::Fr};
+    use itertools::Itertools;
     use std::{fs, ops::Deref, path::PathBuf};
 
     #[test]
@@ -808,6 +809,7 @@ mod tests {
                     false
                 }
             })
+            .sorted_by(|a, b| a.file_name().cmp(&b.file_name()))
             .map(|f| {
                 let path = f.path();
                 let mut parts = path.to_str().unwrap().split('-');

--- a/zkevm-circuits/src/util/cell_placement_strategy.rs
+++ b/zkevm-circuits/src/util/cell_placement_strategy.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 use eth_types::Field;
 use halo2_proofs::plonk::{Advice, Column, ConstraintSystem};
@@ -8,7 +8,7 @@ use super::cell_manager::{
 };
 
 #[derive(Clone, Debug, Default)]
-pub(crate) struct CMFixedWidthStrategyDistribution(HashMap<CellType, Vec<Column<Advice>>>);
+pub(crate) struct CMFixedWidthStrategyDistribution(BTreeMap<CellType, Vec<Column<Advice>>>);
 
 impl CMFixedWidthStrategyDistribution {
     pub(crate) fn add(&mut self, cell_type: CellType, advice: Column<Advice>) {
@@ -34,7 +34,7 @@ pub(crate) struct CMFixedWidthStrategy {
     advices: CMFixedWidthStrategyDistribution,
     height_offset: usize,
 
-    next: HashMap<CellType, (usize, usize)>,
+    next: BTreeMap<CellType, (usize, usize)>,
 
     perm_substitution: bool,
     max_height: usize,
@@ -52,7 +52,7 @@ impl CMFixedWidthStrategy {
         CMFixedWidthStrategy {
             advices,
             height_offset,
-            next: HashMap::default(),
+            next: BTreeMap::default(),
             perm_substitution: false,
             max_height: usize::max_value(),
         }


### PR DESCRIPTION
### Description

Change HashMap to BTreeMap in memory.rs and in cell_placement_strategy.

### Issue Link

#1700

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Contents

- fix in memory.rs
- fix in cell_placement_strategy

### Rationale

Generates different circuit keys making proof verification fail for different witnesses.

### How Has This Been Tested?

Manual testing.