### PR TITLE
StorageDoesNotExist lookups

### DIFF
--- a/light-client-poc/bin/test_mainnet/main.rs
+++ b/light-client-poc/bin/test_mainnet/main.rs
@@ -65,7 +65,7 @@ async fn run_tests() -> Result<()> {
         2000004,
         include_str!("al/2000004.json"),
         16,
-        max_proof_count,
+        70,
     )
     .await?;
     mock_prove(

--- a/light-client-poc/src/circuits/initial_state/circuit.rs
+++ b/light-client-poc/src/circuits/initial_state/circuit.rs
@@ -359,8 +359,6 @@ impl<F: Field> Circuit<F> for InitialStateCircuit<F> {
             vec![q_enable * xnif(is_last_or_padding.expr(), new_root_propagation.expr())]
         });
 
-        /*
-        Note: when there is a non-existing-proof, the state doesn't change
         meta.create_gate(
             "if not last or padding, if state changed in cur row, next row must change state also",
             |meta| {
@@ -380,7 +378,6 @@ impl<F: Field> Circuit<F> for InitialStateCircuit<F> {
                 ]
             },
         );
-        */
 
         meta.create_gate(
             "if not padding and not last row, roots should be chained",

--- a/light-client-poc/src/circuits/initial_state/circuit.rs
+++ b/light-client-poc/src/circuits/initial_state/circuit.rs
@@ -359,6 +359,8 @@ impl<F: Field> Circuit<F> for InitialStateCircuit<F> {
             vec![q_enable * xnif(is_last_or_padding.expr(), new_root_propagation.expr())]
         });
 
+        /*
+        Note: when there is a non-existing-proof, the state doesn't change
         meta.create_gate(
             "if not last or padding, if state changed in cur row, next row must change state also",
             |meta| {
@@ -378,6 +380,7 @@ impl<F: Field> Circuit<F> for InitialStateCircuit<F> {
                 ]
             },
         );
+        */
 
         meta.create_gate(
             "if not padding and not last row, roots should be chained",

--- a/light-client-poc/src/witness/mod.rs
+++ b/light-client-poc/src/witness/mod.rs
@@ -270,7 +270,12 @@ impl<F: Field> Witness<F> {
             if old.balance != new.balance {
                 changed_values.push(TrieModification::balance(address, new.balance));
             }
-            if old.code_hash != new.code_hash {
+            // If the account has been implicitly created before this code_hash modification
+            // and if this code_hash modification sets it to the default value (which have been
+            // already set implicitly), omit it.
+            let default_code_hash = "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470";
+            let is_default = new.code_hash == H256::from_str(default_code_hash).unwrap();
+            if old.code_hash != new.code_hash && !is_default {
                 changed_values.push(TrieModification::codehash(address, new.code_hash));
             }
 


### PR DESCRIPTION
### Description

This PR introduces non-existing proofs for the initial state circuit for the leaves that don't exist yet in the trie. The required changes in the MPT circuit are implemented [here](https://github.com/privacy-scaling-explorations/zkevm-circuits/pull/1699).

### Issue Link

The related issue is [here](https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/1663), but this PR only partially resolves it.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

