### PR TITLE
Simplify Zero and One Words construction and Address compression

### DIFF
--- a/zkevm-circuits/src/evm_circuit/util.rs
+++ b/zkevm-circuits/src/evm_circuit/util.rs
@@ -449,15 +449,6 @@ pub(crate) fn is_precompiled(address: &Address) -> bool {
     address.0[0..19] == [0u8; 19] && (1..=9).contains(&address.0[19])
 }
 
-const BASE_128_BYTES: [u8; 32] = [
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-];
-
-/// convert address (h160) to single expression.
-pub fn address_word_to_expr<F: Field>(address: Word<Expression<F>>) -> Expression<F> {
-    address.lo() + address.hi() * Expression::Constant(F::from_repr(BASE_128_BYTES).unwrap())
-}
-
 /// Helper struct to read rw operations from a step sequentially.
 pub(crate) struct StepRws<'a> {
     rws: &'a RwMap,

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -28,8 +28,7 @@ use halo2_proofs::{
 };
 
 use super::{
-    address_word_to_expr, rlc, AccountAddress, CachedRegion, CellType, MemoryAddress,
-    StoredExpression, U64Cell,
+    rlc, AccountAddress, CachedRegion, CellType, MemoryAddress, StoredExpression, U64Cell,
 };
 
 // Max degree allowed in all expressions passing through the ConstraintBuilder.
