### PR TITLE
fix soundness: share txid write lookup across step

### DIFF
--- a/bus-mapping/src/evm/opcodes/begin_end_tx.rs
+++ b/bus-mapping/src/evm/opcodes/begin_end_tx.rs
@@ -343,10 +343,6 @@ pub(crate) fn end_tx(
     // Write the tx receipt
     write_tx_receipt(state, exec_step, call.is_persistent)?;
 
-    // Write the next transaction id if we're not at the last tx
-    if !state.tx_ctx.is_last_tx() {
-        // do nothing. as the txid lookup will share the same rwc and txid with next step
-    }
     Ok(())
 }
 

--- a/bus-mapping/src/evm/opcodes/begin_end_tx.rs
+++ b/bus-mapping/src/evm/opcodes/begin_end_tx.rs
@@ -345,12 +345,7 @@ pub(crate) fn end_tx(
 
     // Write the next transaction id if we're not at the last tx
     if !state.tx_ctx.is_last_tx() {
-        state.call_context_write(
-            exec_step,
-            state.block_ctx.rwc.0 + 1,
-            CallContextField::TxId,
-            (state.tx_ctx.id() + 1).into(),
-        )?;
+        // do nothing. as the txid lookup will share the same rwc and txid with next step
     }
     Ok(())
 }

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -1081,7 +1081,6 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
     }
 
     // Call context
-
     pub(crate) fn call_context(
         &mut self,
         call_id: Option<Expression<F>>,
@@ -1132,6 +1131,8 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         );
     }
 
+    // same as call_context_lookup_write with bypassing external rwc
+    // Note: will not bumping internal rwc
     pub(crate) fn call_context_lookup_write_with_counter(
         &mut self,
         rw_counter: Expression<F>,

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -1132,6 +1132,30 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         );
     }
 
+    pub(crate) fn call_context_lookup_write_with_counter(
+        &mut self,
+        rw_counter: Expression<F>,
+        call_id: Option<Expression<F>>,
+        field_tag: CallContextFieldTag,
+        value: Word<Expression<F>>,
+    ) {
+        self.rw_lookup_with_counter(
+            "CallContext lookup",
+            rw_counter,
+            1.expr(),
+            Target::CallContext,
+            RwValues::new(
+                call_id.unwrap_or_else(|| self.curr.state.call_id.expr()),
+                0.expr(),
+                field_tag.expr(),
+                Word::zero(),
+                value,
+                Word::zero(),
+                Word::zero(),
+            ),
+        );
+    }
+
     pub(crate) fn call_context_lookup_write(
         &mut self,
         call_id: Option<Expression<F>>,

--- a/zkevm-circuits/src/test_util.rs
+++ b/zkevm-circuits/src/test_util.rs
@@ -145,7 +145,8 @@ impl<const NACC: usize, const NTX: usize> CircuitTestBuilder<NACC, NTX> {
 }
 
 impl<const NACC: usize, const NTX: usize> CircuitTestBuilder<NACC, NTX> {
-    fn build_block(&self) -> Result<Block<Fr>, CircuitTestError> {
+    /// build block
+    pub fn build_block(&self) -> Result<Block<Fr>, CircuitTestError> {
         if let Some(block) = &self.block {
             // If a block is specified, no need to modify the block
             return Ok(block.clone());


### PR DESCRIPTION
### Description

This PR fix soundness by sharing txid write lookup between current step and next step

### Issue Link

#1707 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Design rationale
Before fix, `cur_end_tx -> callcontext(txid, WRITE)` vs `next_begin_tx -> callcontext(txid, WRITE)` are meant to constraint `next_tx_id = cur_tx_id + 1`. However, because 2 callcontext write are different records in rw_table, so actually second record are under-constraint and tx_id can be manipulated. 

Because so far we do not have negative test framework. So this PR just simply adding a simple positive test to assure there is no consecutive tx_id write with SAME tx_id.

If this fix make sense, will update zkevm-specs accordingly https://github.com/privacy-scaling-explorations/zkevm-specs/blob/master/src/zkevm_specs/evm_circuit/execution/end_tx.py#L71-L79