### PR TITLE
Runtime config

### DIFF
--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -674,14 +674,7 @@ pub fn build_state_code_db(
 impl<P: JsonRpcClient> BuilderClient<P> {
     /// Create a new BuilderClient
     pub async fn new(client: GethClient<P>, circuits_params: FixedCParams) -> Result<Self, Error> {
-        let chain_id = client.get_chain_id().await?;
-
-        Ok(Self {
-            cli: client,
-            chain_id: chain_id.into(),
-            circuits_params,
-            feature_config: FeatureConfig::default(),
-        })
+        Self::new_with_features(client, circuits_params, FeatureConfig::default()).await
     }
 
     /// Create a new BuilderClient

--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -72,6 +72,13 @@ impl Default for FeatureConfig {
     }
 }
 
+impl FeatureConfig {
+    /// Check if we are mainnet config
+    pub fn is_mainnet(&self) -> bool {
+        self.zero_difficulty && !self.free_first_tx && self.enable_eip1559 && !self.invalid_tx
+    }
+}
+
 /// Circuit Setup Parameters
 #[derive(Debug, Clone, Copy)]
 pub struct FixedCParams {

--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -42,6 +42,16 @@ use std::{
 pub use transaction::{Transaction, TransactionContext};
 pub use withdrawal::{Withdrawal, WithdrawalContext};
 
+
+/// Runtime Config
+#[derive(Debug, Clone, Copy)]
+pub struct FeatureConfig {
+    zero_difficulty: bool,
+    free_first_tx: bool,
+    enable_eip1559: bool,
+    invalid_tx: bool,
+}
+
 /// Circuit Setup Parameters
 #[derive(Debug, Clone, Copy)]
 pub struct FixedCParams {

--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -616,6 +616,7 @@ pub struct BuilderClient<P: JsonRpcClient> {
     cli: GethClient<P>,
     chain_id: Word,
     circuits_params: FixedCParams,
+    feature_config: FeatureConfig,
 }
 
 /// Get State Accesses from TxExecTraces
@@ -679,6 +680,23 @@ impl<P: JsonRpcClient> BuilderClient<P> {
             cli: client,
             chain_id: chain_id.into(),
             circuits_params,
+            feature_config: FeatureConfig::default(),
+        })
+    }
+
+    /// Create a new BuilderClient
+    pub async fn new_with_features(
+        client: GethClient<P>,
+        circuits_params: FixedCParams,
+        feature_config: FeatureConfig,
+    ) -> Result<Self, Error> {
+        let chain_id = client.get_chain_id().await?;
+
+        Ok(Self {
+            cli: client,
+            chain_id: chain_id.into(),
+            circuits_params,
+            feature_config,
         })
     }
 
@@ -795,7 +813,7 @@ impl<P: JsonRpcClient> BuilderClient<P> {
             code_db,
             block,
             self.circuits_params,
-            FeatureConfig::default(),
+            self.feature_config,
         );
         builder.handle_block(eth_block, geth_traces)?;
         Ok(builder)

--- a/bus-mapping/src/mock.rs
+++ b/bus-mapping/src/mock.rs
@@ -34,6 +34,14 @@ impl<C: CircuitsParams> BlockData<C> {
     /// Generate a new CircuitInputBuilder initialized with the context of the
     /// BlockData.
     pub fn new_circuit_input_builder(&self) -> CircuitInputBuilder<C> {
+        self.new_circuit_input_builder_with_feature(FeatureConfig::default())
+    }
+    /// Generate a new CircuitInputBuilder initialized with the context of the
+    /// BlockData.
+    pub fn new_circuit_input_builder_with_feature(
+        &self,
+        feature_config: FeatureConfig,
+    ) -> CircuitInputBuilder<C> {
         CircuitInputBuilder::new(
             self.sdb.clone(),
             self.code_db.clone(),
@@ -45,7 +53,7 @@ impl<C: CircuitsParams> BlockData<C> {
             )
             .unwrap(),
             self.circuits_params,
-            FeatureConfig::default(),
+            feature_config,
         )
     }
 

--- a/bus-mapping/src/mock.rs
+++ b/bus-mapping/src/mock.rs
@@ -3,7 +3,7 @@
 use crate::{
     circuit_input_builder::{
         get_state_accesses, Block, CircuitInputBuilder, CircuitsParams, DynamicCParams,
-        FixedCParams,
+        FeatureConfig, FixedCParams,
     },
     state_db::{self, CodeDB, StateDB},
 };
@@ -45,6 +45,7 @@ impl<C: CircuitsParams> BlockData<C> {
             )
             .unwrap(),
             self.circuits_params,
+            FeatureConfig::default(),
         )
     }
 

--- a/zkevm-circuits/src/bin/stats/main.rs
+++ b/zkevm-circuits/src/bin/stats/main.rs
@@ -1,3 +1,4 @@
+use bus_mapping::circuit_input_builder::FeatureConfig;
 use cli_table::{print_stdout, Cell, Style, Table};
 use eth_types::{bytecode, evm_types::OpcodeId, ToWord};
 use halo2_proofs::{
@@ -113,7 +114,7 @@ fn copy_states_stats() {
 /// cell consumers of each EVM Cell type.
 fn get_exec_steps_occupancy() {
     let mut meta = ConstraintSystem::<Fr>::default();
-    let circuit = EvmCircuit::configure(&mut meta);
+    let circuit = EvmCircuit::configure_with_params(&mut meta, FeatureConfig::default());
 
     let report = circuit.0.execution.instrument().clone().analyze();
     macro_rules! gen_report {

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -410,8 +410,8 @@ impl<F: Field> Circuit<F> for EvmCircuit<F> {
         )
     }
 
-    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
-        Self::configure_with_params(meta, Default::default())
+    fn configure(_meta: &mut ConstraintSystem<F>) -> Self::Config {
+        unreachable!();
     }
 
     fn synthesize(

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -315,7 +315,7 @@ pub(crate) mod cached {
         static ref CACHE: Cache = {
             let mut meta = ConstraintSystem::<Fr>::default();
             // Cached EVM circuit is configured with Mainnet FeatureConfig
-            let config = EvmCircuit::<Fr>::configure(&mut meta);
+            let config = EvmCircuit::<Fr>::configure_with_params(&mut meta, FeatureConfig::default());
             Cache { cs: meta, config }
         };
     }

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -26,7 +26,7 @@ use crate::{
     },
     util::{Challenges, SubCircuit, SubCircuitConfig},
 };
-use bus_mapping::evm::OpcodeId;
+use bus_mapping::{circuit_input_builder::FeatureConfig, evm::OpcodeId};
 use eth_types::Field;
 use execution::ExecutionConfig;
 use itertools::Itertools;
@@ -74,6 +74,7 @@ pub struct EvmCircuitConfigArgs<F: Field> {
     pub u8_table: UXTable<8>,
     /// U16Table
     pub u16_table: UXTable<16>,
+    /// Feature config
     pub feature_config: FeatureConfig,
 }
 
@@ -365,41 +366,39 @@ impl<F: Field> Circuit<F> for EvmCircuit<F> {
         Self::default()
     }
 
-    fn configure_with_params(
-            meta: &mut ConstraintSystem<F>,
-            params: Self::Params,
-        ) -> Self::Config {
-            let tx_table = TxTable::construct(meta);
-            let rw_table = RwTable::construct(meta);
-            let bytecode_table = BytecodeTable::construct(meta);
-            let block_table = BlockTable::construct(meta);
-            let q_copy_table = meta.fixed_column();
-            let copy_table = CopyTable::construct(meta, q_copy_table);
-            let keccak_table = KeccakTable::construct(meta);
-            let exp_table = ExpTable::construct(meta);
-            let u8_table = UXTable::construct(meta);
-            let u16_table = UXTable::construct(meta);
-            let challenges = Challenges::construct(meta);
-            let challenges_expr = challenges.exprs(meta);
-    
-            (
-                EvmCircuitConfig::new(
-                    meta,
-                    EvmCircuitConfigArgs {
-                        challenges: challenges_expr,
-                        tx_table,
-                        rw_table,
-                        bytecode_table,
-                        block_table,
-                        copy_table,
-                        keccak_table,
-                        exp_table,
-                        u8_table,
-                        u16_table,
-                    },
-                ),
-                challenges,
-            )
+    fn configure_with_params(meta: &mut ConstraintSystem<F>, params: Self::Params) -> Self::Config {
+        let tx_table = TxTable::construct(meta);
+        let rw_table = RwTable::construct(meta);
+        let bytecode_table = BytecodeTable::construct(meta);
+        let block_table = BlockTable::construct(meta);
+        let q_copy_table = meta.fixed_column();
+        let copy_table = CopyTable::construct(meta, q_copy_table);
+        let keccak_table = KeccakTable::construct(meta);
+        let exp_table = ExpTable::construct(meta);
+        let u8_table = UXTable::construct(meta);
+        let u16_table = UXTable::construct(meta);
+        let challenges = Challenges::construct(meta);
+        let challenges_expr = challenges.exprs(meta);
+
+        (
+            EvmCircuitConfig::new(
+                meta,
+                EvmCircuitConfigArgs {
+                    challenges: challenges_expr,
+                    tx_table,
+                    rw_table,
+                    bytecode_table,
+                    block_table,
+                    copy_table,
+                    keccak_table,
+                    exp_table,
+                    u8_table,
+                    u16_table,
+                    feature_config: params,
+                },
+            ),
+            challenges,
+        )
     }
 
     fn configure(_meta: &mut ConstraintSystem<F>) -> Self::Config {

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -452,7 +452,10 @@ mod evm_circuit_stats {
         util::{unusable_rows, SubCircuit},
         witness::block_convert,
     };
-    use bus_mapping::{circuit_input_builder::FixedCParams, mock::BlockData};
+    use bus_mapping::{
+        circuit_input_builder::{FeatureConfig, FixedCParams},
+        mock::BlockData,
+    };
 
     use eth_types::{bytecode, geth_types::GethData};
     use halo2_proofs::{self, dev::MockProver, halo2curves::bn256::Fr};
@@ -466,7 +469,7 @@ mod evm_circuit_stats {
     fn evm_circuit_unusable_rows() {
         assert_eq!(
             EvmCircuit::<Fr>::unusable_rows(),
-            unusable_rows::<Fr, EvmCircuit::<Fr>>(()),
+            unusable_rows::<Fr, EvmCircuit::<Fr>>(FeatureConfig::default()),
         )
     }
 

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -314,6 +314,7 @@ pub(crate) mod cached {
         /// Circuit configuration.  These values are calculated just once.
         static ref CACHE: Cache = {
             let mut meta = ConstraintSystem::<Fr>::default();
+            // Cached EVM circuit is configured with Mainnet FeatureConfig
             let config = EvmCircuit::<Fr>::configure(&mut meta);
             Cache { cs: meta, config }
         };
@@ -364,6 +365,14 @@ impl<F: Field> Circuit<F> for EvmCircuit<F> {
 
     fn without_witnesses(&self) -> Self {
         Self::default()
+    }
+
+    /// Try to get the [`FeatureConfig`] from the block or fallback to default
+    fn params(&self) -> Self::Params {
+        self.block
+            .as_ref()
+            .map(|block| block.feature_config)
+            .unwrap_or_default()
     }
 
     fn configure_with_params(meta: &mut ConstraintSystem<F>, params: Self::Params) -> Self::Config {

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -476,9 +476,20 @@ mod evm_circuit_stats {
 
     #[test]
     fn evm_circuit_unusable_rows() {
+        let computed = EvmCircuit::<Fr>::unusable_rows();
+        let mainnet_config = FeatureConfig::default();
+        let invalid_tx_config = FeatureConfig {
+            invalid_tx: true,
+            ..Default::default()
+        };
+
         assert_eq!(
-            EvmCircuit::<Fr>::unusable_rows(),
-            unusable_rows::<Fr, EvmCircuit::<Fr>>(FeatureConfig::default()),
+            computed,
+            unusable_rows::<Fr, EvmCircuit::<Fr>>(mainnet_config),
+        );
+        assert_eq!(
+            computed,
+            unusable_rows::<Fr, EvmCircuit::<Fr>>(invalid_tx_config),
         )
     }
 

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -401,8 +401,8 @@ impl<F: Field> Circuit<F> for EvmCircuit<F> {
         )
     }
 
-    fn configure(_meta: &mut ConstraintSystem<F>) -> Self::Config {
-        unreachable!()
+    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+        Self::configure_with_params(meta, Default::default())
     }
 
     fn synthesize(

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -357,6 +357,7 @@ impl<F: Field> ExecutionConfig<F> {
         copy_table: &dyn LookupTable<F>,
         keccak_table: &dyn LookupTable<F>,
         exp_table: &dyn LookupTable<F>,
+        feature_config: FeatureConfig,
     ) -> Self {
         let mut instrument = Instrument::default();
         let q_usable = meta.complex_selector();
@@ -395,6 +396,7 @@ impl<F: Field> ExecutionConfig<F> {
 
             let execution_state_selector_constraints = step_curr.state.execution_state.configure();
 
+            // TODO: Change logic depending on feature_config.invalid_tx
             // NEW: Enabled, this will break hand crafted tests, maybe we can remove them?
             let first_step_check = {
                 let begin_tx_invalid_tx_end_block_selector = step_curr.execution_state_selector([
@@ -504,6 +506,7 @@ impl<F: Field> ExecutionConfig<F> {
                         &mut stored_expressions_map,
                         &mut debug_expressions_map,
                         &mut instrument,
+                        feature_config.clone(),
                     ))
                 })()
             };
@@ -654,6 +657,7 @@ impl<F: Field> ExecutionConfig<F> {
         stored_expressions_map: &mut HashMap<ExecutionState, Vec<StoredExpression<F>>>,
         debug_expressions_map: &mut HashMap<ExecutionState, Vec<(String, Expression<F>)>>,
         instrument: &mut Instrument,
+        feature_config: FeatureConfig,
     ) -> G {
         // Configure the gadget with the max height first so we can find out the actual
         // height
@@ -665,6 +669,7 @@ impl<F: Field> ExecutionConfig<F> {
                 dummy_step_next,
                 challenges,
                 G::EXECUTION_STATE,
+                feature_config,
             );
             G::configure(&mut cb);
             let (_, _, height, _) = cb.build();
@@ -782,6 +787,7 @@ impl<F: Field> ExecutionConfig<F> {
             let q_step = meta.query_advice(q_step, Rotation::cur());
             let q_step_last = meta.query_selector(q_step_last);
 
+            // TODO: diable InvalidTx
             // ExecutionState transition should be correct.
             iter::empty()
                 .chain(

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -1277,9 +1277,10 @@ impl<F: Field> ExecutionConfig<F> {
             ExecutionState::EndTx => assign_exec_step!(self.end_tx_gadget),
             ExecutionState::EndBlock => assign_exec_step!(self.end_block_gadget),
             ExecutionState::InvalidTx => {
-                if let Some(invalid_tx) = &self.invalid_tx {
-                    assign_exec_step!(invalid_tx)
-                }
+                assign_exec_step!(self
+                    .invalid_tx
+                    .as_deref()
+                    .expect("invalid tx gadget must exist"))
             }
             // opcode
             ExecutionState::ADD_SUB => assign_exec_step!(self.add_sub_gadget),

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -396,14 +396,17 @@ impl<F: Field> ExecutionConfig<F> {
 
             let execution_state_selector_constraints = step_curr.state.execution_state.configure();
 
-            // TODO: Change logic depending on feature_config.invalid_tx
             // NEW: Enabled, this will break hand crafted tests, maybe we can remove them?
             let first_step_check = {
-                let begin_tx_invalid_tx_end_block_selector = step_curr.execution_state_selector([
-                    ExecutionState::BeginTx,
-                    ExecutionState::InvalidTx,
-                    ExecutionState::EndBlock,
-                ]);
+                let begin_tx_invalid_tx_end_block_selector = step_curr.execution_state_selector(
+                    [ExecutionState::BeginTx, ExecutionState::EndBlock]
+                        .into_iter()
+                        .chain(
+                            feature_config
+                                .invalid_tx
+                                .then_some(ExecutionState::InvalidTx),
+                        ),
+                );
                 iter::once((
                     "First step should be BeginTx, InvalidTx or EndBlock",
                     q_step_first * (1.expr() - begin_tx_invalid_tx_end_block_selector),

--- a/zkevm-circuits/src/evm_circuit/execution/invalid_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/invalid_tx.rs
@@ -69,7 +69,7 @@ impl<F: Field> ExecutionGadget<F> for InvalidTxGadget<F> {
             insufficient_gas_limit.expr(),
             insufficient_balance.expr(),
         ]);
-        cb.require_equal("Tx needs to be invalid", invalid_tx.expr(), 1.expr());
+        cb.require_true("Tx needs to be invalid", invalid_tx.expr());
 
         let end_tx = EndTxHelperGadget::construct(
             cb,

--- a/zkevm-circuits/src/evm_circuit/execution/invalid_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/invalid_tx.rs
@@ -138,8 +138,8 @@ impl<F: Field> ExecutionGadget<F> for InvalidTxGadget<F> {
 #[cfg(test)]
 mod test {
     use crate::test_util::CircuitTestBuilder;
+    use bus_mapping::circuit_input_builder::FeatureConfig;
     use eth_types::{self, bytecode, Word};
-
     use mock::{eth, gwei, TestContext, MOCK_ACCOUNTS};
 
     #[test]
@@ -164,7 +164,12 @@ mod test {
             |block, _| block,
         )
         .unwrap();
-        CircuitTestBuilder::new_from_test_ctx(ctx).run();
+        CircuitTestBuilder::new_from_test_ctx(ctx)
+            .feature(FeatureConfig {
+                invalid_tx: true,
+                ..Default::default()
+            })
+            .run();
     }
 
     #[test]
@@ -194,7 +199,12 @@ mod test {
             |block, _| block,
         )
         .unwrap();
-        CircuitTestBuilder::new_from_test_ctx(ctx).run();
+        CircuitTestBuilder::new_from_test_ctx(ctx)
+            .feature(FeatureConfig {
+                invalid_tx: true,
+                ..Default::default()
+            })
+            .run();
     }
 
     #[test]
@@ -220,7 +230,12 @@ mod test {
             |block, _| block,
         )
         .unwrap();
-        CircuitTestBuilder::new_from_test_ctx(ctx).run();
+        CircuitTestBuilder::new_from_test_ctx(ctx)
+            .feature(FeatureConfig {
+                invalid_tx: true,
+                ..Default::default()
+            })
+            .run();
     }
 
     #[test]
@@ -249,7 +264,12 @@ mod test {
                 |block, _| block,
             )
             .unwrap();
-            CircuitTestBuilder::new_from_test_ctx(ctx).run();
+            CircuitTestBuilder::new_from_test_ctx(ctx)
+                .feature(FeatureConfig {
+                    invalid_tx: true,
+                    ..Default::default()
+                })
+                .run();
         }
 
         // Check different permutations to make sure all transitions work correctly

--- a/zkevm-circuits/src/evm_circuit/param.rs
+++ b/zkevm-circuits/src/evm_circuit/param.rs
@@ -169,19 +169,35 @@ pub(crate) const N_BYTES_WITHDRAWAL: usize = N_BYTES_U64 //id
     + N_BYTES_U64; // amount
 
 lazy_static::lazy_static! {
+    static ref INVALID_TX_CONFIG: FeatureConfig = FeatureConfig {
+        invalid_tx: true,
+        ..Default::default()
+    };
     // Step slot height in evm circuit
-    pub(crate) static ref EXECUTION_STATE_HEIGHT_MAP : HashMap<ExecutionState, usize> = get_step_height_map();
+    // We enable the invalid_tx feature to get invalid tx's ExecutionState height
+    // We garentee the heights of other ExecutionStates remains unchanged in the following test
+    pub(crate) static ref EXECUTION_STATE_HEIGHT_MAP : HashMap<ExecutionState, usize> = get_step_height_map(*INVALID_TX_CONFIG);
 }
-fn get_step_height_map() -> HashMap<ExecutionState, usize> {
+fn get_step_height_map(feature_config: FeatureConfig) -> HashMap<ExecutionState, usize> {
     let mut meta = ConstraintSystem::<Fr>::default();
-    let circuit = EvmCircuit::configure_with_params(
-        &mut meta,
-        FeatureConfig {
-            // Enable invalid_tx to get ExecutionState height
-            invalid_tx: true,
-            ..Default::default()
-        },
-    );
-
+    let circuit = EvmCircuit::configure_with_params(&mut meta, feature_config);
     circuit.0.execution.height_map
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_step_height_map() {
+        let mainnet_config = FeatureConfig::default();
+        let map_mainnet = get_step_height_map(mainnet_config);
+
+        let map_invalid_tx = {
+            let mut map = EXECUTION_STATE_HEIGHT_MAP.clone();
+            map.remove(&ExecutionState::InvalidTx);
+            map
+        };
+        // We show that the invalid tx feature affects none of the other execution state heights
+        assert_eq!(map_invalid_tx, map_mainnet);
+    }
 }

--- a/zkevm-circuits/src/evm_circuit/param.rs
+++ b/zkevm-circuits/src/evm_circuit/param.rs
@@ -174,11 +174,14 @@ lazy_static::lazy_static! {
 }
 fn get_step_height_map() -> HashMap<ExecutionState, usize> {
     let mut meta = ConstraintSystem::<Fr>::default();
-    let circuit = EvmCircuit::configure_with_params(&mut meta, FeatureConfig{
-        // Enable invalid_tx to get ExecutionState height
-        invalid_tx: true,
-        ..Default::default()
-    });
+    let circuit = EvmCircuit::configure_with_params(
+        &mut meta,
+        FeatureConfig {
+            // Enable invalid_tx to get ExecutionState height
+            invalid_tx: true,
+            ..Default::default()
+        },
+    );
 
     circuit.0.execution.height_map
 }

--- a/zkevm-circuits/src/evm_circuit/param.rs
+++ b/zkevm-circuits/src/evm_circuit/param.rs
@@ -1,6 +1,7 @@
 //! Constants and parameters for the EVM circuit
 use super::table::Table;
 use crate::evm_circuit::{step::ExecutionState, EvmCircuit};
+use bus_mapping::circuit_input_builder::FeatureConfig;
 use halo2_proofs::{
     halo2curves::bn256::Fr,
     plonk::{Circuit, ConstraintSystem},
@@ -173,7 +174,11 @@ lazy_static::lazy_static! {
 }
 fn get_step_height_map() -> HashMap<ExecutionState, usize> {
     let mut meta = ConstraintSystem::<Fr>::default();
-    let circuit = EvmCircuit::configure(&mut meta);
+    let circuit = EvmCircuit::configure_with_params(&mut meta, FeatureConfig{
+        // Enable invalid_tx to get ExecutionState height
+        invalid_tx: true,
+        ..Default::default()
+    });
 
     circuit.0.execution.height_map
 }

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -315,7 +315,7 @@ pub(crate) struct EVMConstraintBuilder<'a, F: Field> {
     stored_expressions: Vec<StoredExpression<F>>,
     pub(crate) debug_expressions: Vec<(String, Expression<F>)>,
     meta: &'a mut ConstraintSystem<F>,
-    feature_config: FeatureConfig,
+    pub(crate) feature_config: FeatureConfig,
 }
 
 impl<'a, F: Field> ConstrainBuilderCommon<F> for EVMConstraintBuilder<'a, F> {

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -313,6 +313,7 @@ pub(crate) struct EVMConstraintBuilder<'a, F: Field> {
     stored_expressions: Vec<StoredExpression<F>>,
     pub(crate) debug_expressions: Vec<(String, Expression<F>)>,
     meta: &'a mut ConstraintSystem<F>,
+    feature_config: FeatureConfig,
 }
 
 impl<'a, F: Field> ConstrainBuilderCommon<F> for EVMConstraintBuilder<'a, F> {
@@ -337,6 +338,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         next: Step<F>,
         challenges: &'a Challenges<Expression<F>>,
         execution_state: ExecutionState,
+        feature_config: FeatureConfig,
     ) -> Self {
         Self {
             curr,
@@ -358,6 +360,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
             stored_expressions: Vec::new(),
             meta,
             debug_expressions: Vec::new(),
+            feature_config,
         }
     }
 

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -15,7 +15,9 @@ use crate::{
         Challenges, Expr,
     },
 };
-use bus_mapping::{operation::Target, state_db::EMPTY_CODE_HASH_LE};
+use bus_mapping::{
+    circuit_input_builder::FeatureConfig, operation::Target, state_db::EMPTY_CODE_HASH_LE,
+};
 use eth_types::Field;
 use gadgets::util::{not, sum};
 use halo2_proofs::{

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/test_util.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/test_util.rs
@@ -1,3 +1,4 @@
+use bus_mapping::circuit_input_builder::FeatureConfig;
 use itertools::Itertools;
 use std::marker::PhantomData;
 use strum::IntoEnumIterator;
@@ -122,6 +123,7 @@ impl<F: Field, G: MathGadgetContainer<F>> Circuit<F> for UnitTestMathGadgetBaseC
             step_next,
             &challenges_exprs,
             ExecutionState::STOP,
+            FeatureConfig::default(),
         );
         let math_gadget_container = G::configure_gadget_container(&mut cb);
         let (constraints, stored_expressions, _, _) = cb.build();

--- a/zkevm-circuits/src/evm_circuit/util/memory_gadget/test_util.rs
+++ b/zkevm-circuits/src/evm_circuit/util/memory_gadget/test_util.rs
@@ -11,6 +11,7 @@ use crate::{
     },
     util::Challenges,
 };
+use bus_mapping::circuit_input_builder::FeatureConfig;
 use eth_types::{Field, Word};
 pub(crate) use halo2_proofs::circuit::Layouter;
 use halo2_proofs::{
@@ -101,6 +102,7 @@ impl<F: Field, G: MemoryGadgetContainer<F>> Circuit<F> for UnitTestMemoryGadgetB
             step_next,
             &challenges_exprs,
             ExecutionState::STOP,
+            FeatureConfig::default(),
         );
         let memory_gadget_container = G::configure_gadget_container(&mut cb);
         let (constraints, stored_expressions, _, _) = cb.build();

--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -99,20 +99,8 @@ pub struct SuperCircuitConfig<F: Field> {
     exp_circuit: ExpCircuitConfig<F>,
 }
 
-/// Circuit configuration arguments
-pub struct SuperCircuitConfigArgs<F: Field> {
-    /// Max txs
-    pub max_txs: usize,
-    /// Max withdrawals
-    pub max_withdrawals: usize,
-    /// Max calldata
-    pub max_calldata: usize,
-    /// Mock randomness
-    pub mock_randomness: F,
-}
-
 impl<F: Field> SubCircuitConfig<F> for SuperCircuitConfig<F> {
-    type ConfigArgs = SuperCircuitConfigArgs<F>;
+    type ConfigArgs = SuperCircuitParams<F>;
 
     /// Configure SuperCircuitConfig
     fn new(
@@ -122,6 +110,7 @@ impl<F: Field> SubCircuitConfig<F> for SuperCircuitConfig<F> {
             max_withdrawals,
             max_calldata,
             mock_randomness,
+            feature_config,
         }: Self::ConfigArgs,
     ) -> Self {
         let tx_table = TxTable::construct(meta);
@@ -221,7 +210,7 @@ impl<F: Field> SubCircuitConfig<F> for SuperCircuitConfig<F> {
                 exp_table,
                 u8_table,
                 u16_table,
-                feature_config: FeatureConfig::default(),
+                feature_config,
             },
         );
 
@@ -264,6 +253,8 @@ pub struct SuperCircuit<F: Field> {
     pub keccak_circuit: KeccakCircuit<F>,
     /// Circuits Parameters
     pub circuits_params: FixedCParams,
+    /// Feature Config
+    pub feature_config: FeatureConfig,
     /// Mock randomness
     pub mock_randomness: F,
 }
@@ -318,6 +309,7 @@ impl<F: Field> SubCircuit<F> for SuperCircuit<F> {
             exp_circuit,
             keccak_circuit,
             circuits_params: block.circuits_params,
+            feature_config: block.feature_config,
             mock_randomness: block.randomness,
         }
     }
@@ -391,6 +383,7 @@ pub struct SuperCircuitParams<F: Field> {
     max_withdrawals: usize,
     max_calldata: usize,
     mock_randomness: F,
+    feature_config: FeatureConfig,
 }
 
 impl<F: Field> Circuit<F> for SuperCircuit<F> {
@@ -408,19 +401,12 @@ impl<F: Field> Circuit<F> for SuperCircuit<F> {
             max_withdrawals: self.circuits_params.max_withdrawals,
             max_calldata: self.circuits_params.max_calldata,
             mock_randomness: self.mock_randomness,
+            feature_config: self.feature_config,
         }
     }
 
     fn configure_with_params(meta: &mut ConstraintSystem<F>, params: Self::Params) -> Self::Config {
-        Self::Config::new(
-            meta,
-            SuperCircuitConfigArgs {
-                max_txs: params.max_txs,
-                max_withdrawals: params.max_withdrawals,
-                max_calldata: params.max_calldata,
-                mock_randomness: params.mock_randomness,
-            },
-        )
+        Self::Config::new(meta, params)
     }
 
     fn configure(_meta: &mut ConstraintSystem<F>) -> Self::Config {

--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -70,7 +70,7 @@ use crate::{
     witness::{block_convert, Block, MptUpdates},
 };
 use bus_mapping::{
-    circuit_input_builder::{CircuitInputBuilder, FixedCParams},
+    circuit_input_builder::{CircuitInputBuilder, FeatureConfig, FixedCParams},
     mock::BlockData,
 };
 use eth_types::{geth_types::GethData, Field};
@@ -221,6 +221,7 @@ impl<F: Field> SubCircuitConfig<F> for SuperCircuitConfig<F> {
                 exp_table,
                 u8_table,
                 u16_table,
+                feature_config: FeatureConfig::default(),
             },
         );
 

--- a/zkevm-circuits/src/super_circuit/test.rs
+++ b/zkevm-circuits/src/super_circuit/test.rs
@@ -17,6 +17,7 @@ fn super_circuit_degree() {
         max_withdrawals: 5,
         max_calldata: 32,
         mock_randomness: Fr::from(0x100),
+        feature_config: FeatureConfig::default(),
     };
     SuperCircuit::configure_with_params(&mut cs, params);
     log::info!("super circuit degree: {}", cs.degree());

--- a/zkevm-circuits/src/test_util.rs
+++ b/zkevm-circuits/src/test_util.rs
@@ -6,7 +6,10 @@ use crate::{
     util::SubCircuit,
     witness::{Block, Rw},
 };
-use bus_mapping::{circuit_input_builder::FixedCParams, mock::BlockData};
+use bus_mapping::{
+    circuit_input_builder::{FeatureConfig, FixedCParams},
+    mock::BlockData,
+};
 use eth_types::geth_types::GethData;
 use itertools::all;
 use std::cmp;
@@ -81,6 +84,7 @@ const NUM_BLINDING_ROWS: usize = 64;
 pub struct CircuitTestBuilder<const NACC: usize, const NTX: usize> {
     test_ctx: Option<TestContext<NACC, NTX>>,
     circuits_params: Option<FixedCParams>,
+    feature_config: Option<FeatureConfig>,
     block: Option<Block<Fr>>,
     block_modifiers: Vec<Box<dyn Fn(&mut Block<Fr>)>>,
 }
@@ -91,6 +95,7 @@ impl<const NACC: usize, const NTX: usize> CircuitTestBuilder<NACC, NTX> {
         CircuitTestBuilder {
             test_ctx: None,
             circuits_params: None,
+            feature_config: None,
             block: None,
             block_modifiers: vec![],
         }
@@ -123,6 +128,13 @@ impl<const NACC: usize, const NTX: usize> CircuitTestBuilder<NACC, NTX> {
             "circuit_params already provided in the block"
         );
         self.circuits_params = Some(params);
+        self
+    }
+
+    /// Configure [`FeatureConfig`]
+    pub fn feature(mut self, feature_config: FeatureConfig) -> Self {
+        assert!(self.feature_config.is_none(), "Already configured");
+        self.feature_config = Some(feature_config);
         self
     }
 

--- a/zkevm-circuits/src/test_util.rs
+++ b/zkevm-circuits/src/test_util.rs
@@ -194,7 +194,7 @@ impl<const NACC: usize, const NTX: usize> CircuitTestBuilder<NACC, NTX> {
             let circuit = EvmCircuitCached::get_test_circuit_from_block(block);
             MockProver::<Fr>::run(k, &circuit, vec![])
         } else {
-            let circuit = EvmCircuit::new(block);
+            let circuit = EvmCircuit::get_test_circuit_from_block(block);
             MockProver::<Fr>::run(k, &circuit, vec![])
         };
 

--- a/zkevm-circuits/src/witness/block.rs
+++ b/zkevm-circuits/src/witness/block.rs
@@ -7,7 +7,7 @@ use crate::{
     util::{log2_ceil, word, SubCircuit},
 };
 use bus_mapping::{
-    circuit_input_builder::{self, CopyEvent, ExpEvent, FixedCParams, Withdrawal, FeatureConfig},
+    circuit_input_builder::{self, CopyEvent, ExpEvent, FeatureConfig, FixedCParams, Withdrawal},
     state_db::CodeDB,
     Error,
 };
@@ -43,6 +43,7 @@ pub struct Block<F> {
     pub exp_circuit_pad_to: usize,
     /// Circuit Setup Parameters
     pub circuits_params: FixedCParams,
+    /// Feature Config
     pub feature_config: FeatureConfig,
     /// Inputs to the SHA3 opcode
     pub sha3_inputs: Vec<Vec<u8>>,

--- a/zkevm-circuits/src/witness/block.rs
+++ b/zkevm-circuits/src/witness/block.rs
@@ -7,7 +7,7 @@ use crate::{
     util::{log2_ceil, word, SubCircuit},
 };
 use bus_mapping::{
-    circuit_input_builder::{self, CopyEvent, ExpEvent, FixedCParams, Withdrawal},
+    circuit_input_builder::{self, CopyEvent, ExpEvent, FixedCParams, Withdrawal, FeatureConfig},
     state_db::CodeDB,
     Error,
 };
@@ -43,6 +43,7 @@ pub struct Block<F> {
     pub exp_circuit_pad_to: usize,
     /// Circuit Setup Parameters
     pub circuits_params: FixedCParams,
+    pub feature_config: FeatureConfig,
     /// Inputs to the SHA3 opcode
     pub sha3_inputs: Vec<Vec<u8>>,
     /// State root of the previous block
@@ -288,6 +289,7 @@ pub fn block_convert<F: Field>(
         exp_events: block.exp_events.clone(),
         sha3_inputs: block.sha3_inputs.clone(),
         circuits_params: builder.circuits_params,
+        feature_config: builder.feature_config,
         exp_circuit_pad_to: <usize>::default(),
         prev_state_root: block.prev_state_root,
         keccak_inputs: circuit_input_builder::keccak_inputs(block, code_db)?,


### PR DESCRIPTION
### Description

We add an initial structure for runtime config. In this PR, we plan to add only the invalid tx configuration for the starter.

### Issue Link

#1636 

### Type of change

New feature (non-breaking change which adds functionality)


### Decision

- Allow Geth to take invalid tx. The config doesn't affect geth util


### TODO

- [x] Fix invalid tx test
- [ ] Add tx validity check. (Will continue #1740)