@@ -859,7 +858,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
             Target::TxAccessListAccount,
             RwValues::new(
                 tx_id,
-                address_word_to_expr(account_address),
+                account_address.compress(),
                 0.expr(),
                 Word::zero(),
                 Word::from_lo_unchecked(value),
@@ -882,7 +881,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
             Target::TxAccessListAccount,
             RwValues::new(
                 tx_id,
-                address_word_to_expr(account_address),
+                account_address.compress(),
                 0.expr(),
                 Word::zero(),
                 Word::from_lo_unchecked(value.clone()),
@@ -905,7 +904,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
             Target::TxAccessListAccountStorage,
             RwValues::new(
                 tx_id,
-                address_word_to_expr(account_address),
+                account_address.compress(),
                 0.expr(),
                 storage_key,
                 value,
@@ -929,7 +928,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
             Target::TxAccessListAccountStorage,
             RwValues::new(
                 tx_id,
-                address_word_to_expr(account_address),
+                account_address.compress(),
                 0.expr(),
                 storage_key,
                 value.clone(),
@@ -994,7 +993,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
             Target::Account,
             RwValues::new(
                 0.expr(),
-                address_word_to_expr(account_address),
+                account_address.compress(),
                 field_tag.expr(),
                 Word::zero(),
                 value.clone(),
@@ -1017,7 +1016,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
             Target::Account,
             RwValues::new(
                 0.expr(),
-                address_word_to_expr(account_address),
+                account_address.compress(),
                 field_tag.expr(),
                 Word::zero(),
                 value,
@@ -1043,7 +1042,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
             Target::Storage,
             RwValues::new(
                 tx_id,
-                address_word_to_expr(account_address),
+                account_address.compress(),
                 0.expr(),
                 key,
                 value.clone(),
@@ -1069,7 +1068,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
             Target::Storage,
             RwValues::new(
                 tx_id,
-                address_word_to_expr(account_address),
+                account_address.compress(),
                 0.expr(),
                 key,
                 value,

--- a/zkevm-circuits/src/mpt_circuit/account_leaf.rs
+++ b/zkevm-circuits/src/mpt_circuit/account_leaf.rs
@@ -498,10 +498,10 @@ impl<F: Field> AccountLeafConfig<F> {
 
         // Key
         let mut key_rlc = vec![0.scalar(); 2];
-        let mut nonce = vec![Word::<F>::new([0.scalar(), 0.scalar()]); 2];
-        let mut balance = vec![Word::<F>::new([0.scalar(), 0.scalar()]); 2];
-        let mut storage = vec![Word::<F>::new([0.scalar(), 0.scalar()]); 2];
-        let mut codehash = vec![Word::<F>::new([0.scalar(), 0.scalar()]); 2];
+        let mut nonce = vec![Word::zero_f(); 2];
+        let mut balance = vec![Word::zero_f(); 2];
+        let mut storage = vec![Word::zero_f(); 2];
+        let mut codehash = vec![Word::zero_f(); 2];
         let mut key_data = vec![KeyDataWitness::default(); 2];
         let mut parent_data = vec![ParentDataWitness::default(); 2];
         for is_s in [true, false] {
@@ -671,20 +671,11 @@ impl<F: Field> AccountLeafConfig<F> {
         } else if is_codehash_mod {
             (MPTProofType::CodeHashChanged, codehash)
         } else if is_account_delete_mod {
-            (
-                MPTProofType::AccountDestructed,
-                vec![Word::<F>::new([0.scalar(), 0.scalar()]); 2],
-            )
+            (MPTProofType::AccountDestructed, vec![Word::zero_f(); 2])
         } else if is_non_existing_proof {
-            (
-                MPTProofType::AccountDoesNotExist,
-                vec![Word::<F>::new([0.scalar(), 0.scalar()]); 2],
-            )
+            (MPTProofType::AccountDoesNotExist, vec![Word::zero_f(); 2])
         } else {
-            (
-                MPTProofType::Disabled,
-                vec![Word::<F>::new([0.scalar(), 0.scalar()]); 2],
-            )
+            (MPTProofType::Disabled, vec![Word::zero_f(); 2])
         };
 
         if account.is_mod_extension[0] || account.is_mod_extension[1] {
@@ -698,7 +689,7 @@ impl<F: Field> AccountLeafConfig<F> {
 
         let mut new_value = value[false.idx()];
         if parent_data[false.idx()].is_placeholder {
-            new_value = word::Word::<F>::new([0.scalar(), 0.scalar()]);
+            new_value = word::Word::zero_f();
         }
         mpt_config.mpt_table.assign_cached(
             region,
@@ -707,7 +698,7 @@ impl<F: Field> AccountLeafConfig<F> {
                 address: Value::known(from_bytes::value(
                     &account.address.iter().cloned().rev().collect::<Vec<_>>(),
                 )),
-                storage_key: word::Word::<F>::new([0.scalar(), 0.scalar()]).into_value(),
+                storage_key: word::Word::zero_f().into_value(),
                 proof_type: Value::known(proof_type.scalar()),
                 new_root: main_data.new_root.into_value(),
                 old_root: main_data.old_root.into_value(),

--- a/zkevm-circuits/src/mpt_circuit/account_leaf.rs
+++ b/zkevm-circuits/src/mpt_circuit/account_leaf.rs
@@ -148,10 +148,10 @@ impl<F: Field> AccountLeafConfig<F> {
             require!(config.main_data.is_below_account => false);
 
             let mut key_rlc = vec![0.expr(); 2];
-            let mut nonce = vec![Word::<Expression<F>>::new([0.expr(), 0.expr()]); 2];
-            let mut balance = vec![Word::<Expression<F>>::new([0.expr(), 0.expr()]); 2];
-            let mut storage = vec![Word::<Expression<F>>::new([0.expr(), 0.expr()]); 2];
-            let mut codehash = vec![Word::<Expression<F>>::new([0.expr(), 0.expr()]); 2];
+            let mut nonce = vec![Word::zero(); 2];
+            let mut balance = vec![Word::zero(); 2];
+            let mut storage = vec![Word::zero(); 2];
+            let mut codehash = vec![Word::zero(); 2];
             let mut leaf_no_key_rlc = vec![0.expr(); 2];
             let mut leaf_no_key_rlc_mult = vec![0.expr(); 2];
             let mut value_list_num_bytes = vec![0.expr(); 2];
@@ -435,7 +435,7 @@ impl<F: Field> AccountLeafConfig<F> {
                     &mut cb.base,
                     address.clone(),
                     proof_type.clone(),
-                    Word::<Expression<F>>::new([0.expr(), 0.expr()]),
+                    Word::zero(),
                     config.main_data.new_root.expr(),
                     config.main_data.old_root.expr(),
                     Word::<Expression<F>>::new([new_value_lo, new_value_hi]),
@@ -447,10 +447,10 @@ impl<F: Field> AccountLeafConfig<F> {
                     &mut cb.base,
                     address,
                     proof_type,
-                    Word::<Expression<F>>::new([0.expr(), 0.expr()]),
+                    Word::zero(),
                     config.main_data.new_root.expr(),
                     config.main_data.old_root.expr(),
-                    Word::<Expression<F>>::new([0.expr(), 0.expr()]),
+                    Word::zero(),
                     Word::<Expression<F>>::new([old_value_lo, old_value_hi]),
                 );
             }};

--- a/zkevm-circuits/src/mpt_circuit/branch.rs
+++ b/zkevm-circuits/src/mpt_circuit/branch.rs
@@ -351,7 +351,7 @@ impl<F: Field> BranchGadget<F> {
         let key_mult_post_branch = *key_mult * mult;
 
         // Set the branch we'll take
-        let mut mod_node_hash_word = [word::Word::<F>::new([0.scalar(), 0.scalar()]); 2];
+        let mut mod_node_hash_word = [word::Word::zero_f(); 2];
         let mut mod_node_hash_rlc = [0.scalar(); 2];
         for is_s in [true, false] {
             (

--- a/zkevm-circuits/src/mpt_circuit/extension.rs
+++ b/zkevm-circuits/src/mpt_circuit/extension.rs
@@ -100,7 +100,7 @@ impl<F: Field> ExtensionGadget<F> {
             require!((FixedTableTag::ExtOddKey.expr(), first_byte, config.is_key_part_odd.expr()) =>> @FIXED);
 
             let mut branch_rlp_rlc = vec![0.expr(); 2];
-            let mut branch_rlp_word = vec![Word::<Expression<F>>::new([0.expr(), 0.expr()]); 2];
+            let mut branch_rlp_word = vec![Word::zero(); 2];
             for is_s in [true, false] {
                 // In C we have the key nibbles, we check below only for S.
                 if is_s {

--- a/zkevm-circuits/src/mpt_circuit/extension_branch.rs
+++ b/zkevm-circuits/src/mpt_circuit/extension_branch.rs
@@ -287,7 +287,7 @@ impl<F: Field> ExtensionBranchConfig<F> {
                     mod_node_hash_rlc[is_s.idx()],
                     false,
                     false,
-                    Word::<F>::new([0.scalar(), 0.scalar()]),
+                    Word::zero_f(),
                 )?;
             } else {
                 KeyData::witness_store(

--- a/zkevm-circuits/src/mpt_circuit/extension_branch.rs
+++ b/zkevm-circuits/src/mpt_circuit/extension_branch.rs
@@ -158,7 +158,7 @@ impl<F: Field> ExtensionBranchConfig<F> {
                         branch.mod_rlc[is_s.idx()].expr(),
                         false.expr(),
                         false.expr(),
-                        Word::<Expression<F>>::new([0.expr(), 0.expr()])
+                        Word::zero(),
                     );
                  } elsex {
                     KeyData::store(

--- a/zkevm-circuits/src/mpt_circuit/helpers.rs
+++ b/zkevm-circuits/src/mpt_circuit/helpers.rs
@@ -1081,11 +1081,8 @@ impl<F: Field> IsPlaceholderLeafGadget<F> {
                     Expression::Constant(empty_hash.hi()),
                 ]),
             );
-            let is_nil_in_branch_at_mod_index = IsEqualWordGadget::construct(
-                &mut cb.base,
-                &parent_word,
-                &Word::<Expression<F>>::new([0.expr(), 0.expr()]),
-            );
+            let is_nil_in_branch_at_mod_index =
+                IsEqualWordGadget::construct(&mut cb.base, &parent_word, &Word::zero());
 
             Self {
                 is_empty_trie,

--- a/zkevm-circuits/src/mpt_circuit/start.rs
+++ b/zkevm-circuits/src/mpt_circuit/start.rs
@@ -40,7 +40,7 @@ impl<F: Field> StartConfig<F> {
 
             config.proof_type = cb.query_cell();
 
-            let mut root = vec![Word::new([0.expr(), 0.expr()]); 2];
+            let mut root = vec![Word::zero(); 2];
             for is_s in [true, false] {
                 root[is_s.idx()] = root_items[is_s.idx()].word();
             }

--- a/zkevm-circuits/src/mpt_circuit/start.rs
+++ b/zkevm-circuits/src/mpt_circuit/start.rs
@@ -96,7 +96,7 @@ impl<F: Field> StartConfig<F> {
         self.proof_type
             .assign(region, offset, start.proof_type.scalar())?;
 
-        let mut root = vec![Word::new([0.scalar(), 0.scalar()]); 2];
+        let mut root = vec![Word::zero_f(); 2];
         for is_s in [true, false] {
             root[is_s.idx()] = rlp_values[is_s.idx()].word();
         }

--- a/zkevm-circuits/src/mpt_circuit/storage_leaf.rs
+++ b/zkevm-circuits/src/mpt_circuit/storage_leaf.rs
@@ -179,7 +179,7 @@ impl<F: Field> StorageLeafConfig<F> {
 
                     // Placeholder leaves default to value `0`.
                     ifx! {is_placeholder_leaf => {
-                        require!(value_word[is_s.idx()] => [0.expr(), 0.expr()]);
+                        require!(value_word[is_s.idx()] => Word::zero());
                     }}
 
                     // Make sure the RLP encoding is correct.

--- a/zkevm-circuits/src/mpt_circuit/storage_leaf.rs
+++ b/zkevm-circuits/src/mpt_circuit/storage_leaf.rs
@@ -373,7 +373,7 @@ impl<F: Field> StorageLeafConfig<F> {
         let mut key_data = vec![KeyDataWitness::default(); 2];
         let mut parent_data = vec![ParentDataWitness::default(); 2];
         let mut key_rlc = vec![0.scalar(); 2];
-        let mut value_word = vec![Word::<F>::new([0.scalar(), 0.scalar()]); 2];
+        let mut value_word = vec![Word::zero_f(); 2];
         for is_s in [true, false] {
             self.is_mod_extension[is_s.idx()].assign(
                 region,
@@ -532,7 +532,7 @@ impl<F: Field> StorageLeafConfig<F> {
 
         let mut new_value = value_word[false.idx()];
         if parent_data[false.idx()].is_placeholder {
-            new_value = word::Word::<F>::new([0.scalar(), 0.scalar()]);
+            new_value = word::Word::zero_f();
         }
         mpt_config.mpt_table.assign_cached(
             region,

--- a/zkevm-circuits/src/mpt_circuit/storage_leaf.rs
+++ b/zkevm-circuits/src/mpt_circuit/storage_leaf.rs
@@ -104,7 +104,7 @@ impl<F: Field> StorageLeafConfig<F> {
             require!(config.main_data.is_below_account => true);
 
             let mut key_rlc = vec![0.expr(); 2];
-            let mut value_word = vec![Word::<Expression<F>>::new([0.expr(), 0.expr()]); 2];
+            let mut value_word = vec![Word::zero(); 2];
             let mut value_rlp_rlc = vec![0.expr(); 2];
             let mut value_rlp_rlc_mult = vec![0.expr(); 2];
 
@@ -207,11 +207,11 @@ impl<F: Field> StorageLeafConfig<F> {
                 ParentData::store(
                     cb,
                     &mut ctx.memory[parent_memory(is_s)],
-                    word::Word::<Expression<F>>::new([0.expr(), 0.expr()]),
+                    word::Word::zero(),
                     0.expr(),
                     true.expr(),
                     false.expr(),
-                    word::Word::<Expression<F>>::new([0.expr(), 0.expr()]),
+                    word::Word::zero(),
                 );
             }
 
@@ -332,7 +332,7 @@ impl<F: Field> StorageLeafConfig<F> {
                     address_item.word(),
                     config.main_data.new_root.expr(),
                     config.main_data.old_root.expr(),
-                    Word::<Expression<F>>::new([0.expr(), 0.expr()]),
+                    Word::zero(),
                     value_word[true.idx()].clone(),
                 );
             }};

--- a/zkevm-circuits/src/util/word.rs
+++ b/zkevm-circuits/src/util/word.rs
@@ -343,9 +343,9 @@ impl Word<Column<Advice>> {
     }
 }
 
-impl<F: Field> WordExpr<F> for Word<Cell<F>> {
+impl<F: Field, T: Expr<F> + Clone> WordExpr<F> for Word<T> {
     fn to_word(&self) -> Word<Expression<F>> {
-        self.word_expr().to_word()
+        self.map(|limb| limb.expr())
     }
 }
 
@@ -397,12 +397,6 @@ impl<F: Field> Word<Expression<F>> {
     /// No overflow check on lo/hi limbs
     pub fn mul_unchecked(self, rhs: Self) -> Self {
         Word::new([self.lo() * rhs.lo(), self.hi() * rhs.hi()])
-    }
-}
-
-impl<F: Field> WordExpr<F> for Word<Expression<F>> {
-    fn to_word(&self) -> Word<Expression<F>> {
-        self.clone()
     }
 }
 

--- a/zkevm-circuits/src/util/word.rs
+++ b/zkevm-circuits/src/util/word.rs
@@ -364,7 +364,7 @@ impl<F: Field> Word<F> {
         Self::new([F::ONE, F::ZERO])
     }
 
-    /// Convert address (h160) to single expression.
+    /// Convert address (h160) to single field element.
     /// This method is Address specific
     pub fn compress_f(&self) -> F {
         self.lo() + self.hi() * F::from_repr(BASE_128_BYTES).unwrap()

--- a/zkevm-circuits/src/util/word.rs
+++ b/zkevm-circuits/src/util/word.rs
@@ -348,20 +348,31 @@ impl<F: Field, T: Expr<F> + Clone> WordExpr<F> for Word<T> {
         self.map(|limb| limb.expr())
     }
 }
+impl<F: Field> Word<F> {
+    /// zero word
+    pub fn zero_f() -> Self {
+        Self::new([F::ZERO, F::ZERO])
+    }
+
+    /// one word
+    pub fn one_f() -> Self {
+        Self::new([F::ONE, F::ZERO])
+    }
+}
 
 impl<F: Field> Word<Expression<F>> {
     /// create word from lo limb with hi limb as 0. caller need to guaranteed to be 128 bits.
     pub fn from_lo_unchecked(lo: Expression<F>) -> Self {
-        Self(WordLimbs::<Expression<F>, 2>::new([lo, 0.expr()]))
+        Self::new([lo, 0.expr()])
     }
     /// zero word
     pub fn zero() -> Self {
-        Self(WordLimbs::<Expression<F>, 2>::new([0.expr(), 0.expr()]))
+        Self::new([0.expr(), 0.expr()])
     }
 
     /// one word
     pub fn one() -> Self {
-        Self(WordLimbs::<Expression<F>, 2>::new([1.expr(), 0.expr()]))
+        Self::new([1.expr(), 0.expr()])
     }
 
     /// select based on selector. Here assume selector is 1/0 therefore no overflow check


### PR DESCRIPTION
### Description

While reviewing #1699, I noticed some room to improve the ergonomics of the words.

### Issue Link


### Type of change

New feature (non-breaking change which adds functionality)

### Contents

- Replaced the `address_word_to_expr` function with the `compress` method so that we can compress a word directly without finding that function to use.
- introduced `zero_f` and `one_f` to create zero and one for `Word<F>`.
- 

### Rationale

I noticed that it is hard to create a `one()` and `zero()` method for both `Word<Expression<F>>` and `Word<F>`. The compiler complains about implementing duplicated methods. Since we already use `one()` and `zero()` in many places for `Word<Expression<F>>`, I named `zero_f` and `one_f` for the methods for `Word<F>`.
