### PR TITLE
WASM support for zkevm-circuits crate

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,0 +1,64 @@
+name: WASM
+
+on:
+  merge_group:
+  pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+## `actions-rs/toolchain@v1` overwrite set to false so that
+## `rust-toolchain` is always used and the only source of truth.
+
+jobs:
+  skip_check:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          cancel_others: 'true'
+          concurrent_skipping: 'same_content_newer'
+          paths_ignore: '["**/README.md"]'
+
+  build:
+    needs: [skip_check]
+    if: |
+      github.event.pull_request.draft == false &&
+      (github.event.action == 'ready_for_review' || needs.skip_check.outputs.should_skip != 'true')
+
+    name: Build
+    runs-on: ["${{github.run_id}}", self-hosted, c5.9xlarge]
+
+    steps:
+      - name: Install OpenSSL lib
+        run: sudo apt-get -y install libssl-dev
+
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          override: false
+      - name: Cargo cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Build WASM
+        env:
+          RUSTFLAGS: '-C target-feature=+atomics,+bulk-memory'
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --verbose --release --package zkevm-circuits --no-default-features --target wasm32-unknown-unknown -Z build-std=panic_abort,std

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -45,6 +45,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           override: false
+          components: rust-src
       - name: Cargo cache
         uses: actions/cache@v3
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,8 +1755,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -5160,6 +5162,7 @@ dependencies = [
  "ethers-core",
  "ethers-signers",
  "gadgets",
+ "getrandom",
  "halo2_proofs",
  "hex",
  "integer",

--- a/bus-mapping/Cargo.toml
+++ b/bus-mapping/Cargo.toml
@@ -31,6 +31,5 @@ mock = { path = "../mock" }
 
 [features]
 default = ["notwasm"]
-wasm = []
 notwasm = ["revm-precompile"]
 test = ["mock"]

--- a/bus-mapping/Cargo.toml
+++ b/bus-mapping/Cargo.toml
@@ -20,8 +20,8 @@ serde = {version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.66"
 strum = "0.24"
 strum_macros = "0.24"
-revm-precompile = {version = "=2.2.0", default-features=false}
-
+revm-precompile = { version = "=2.2.0", default-features = false, optional = true }
+ 
 [dev-dependencies]
 hex = "0.4.3"
 pretty_assertions = "1.0.0"
@@ -30,4 +30,7 @@ url = "2.2.2"
 mock = { path = "../mock" }
 
 [features]
+default = ["notwasm"]
+wasm = []
+notwasm = ["revm-precompile"]
 test = ["mock"]

--- a/bus-mapping/src/lib.rs
+++ b/bus-mapping/src/lib.rs
@@ -223,6 +223,16 @@
 #![allow(clippy::upper_case_acronyms)] // Too pedantic
 #![feature(type_changing_struct_update)]
 
+#[cfg(all(target_arch = "wasm32", not(feature = "wasm")))]
+compile_error!("bus-mapping: wasm feature must be enabled on wasm arch");
+#[cfg(all(not(target_arch = "wasm32"), not(feature = "notwasm")))]
+compile_error!("bus-mapping: notwasm feature must be enabled when target arch is not wasm");
+
+#[cfg(all(feature = "wasm", feature = "notwasm"))]
+compile_error!("bus-mapping: both wasm & notwasm are enabled, just one of them must be enabled");
+#[cfg(all(not(feature = "wasm"), not(feature = "notwasm")))]
+compile_error!("bus-mapping: none of wasm & notwasm are enabled, one of them must be enabled");
+
 extern crate alloc;
 extern crate core;
 

--- a/bus-mapping/src/lib.rs
+++ b/bus-mapping/src/lib.rs
@@ -223,15 +223,10 @@
 #![allow(clippy::upper_case_acronyms)] // Too pedantic
 #![feature(type_changing_struct_update)]
 
-#[cfg(all(target_arch = "wasm32", not(feature = "wasm")))]
-compile_error!("bus-mapping: wasm feature must be enabled on wasm arch");
+#[cfg(all(target_arch = "wasm32", feature = "notwasm"))]
+compile_error!("bus-mapping: notwasm feature must be disabled when target arch is wasm");
 #[cfg(all(not(target_arch = "wasm32"), not(feature = "notwasm")))]
 compile_error!("bus-mapping: notwasm feature must be enabled when target arch is not wasm");
-
-#[cfg(all(feature = "wasm", feature = "notwasm"))]
-compile_error!("bus-mapping: both wasm & notwasm are enabled, just one of them must be enabled");
-#[cfg(all(not(feature = "wasm"), not(feature = "notwasm")))]
-compile_error!("bus-mapping: none of wasm & notwasm are enabled, one of them must be enabled");
 
 extern crate alloc;
 extern crate core;

--- a/bus-mapping/src/precompile.rs
+++ b/bus-mapping/src/precompile.rs
@@ -11,7 +11,12 @@ use revm_precompile::{Precompile, PrecompileError, Precompiles};
 /// Check if address is a precompiled or not.
 pub fn is_precompiled(address: &Address) -> bool {
     #[cfg(target_arch = "wasm32")]
-    unreachable!();
+    if address.0[0..19] == [0u8; 19] && (1..=9).contains(&address.0[19]) {
+        // TODO add support for precompiles in WASM
+        panic!("Precompile {address} is currently not supported in WASM");
+    } else {
+        return false;
+    }
 
     #[cfg(not(target_arch = "wasm32"))]
     Precompiles::berlin()
@@ -26,7 +31,8 @@ pub(crate) fn execute_precompiled(
     gas: u64,
 ) -> (Vec<u8>, u64, bool) {
     #[cfg(target_arch = "wasm32")]
-    unreachable!();
+    // TODO add support for precompiles in WASM
+    panic!("Running precompile {address} is currently not supported in WASM");
 
     #[cfg(not(target_arch = "wasm32"))]
     {

--- a/bus-mapping/src/precompile.rs
+++ b/bus-mapping/src/precompile.rs
@@ -10,21 +10,23 @@ use revm_precompile::{Precompile, PrecompileError, Precompiles};
 #[allow(unused_variables)]
 /// Check if address is a precompiled or not.
 pub fn is_precompiled(address: &Address) -> bool {
-    #[cfg(not(target_arch = "wasm32"))]
-    return Precompiles::berlin()
-        .get(address.as_fixed_bytes())
-        .is_some();
     #[cfg(target_arch = "wasm32")]
-    unreachable!()
+    unreachable!();
+
+    #[cfg(not(target_arch = "wasm32"))]
+    Precompiles::berlin()
+        .get(address.as_fixed_bytes())
+        .is_some()
 }
 
+#[allow(unused_variables)]
 pub(crate) fn execute_precompiled(
     address: &Address,
     input: &[u8],
     gas: u64,
 ) -> (Vec<u8>, u64, bool) {
     #[cfg(target_arch = "wasm32")]
-    return (vec![], 0, false);
+    unreachable!();
 
     #[cfg(not(target_arch = "wasm32"))]
     {

--- a/zkevm-circuits/Cargo.toml
+++ b/zkevm-circuits/Cargo.toml
@@ -12,7 +12,7 @@ halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.gi
 num = "0.4"
 sha3 = "0.10"
 array-init = "2.0.0"
-bus-mapping = { path = "../bus-mapping" }
+bus-mapping = { path = "../bus-mapping", default-features = false }
 eth-types = { path = "../eth-types" }
 gadgets = { path = "../gadgets" }
 ethers-core = "=2.0.10"
@@ -33,7 +33,7 @@ integer =   { git = "https://github.com/privacy-scaling-explorations/halo2wrong"
 libsecp256k1 = "0.7"
 num-bigint = { version = "0.4" }
 rand_chacha = "0.3"
-snark-verifier = { git = "https://github.com/privacy-scaling-explorations/snark-verifier", tag = "v2023_04_20", default-features = false, features = ["loader_halo2", "system_halo2", "loader_evm"] }
+snark-verifier = { git = "https://github.com/privacy-scaling-explorations/snark-verifier", tag = "v2023_04_20", default-features = false, features = ["loader_halo2", "system_halo2", "loader_evm"], optional = true }
 cli-table = { version = "0.4", optional = true }
 num_enum = "0.5.7"
 serde = { version = "1.0.130", features = ["derive"] }
@@ -41,8 +41,11 @@ serde_json = "1.0.78"
 thiserror = "1.0"
 hex = {version = "0.4.3", features = ["serde"]}
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2", features = ["js"] }
+
 [dev-dependencies]
-bus-mapping = { path = "../bus-mapping", features = ["test"] }
+bus-mapping = { path = "../bus-mapping", default-features = false }
 ctor = "0.1.22"
 ethers-signers = "=2.0.10"
 itertools = "0.10.1"
@@ -50,7 +53,9 @@ mock = { path = "../mock" }
 pretty_assertions = "1.0.0"
 
 [features]
-default = []
+default = ["notwasm"]
+wasm = ["bus-mapping/wasm"]
+notwasm = [ "bus-mapping/notwasm", "snark-verifier"]
 # We export some test circuits for other crates to consume
 test-circuits = []
 # Test utilities for testool crate to consume

--- a/zkevm-circuits/Cargo.toml
+++ b/zkevm-circuits/Cargo.toml
@@ -54,7 +54,6 @@ pretty_assertions = "1.0.0"
 
 [features]
 default = ["notwasm"]
-wasm = ["bus-mapping/wasm"]
 notwasm = [ "bus-mapping/notwasm", "snark-verifier"]
 # We export some test circuits for other crates to consume
 test-circuits = []

--- a/zkevm-circuits/src/lib.rs
+++ b/zkevm-circuits/src/lib.rs
@@ -17,6 +17,16 @@
 #![deny(unsafe_code)]
 #![deny(clippy::debug_assert_with_mut_call)]
 
+#[cfg(all(target_arch = "wasm32", not(feature = "wasm")))]
+compile_error!("bus-mapping: wasm feature must be enabled on wasm arch");
+#[cfg(all(not(target_arch = "wasm32"), not(feature = "notwasm")))]
+compile_error!("bus-mapping: notwasm feature must be enabled when target arch is not wasm");
+
+#[cfg(all(feature = "wasm", feature = "notwasm"))]
+compile_error!("zkevm-circuits: both wasm & notwasm are enabled, just one of them must be enabled");
+#[cfg(all(not(feature = "wasm"), not(feature = "notwasm")))]
+compile_error!("zkevm-circuits: none of wasm & notwasm are enabled, one of them must be enabled");
+
 pub mod bytecode_circuit;
 #[allow(dead_code, reason = "under active development")]
 pub mod circuit_tools;
@@ -27,12 +37,14 @@ pub mod keccak_circuit;
 #[allow(dead_code, reason = "under active development")]
 pub mod mpt_circuit;
 pub mod pi_circuit;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod root_circuit;
 pub mod state_circuit;
 pub mod super_circuit;
 pub mod table;
 
 #[cfg(any(test, feature = "test-util"))]
+#[cfg(not(target_arch = "wasm32"))]
 pub mod test_util;
 
 pub mod instance;

--- a/zkevm-circuits/src/lib.rs
+++ b/zkevm-circuits/src/lib.rs
@@ -17,15 +17,10 @@
 #![deny(unsafe_code)]
 #![deny(clippy::debug_assert_with_mut_call)]
 
-#[cfg(all(target_arch = "wasm32", not(feature = "wasm")))]
-compile_error!("bus-mapping: wasm feature must be enabled on wasm arch");
+#[cfg(all(target_arch = "wasm32", feature = "notwasm"))]
+compile_error!("bus-mapping: notwasm feature must be disabled when target arch is wasm");
 #[cfg(all(not(target_arch = "wasm32"), not(feature = "notwasm")))]
 compile_error!("bus-mapping: notwasm feature must be enabled when target arch is not wasm");
-
-#[cfg(all(feature = "wasm", feature = "notwasm"))]
-compile_error!("zkevm-circuits: both wasm & notwasm are enabled, just one of them must be enabled");
-#[cfg(all(not(feature = "wasm"), not(feature = "notwasm")))]
-compile_error!("zkevm-circuits: none of wasm & notwasm are enabled, one of them must be enabled");
 
 pub mod bytecode_circuit;
 #[allow(dead_code, reason = "under active development")]


### PR DESCRIPTION
### Description

zkevm-circuits can be used in WASM to verify zkEVM proofs in the browser.

While compiling zkevm-circuits crate for WASM target, the following crate gives issues:
- revm-precompile: used by bus-mappings while generating witnesses
- snark-verifier: used in the root_circuit

Since use-case is to just verify proofs, `revm-precompile` dependency can be removed during WASM compilation. And for SuperCircuit, `snark-verifier` dependency can be removed. It should be easy to add support for root_circuit too, by adding the WASM support to `snark-verifier` crate such that it exposes required rust objects in WASM mode.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

<!--
### Contents

- [_item_]
-->

### Rationale

- I tried to have this without using rust features, i.e. using target arch conditional compilation, but toggling optional dependencies with target arch seems to be very tricky. Hence, two features are introduced `wasm` and `notwasm` (default).

### How Has This Been Tested?

Manual build:

```
cd zkevm-circuits
RUSTFLAGS='-C target-feature=+atomics,+bulk-memory'  cargo build --lib --no-default-features --features wasm  --target wasm32-unknown-unknown -Z build-std=panic_abort,std
```

And running the [verifier](https://proofofexplo.it/verify/Qmek2Mo43HgFn3B6kjMHXBLznqbxyiyxMbTV9sYbJ4oKwE) in the browser.

<!--
<hr>

## How to fill a PR description 

Please give a concise description of your PR.

The target readers could be future developers, reviewers, and auditors. By reading your description, they should easily understand the changes proposed in this pull request.

MUST: Reference the issue to resolve

### Single responsibility

Is RECOMMENDED to create single responsibility commits, but not mandatory.

Anyway, you MUST enumerate the changes in a unitary way, e.g.

```
This PR contains:
- Cleanup of xxxx, yyyy
- Changed xxxx to yyyy in order to bla bla
- Added xxxx function to ...
- Refactored ....
```

### Design choices

RECOMMENDED to:
- What types of design choices did you face?
- What decisions you have made?
- Any valuable information that could help reviewers to think critically
-->