### PR TITLE
perf(circuit-tools): preallocate memory and remove unnecessary clones

### DIFF
--- a/zkevm-circuits/src/circuit_tools/cached_region.rs
+++ b/zkevm-circuits/src/circuit_tools/cached_region.rs
@@ -65,7 +65,8 @@ impl<'r, 'b, F: Field> CachedRegion<'r, 'b, F> {
         cb: &ConstraintBuilder<F, C>,
         challenges: &S,
     ) -> Result<(), Error> {
-        for (offset, region_id) in self.regions.clone() {
+        for n in 0..self.regions.len() {
+            let (offset, region_id) = self.regions[n];
             for stored_expression in cb.get_stored_expressions(region_id).iter() {
                 stored_expression.assign(self, challenges, offset)?;
             }
@@ -76,14 +77,7 @@ impl<'r, 'b, F: Field> CachedRegion<'r, 'b, F> {
     pub(crate) fn annotate_columns<C: CellType>(&mut self, cell_columns: &[CellColumn<F, C>]) {
         for c in cell_columns {
             self.region.name_column(
-                || {
-                    format!(
-                        "{:?} {:?}: {:?} queried",
-                        c.cell_type.clone(),
-                        c.index,
-                        c.height
-                    )
-                },
+                || format!("{:?} {:?}: {:?} queried", c.cell_type, c.index, c.height),
                 c.column,
             );
         }

--- a/zkevm-circuits/src/circuit_tools/constraint_builder.rs
+++ b/zkevm-circuits/src/circuit_tools/constraint_builder.rs
@@ -390,8 +390,8 @@ impl<F: Field, C: CellType> ConstraintBuilder<F, C> {
                 .collect();
             // Align the length of values and table
             assert!(lookup.table.len() >= values.len());
-            while values.len() < lookup.table.len() {
-                values.push(0.expr());
+            if values.len() < lookup.table.len() {
+                values.resize(lookup.table.len(), 0.expr());
             }
             meta.lookup_any(
                 Box::leak(lookup.description.clone().into_boxed_str()),

--- a/zkevm-circuits/src/circuit_tools/memory.rs
+++ b/zkevm-circuits/src/circuit_tools/memory.rs
@@ -68,10 +68,10 @@ impl<F: Field, C: CellType, MB: MemoryBank<F, C>> Memory<F, C, MB> {
     }
 
     pub(crate) fn get_columns(&self) -> Vec<Column<Advice>> {
-        self.banks.values().fold(Vec::new(), |mut acc, bank| {
-            acc.extend(bank.columns().iter());
-            acc
-        })
+        self.banks
+            .values()
+            .flat_map(|bank| bank.columns())
+            .collect()
     }
 
     pub(crate) fn build_constraints(
@@ -152,7 +152,7 @@ impl<F: Field, C: CellType> RwBank<F, C> {
         self.cur.expr()
     }
     pub(crate) fn prepend_key(&self, values: &[Expression<F>]) -> Vec<Expression<F>> {
-        [&[self.cur.expr() + 1.expr()], values].concat().to_vec()
+        [&[self.cur.expr() + 1.expr()], values].concat()
     }
 
     pub(crate) fn prepend_offset(
@@ -160,7 +160,7 @@ impl<F: Field, C: CellType> RwBank<F, C> {
         values: &[Expression<F>],
         offset: Expression<F>,
     ) -> Vec<Expression<F>> {
-        [&[self.cur.expr() - offset], values].concat().to_vec()
+        [&[self.cur.expr() - offset], values].concat()
     }
 }
 


### PR DESCRIPTION
### Description

This change optimizes memory allocations in `circuit-tools`. Where possible pre-allocates needed memory and removes some unneeded clones.

### Type of change

- [x] Perf optimization, refactor (non-breaking change which optimizes code's performance / memory footprint)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Contents

- preallocating or bulk resizing with `.reserve()`, `.with_capacity()` and `.resize()` or collecting
- some clones removals

### Rationale

This should increase performance a bit

### How Has This Been Tested?

```
cargo test -p zkevm-circuits
```