### PR TITLE
[proof chunk] introduce Padding virtual step

### DIFF
--- a/bus-mapping/src/circuit_input_builder/block.rs
+++ b/bus-mapping/src/circuit_input_builder/block.rs
@@ -45,11 +45,11 @@ impl BlockContext {
 /// Block-wise execution steps that don't belong to any Transaction.
 #[derive(Debug)]
 pub struct BlockSteps {
-    /// EndBlock step that is repeated after the last transaction and before
+    /// Padding step that is repeated after the last transaction and before
     /// reaching the last EVM row.
-    pub end_block_not_last: ExecStep,
-    /// Last EndBlock step that appears in the last EVM row.
-    pub end_block_last: ExecStep,
+    pub padding: ExecStep,
+    /// EndBlock step that appears in the last chunk last EVM row.
+    pub end_block: ExecStep,
     /// TODO Define and move chunk related step to Chunk struct
     /// Begin op of a chunk
     pub begin_chunk: ExecStep,
@@ -136,11 +136,11 @@ impl Block {
                     exec_state: ExecState::BeginChunk,
                     ..ExecStep::default()
                 },
-                end_block_not_last: ExecStep {
-                    exec_state: ExecState::EndBlock,
+                padding: ExecStep {
+                    exec_state: ExecState::Padding,
                     ..ExecStep::default()
                 },
-                end_block_last: ExecStep {
+                end_block: ExecStep {
                     exec_state: ExecState::EndBlock,
                     ..ExecStep::default()
                 },

--- a/bus-mapping/src/circuit_input_builder/execution.rs
+++ b/bus-mapping/src/circuit_input_builder/execution.rs
@@ -134,6 +134,8 @@ pub enum ExecState {
     BeginTx,
     /// Virtual step End Tx
     EndTx,
+    /// Virtual step Padding
+    Padding,
     /// Virtual step End Block
     EndBlock,
     /// Virtual step End Chunk

--- a/zkevm-circuits/src/evm_circuit/execution/end_block.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/end_block.rs
@@ -176,17 +176,9 @@ mod test {
             .run();
     }
 
-    // Test where the EVM circuit contains an exact number of rows corresponding to
-    // the trace steps + 1 EndBlock
+    // Test steps + 1 EndBlock without padding
     #[test]
-    fn end_block_exact() {
+    fn end_block_no_padding() {
         test_circuit(0);
-    }
-
-    // Test where the EVM circuit has a fixed size and contains several padding
-    // EndBlocks at the end after the trace steps
-    #[test]
-    fn end_block_padding() {
-        test_circuit(50);
     }
 }

--- a/zkevm-circuits/src/evm_circuit/execution/end_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/end_tx.rs
@@ -180,7 +180,8 @@ impl<F: Field> ExecutionGadget<F> for EndTxGadget<F> {
         );
 
         cb.condition(
-            cb.next.execution_state_selector([ExecutionState::EndBlock]),
+            cb.next
+                .execution_state_selector([ExecutionState::EndBlock, ExecutionState::Padding]),
             |cb| {
                 cb.require_step_state_transition(StepStateTransition {
                     rw_counter: Delta(9.expr() - is_first_tx.expr() + coinbase_reward.rw_delta()),

--- a/zkevm-circuits/src/evm_circuit/execution/padding.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/padding.rs
@@ -1,0 +1,78 @@
+use std::marker::PhantomData;
+
+use crate::evm_circuit::{
+    execution::ExecutionGadget,
+    step::ExecutionState,
+    util::{
+        constraint_builder::{EVMConstraintBuilder, StepStateTransition},
+        CachedRegion,
+    },
+    witness::{Block, Call, ExecStep, Transaction},
+};
+use eth_types::Field;
+use halo2_proofs::plonk::Error;
+
+#[derive(Clone, Debug)]
+pub(crate) struct PaddingGadget<F> {
+    _phantom: PhantomData<F>,
+}
+
+impl<F: Field> ExecutionGadget<F> for PaddingGadget<F> {
+    const NAME: &'static str = "Padding";
+
+    const EXECUTION_STATE: ExecutionState = ExecutionState::Padding;
+
+    fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
+        cb.require_step_state_transition(StepStateTransition {
+            ..StepStateTransition::same()
+        });
+
+        Self {
+            _phantom: PhantomData,
+        }
+    }
+
+    fn assign_exec_step(
+        &self,
+        _region: &mut CachedRegion<'_, '_, F>,
+        _offset: usize,
+        _block: &Block<F>,
+        _: &Transaction,
+        _: &Call,
+        _step: &ExecStep,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::test_util::CircuitTestBuilder;
+
+    use eth_types::bytecode;
+
+    use mock::TestContext;
+
+    fn test_circuit(evm_circuit_pad_to: usize) {
+        let bytecode = bytecode! {
+            PUSH1(0)
+            STOP
+        };
+
+        let ctx = TestContext::<2, 1>::simple_ctx_with_bytecode(bytecode).unwrap();
+
+        // finish required tests using this witness block
+        CircuitTestBuilder::<2, 1>::new_from_test_ctx(ctx)
+            .block_modifier(Box::new(move |block| {
+                block.circuits_params.max_evm_rows = evm_circuit_pad_to
+            }))
+            .run();
+    }
+
+    // Test where the EVM circuit has a fixed size and contains several Padding
+    // at the end after the trace steps
+    #[test]
+    fn padding() {
+        test_circuit(50);
+    }
+}

--- a/zkevm-circuits/src/evm_circuit/param.rs
+++ b/zkevm-circuits/src/evm_circuit/param.rs
@@ -8,7 +8,7 @@ use halo2_proofs::{
 use std::collections::HashMap;
 
 // Step dimension
-pub(crate) const STEP_WIDTH: usize = 131;
+pub(crate) const STEP_WIDTH: usize = 132;
 /// Step height
 pub const MAX_STEP_HEIGHT: usize = 19;
 /// The height of the state of a step, used by gates that connect two

--- a/zkevm-circuits/src/evm_circuit/step.rs
+++ b/zkevm-circuits/src/evm_circuit/step.rs
@@ -42,6 +42,7 @@ pub enum ExecutionState {
     BeginTx,
     EndTx,
     EndBlock,
+    Padding,
     BeginChunk,
     EndChunk,
     // Opcode successful cases
@@ -302,6 +303,7 @@ impl From<&ExecStep> for ExecutionState {
             }
             ExecState::BeginTx => ExecutionState::BeginTx,
             ExecState::EndTx => ExecutionState::EndTx,
+            ExecState::Padding => ExecutionState::Padding,
             ExecState::EndBlock => ExecutionState::EndBlock,
             ExecState::BeginChunk => ExecutionState::BeginChunk,
             ExecState::EndChunk => ExecutionState::EndChunk,

--- a/zkevm-circuits/src/witness/block.rs
+++ b/zkevm-circuits/src/witness/block.rs
@@ -27,11 +27,11 @@ pub struct Block<F> {
     pub randomness: F,
     /// Transactions in the block
     pub txs: Vec<Transaction>,
-    /// EndBlock step that is repeated after the last transaction and before
+    /// Padding step that is repeated after the last transaction and before
     /// reaching the last EVM row.
-    pub end_block_not_last: ExecStep,
-    /// Last EndBlock step that appears in the last EVM row.
-    pub end_block_last: ExecStep,
+    pub padding: ExecStep,
+    /// EndBlock step that appears in the last chunk last EVM row.
+    pub end_block: ExecStep,
     /// BeginChunk step to propagate State
     pub begin_chunk: ExecStep,
     /// EndChunk step that appears in the last EVM row for all the chunks other than the last.
@@ -282,8 +282,8 @@ pub fn block_convert<F: Field>(
         // TODO get permutation fingerprint & challenges
         permu_alpha: F::from(103),
         permu_gamma: F::from(101),
-        end_block_not_last: block.block_steps.end_block_not_last.clone(),
-        end_block_last: block.block_steps.end_block_last.clone(),
+        padding: block.block_steps.padding.clone(),
+        end_block: block.block_steps.end_block.clone(),
         // TODO refactor chunk related field to chunk structure
         begin_chunk: block.block_steps.begin_chunk.clone(),
         end_chunk: block.block_steps.end_chunk.clone(),


### PR DESCRIPTION
### Description

Introduce this virtual step to carry transition context, which do not incur any extra rw_table lookup.
This also eliminate ambiguous `end_block_non_last` with unified padding virtual step.

### Design Rationale

Why introduce Padding
- Currently we use EndBlock as padding, which still append few unnecessary rw_table lookup, so it make slight hard to control `evm_row` and `max_rws` separate and independently.
- EndBlock as padding only work in single chunk. When comes to multiple chunk, we will have the case that we need to padding execution steps. Padding as [...EndBlock, EndBlock, ... EndChunk] is semantically unpreferred. Another option is [... EndChunk,... EndChunk, EndChunk] however EndChunk introduce > 10 rw_table lookup, so padding like this will easily to hit  `max_rws` bound.

Therefore, introduce virtual step `Padding` to solve it.

### 2 use cases for this

#### Padding then following by `EndChunk`
```
[
...
Padding,
Padding,
EndChunk
]
```

#### Padding then following by `EndBlock`
```
[
...
Padding,
Padding,
EndBlock
]
```