### PR TITLE
chore: set resolver v2 at the workspace level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "zkevm-circuits",
     "bus-mapping",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -40,7 +40,7 @@ mock_prover = []
 
 [build-dependencies]
 env = "0.0.0"
-ethers = "=2.0.10"
+ethers = { version = "=2.0.10", features = ["ethers-solc"] }
 ethers-contract-abigen = "=2.0.10"
 glob = "0.3.1"
 log = "0.4.14"

--- a/light-client-poc/Cargo.toml
+++ b/light-client-poc/Cargo.toml
@@ -2,7 +2,6 @@
 name = "light-client-poc"
 version = "0.1.0"
 edition = "2021"
-resolver = "2"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
### Description

Cargo defaults to `resolver = "2"` in edition 2021 only for singular crates. Workspace tho defaults to the old `resolver = "1"` and will override this setting for all crates in the workspace. [The guideline](https://doc.rust-lang.org/cargo/reference/workspaces.html#virtual-workspace) is to manually set the `resolver = "2"` on workspace level.
This was documented recently and since a few releases produces a warning on building. You don't see it due to the `rust-toolchain` setting.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue) (not really a bugfix but that's the closest match)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Contents

- specifies `resolver = "2"` on workspace level
- removes `resolver = "2"` from light-client-poc/Cargo.toml because it was ignored anyway

This also fixes this warning:

```
warning: resolver for the non root package will be ignored, specify resolver at the workspace root:
package:   /data/bishop/zkevm-circuits/light-client-poc/Cargo.toml
workspace: /data/bishop/zkevm-circuits/Cargo.toml
```
