### PR TITLE
Replace word::Word with WordLoHi

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,7 @@
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] This change requires a documentation update
+- [ ] Refactor (no updates to logic)
 
 ### Contents
 

--- a/light-client-poc/src/circuit/equal_words.rs
+++ b/light-client-poc/src/circuit/equal_words.rs
@@ -9,16 +9,16 @@ use halo2_proofs::{
     plonk::{Advice, Column, ConstraintSystem, Error, Expression, Selector},
     poly::Rotation,
 };
-use zkevm_circuits::util::word::Word;
+use zkevm_circuits::util::word::WordLoHi;
 
 #[derive(Clone, Debug)]
-pub struct EqualWordsConfig<F: Field>(Word<IsZeroConfig<F>>);
+pub struct EqualWordsConfig<F: Field>(WordLoHi<IsZeroConfig<F>>);
 impl<F: Field> EqualWordsConfig<F> {
     pub fn configure(
         meta: &mut ConstraintSystem<F>,
         q_enable: Selector,
-        first: (Word<Column<Advice>>, Rotation),
-        second: (Word<Column<Advice>>, Rotation),
+        first: (WordLoHi<Column<Advice>>, Rotation),
+        second: (WordLoHi<Column<Advice>>, Rotation),
     ) -> Self {
         let lo_inv = meta.advice_column();
         let lo = IsZeroChip::configure(
@@ -42,7 +42,7 @@ impl<F: Field> EqualWordsConfig<F> {
             hi_inv,
         );
 
-        Self(Word::new([lo, hi]))
+        Self(WordLoHi::new([lo, hi]))
     }
 
     pub fn expr(&self) -> Expression<F> {
@@ -54,8 +54,8 @@ impl<F: Field> EqualWordsConfig<F> {
         region: &mut Region<'_, F>,
         offset: usize,
         name: &str,
-        first: &Word<F>,
-        second: &Word<F>,
+        first: &WordLoHi<F>,
+        second: &WordLoHi<F>,
     ) -> Result<(), Error> {
         region.name_column(|| format!("{}_lo_inv", name), self.0.lo().value_inv);
         region.name_column(|| format!("{}_hi_inv", name), self.0.hi().value_inv);

--- a/light-client-poc/src/circuit/state_update.rs
+++ b/light-client-poc/src/circuit/state_update.rs
@@ -21,7 +21,7 @@ use halo2_proofs::{
 use zkevm_circuits::{
     mpt_circuit::{MPTCircuit, MPTCircuitParams, MPTConfig},
     table::{KeccakTable, MptTable},
-    util::{word, Challenges},
+    util::{word::WordLoHi, Challenges},
 };
 
 use super::witness::{
@@ -117,12 +117,12 @@ impl<F: Field> Circuit<F> for StateUpdateCircuit<F> {
         let pi_instance = meta.instance_column();
         let pi_mpt = MptTable {
             address: meta.advice_column(),
-            storage_key: word::Word::new([meta.advice_column(), meta.advice_column()]),
+            storage_key: WordLoHi::new([meta.advice_column(), meta.advice_column()]),
             proof_type: meta.advice_column(),
-            new_root: word::Word::new([meta.advice_column(), meta.advice_column()]),
-            old_root: word::Word::new([meta.advice_column(), meta.advice_column()]),
-            new_value: word::Word::new([meta.advice_column(), meta.advice_column()]),
-            old_value: word::Word::new([meta.advice_column(), meta.advice_column()]),
+            new_root: WordLoHi::new([meta.advice_column(), meta.advice_column()]),
+            old_root: WordLoHi::new([meta.advice_column(), meta.advice_column()]),
+            new_value: WordLoHi::new([meta.advice_column(), meta.advice_column()]),
+            old_value: WordLoHi::new([meta.advice_column(), meta.advice_column()]),
         };
 
         for col in [

--- a/light-client-poc/src/circuit/witness.rs
+++ b/light-client-poc/src/circuit/witness.rs
@@ -15,9 +15,7 @@ use eyre::Result;
 
 use mpt_witness_generator::{ProofType, TrieModification};
 use zkevm_circuits::{
-    mpt_circuit::witness_row::Node,
-    table::mpt_table::MPTProofType,
-    util::word::{self, Word},
+    mpt_circuit::witness_row::Node, table::mpt_table::MPTProofType, util::word::WordLoHi,
 };
 
 #[derive(Default, Debug, Clone)]
@@ -82,10 +80,10 @@ pub struct StateUpdateWitness<F: Field> {
 pub struct SingleTrieModification<F: Field> {
     pub typ: F,
     pub address: F,
-    pub value: word::Word<F>,
-    pub key: word::Word<F>,
-    pub old_root: word::Word<F>,
-    pub new_root: word::Word<F>,
+    pub value: WordLoHi<F>,
+    pub key: WordLoHi<F>,
+    pub old_root: WordLoHi<F>,
+    pub new_root: WordLoHi<F>,
 }
 
 #[derive(Default, Clone)]
@@ -350,10 +348,10 @@ impl<F: Field> StateUpdateWitness<F> {
                 let lc_proof = SingleTrieModification::<F> {
                     typ: F::from(proof_type as u64),
                     address: address.to_scalar().unwrap(),
-                    value: Word::<F>::from(value),
-                    key: Word::<F>::from(key),
-                    old_root: Word::<F>::from(from_root),
-                    new_root: Word::<F>::from(to_root),
+                    value: WordLoHi::<F>::from(value),
+                    key: WordLoHi::<F>::from(key),
+                    old_root: WordLoHi::<F>::from(from_root),
+                    new_root: WordLoHi::<F>::from(to_root),
                 };
                 lc_proofs.push(lc_proof);
             }

--- a/zkevm-circuits/src/bytecode_circuit.rs
+++ b/zkevm-circuits/src/bytecode_circuit.rs
@@ -16,8 +16,8 @@ use crate::{
     },
     table::{BytecodeFieldTag, BytecodeTable, KeccakTable, LookupTable},
     util::{
-        self, get_push_size,
-        word::{empty_code_hash_word_value, Word, Word32, WordExpr},
+        get_push_size,
+        word::{empty_code_hash_word_value, Word32, WordExpr, WordLoHi},
         Challenges, Expr, SubCircuit, SubCircuitConfig,
     },
     witness::{self},
@@ -40,7 +40,7 @@ const PUSH_TABLE_WIDTH: usize = 2;
 #[derive(Debug, Clone, Default)]
 /// Row for assignment
 pub(crate) struct BytecodeCircuitRow<F: Field> {
-    pub(crate) code_hash: Word<Value<F>>,
+    pub(crate) code_hash: WordLoHi<Value<F>>,
     tag: F,
     pub(crate) index: F,
     pub(crate) is_code: F,
@@ -52,7 +52,13 @@ pub(crate) struct BytecodeCircuitRow<F: Field> {
 }
 impl<F: Field> BytecodeCircuitRow<F> {
     #[cfg(test)]
-    pub(crate) fn new(code_hash: Word<Value<F>>, tag: F, index: F, is_code: F, value: F) -> Self {
+    pub(crate) fn new(
+        code_hash: WordLoHi<Value<F>>,
+        tag: F,
+        index: F,
+        is_code: F,
+        value: F,
+    ) -> Self {
         Self {
             code_hash,
             tag,
@@ -89,7 +95,7 @@ impl<F: Field> From<Vec<Bytecode>> for BytecodeCircuitAssignment<F> {
     fn from(codes: Vec<Bytecode>) -> Self {
         let mut rows = vec![];
         for bytecode in codes.iter() {
-            let code_hash = util::word::Word::from(bytecode.hash()).into_value();
+            let code_hash = WordLoHi::from(bytecode.hash()).into_value();
             let code_size = bytecode.codesize();
             let head = BytecodeCircuitRow {
                 code_hash,
@@ -366,7 +372,7 @@ impl<F: Field> SubCircuitConfig<F> for BytecodeCircuitConfig<F> {
                 meta.query_advice(length, Rotation::cur()),
             );
 
-            let empty_hash_word: Word<Expression<F>> =
+            let empty_hash_word: WordLoHi<Expression<F>> =
                 Word32::new(*EMPTY_CODE_HASH_LE).to_expr().to_word();
 
             cb.require_equal_word(

--- a/zkevm-circuits/src/circuit_tools/cell_manager.rs
+++ b/zkevm-circuits/src/circuit_tools/cell_manager.rs
@@ -4,7 +4,7 @@ use crate::{
     circuit_tools::cached_region::CachedRegion,
     evm_circuit::util::rlc,
     table::LookupTable,
-    util::{query_expression, word::Word, Expr},
+    util::{query_expression, word::WordLoHi, Expr},
 };
 use eth_types::Field;
 use halo2_proofs::{
@@ -103,11 +103,11 @@ impl<F: Field> Expr<F> for &Cell<F> {
     }
 }
 
-pub(crate) type WordCell<F> = Word<Cell<F>>;
+pub(crate) type WordLoHiCell<F> = WordLoHi<Cell<F>>;
 
-impl<F: Field> WordCell<F> {
-    pub fn expr(&self) -> Word<Expression<F>> {
-        Word::new([self.lo().expr(), self.hi().expr()])
+impl<F: Field> WordLoHiCell<F> {
+    pub fn expr(&self) -> WordLoHi<Expression<F>> {
+        WordLoHi::new([self.lo().expr(), self.hi().expr()])
     }
 }
 

--- a/zkevm-circuits/src/circuit_tools/constraint_builder.rs
+++ b/zkevm-circuits/src/circuit_tools/constraint_builder.rs
@@ -9,7 +9,7 @@ use std::{
 use crate::{
     evm_circuit::util::rlc,
     table::LookupTable,
-    util::{query_expression, word::Word, Expr},
+    util::{query_expression, word::WordLoHi, Expr},
 };
 use eth_types::Field;
 use gadgets::util::{and, sum, Scalar};
@@ -18,7 +18,7 @@ use itertools::Itertools;
 
 use super::{
     cached_region::StoredExpression,
-    cell_manager::{Cell, CellManager, CellType, WordCell},
+    cell_manager::{Cell, CellManager, CellType, WordLoHiCell},
 };
 
 fn get_condition_expr<F: Field>(conditions: &Vec<Expression<F>>) -> Expression<F> {
@@ -352,8 +352,8 @@ impl<F: Field, C: CellType> ConstraintBuilder<F, C> {
     }
 
     // default query_word is 2 limbs. Each limb is not guaranteed to be 128 bits.
-    pub(crate) fn query_word_unchecked(&mut self) -> WordCell<F> {
-        Word::new(self.query_cells_dyn(C::default(), 2).try_into().unwrap())
+    pub(crate) fn query_word_unchecked(&mut self) -> WordLoHiCell<F> {
+        WordLoHi::new(self.query_cells_dyn(C::default(), 2).try_into().unwrap())
     }
 
     pub(crate) fn validate_degree(&self, degree: usize, name: &'static str) {
@@ -718,7 +718,7 @@ impl<F: Field, E: Expr<F>> ExprVec<F> for &[E] {
     }
 }
 
-impl<F: Field, E: Expr<F> + Clone> ExprVec<F> for Word<E> {
+impl<F: Field, E: Expr<F> + Clone> ExprVec<F> for WordLoHi<E> {
     fn to_expr_vec(&self) -> Vec<Expression<F>> {
         vec![self.lo().expr(), self.hi().expr()]
     }

--- a/zkevm-circuits/src/circuit_tools/gadgets.rs
+++ b/zkevm-circuits/src/circuit_tools/gadgets.rs
@@ -8,7 +8,7 @@ use halo2_proofs::{
 
 use crate::{
     evm_circuit::util::{from_bytes, pow_of_two, transpose_val_ret},
-    util::word::{Word, WordExpr},
+    util::word::{WordExpr, WordLoHi},
 };
 
 use super::{
@@ -107,8 +107,8 @@ pub struct IsEqualWordGadget<F> {
 impl<F: Field> IsEqualWordGadget<F> {
     pub(crate) fn construct<C: CellType>(
         cb: &mut ConstraintBuilder<F, C>,
-        lhs: &Word<Expression<F>>,
-        rhs: &Word<Expression<F>>,
+        lhs: &WordLoHi<Expression<F>>,
+        rhs: &WordLoHi<Expression<F>>,
     ) -> Self {
         let (lhs_lo, lhs_hi) = lhs.to_word().to_lo_hi();
         let (rhs_lo, rhs_hi) = rhs.to_word().to_lo_hi();
@@ -129,8 +129,8 @@ impl<F: Field> IsEqualWordGadget<F> {
         &self,
         region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
-        lhs: Word<F>,
-        rhs: Word<F>,
+        lhs: WordLoHi<F>,
+        rhs: WordLoHi<F>,
     ) -> Result<F, Error> {
         let (lhs_lo, lhs_hi) = lhs.to_lo_hi();
         let (rhs_lo, rhs_hi) = rhs.to_lo_hi();
@@ -143,8 +143,8 @@ impl<F: Field> IsEqualWordGadget<F> {
         &self,
         region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
-        lhs: Value<Word<F>>,
-        rhs: Value<Word<F>>,
+        lhs: Value<WordLoHi<F>>,
+        rhs: Value<WordLoHi<F>>,
     ) -> Result<Value<F>, Error> {
         transpose_val_ret(
             lhs.zip(rhs)
@@ -159,7 +159,7 @@ impl<F: Field> IsEqualWordGadget<F> {
         lhs: eth_types::Word,
         rhs: eth_types::Word,
     ) -> Result<F, Error> {
-        self.assign(region, offset, Word::from(lhs), Word::from(rhs))
+        self.assign(region, offset, WordLoHi::from(lhs), WordLoHi::from(rhs))
     }
 }
 

--- a/zkevm-circuits/src/copy_circuit/util.rs
+++ b/zkevm-circuits/src/copy_circuit/util.rs
@@ -1,12 +1,12 @@
-use crate::util::word::Word;
+use crate::util::word::WordLoHi;
 use bus_mapping::circuit_input_builder::NumberOrHash;
 use eth_types::Field;
 use halo2_proofs::circuit::Value;
 
 /// Encode the type `NumberOrHash` into a field element
-pub fn number_or_hash_to_word<F: Field>(v: &NumberOrHash) -> Word<Value<F>> {
+pub fn number_or_hash_to_word<F: Field>(v: &NumberOrHash) -> WordLoHi<Value<F>> {
     match v {
-        NumberOrHash::Number(n) => Word::from(*n as u64).into_value(),
-        NumberOrHash::Hash(h) => Word::from(*h).into_value(),
+        NumberOrHash::Number(n) => WordLoHi::from(*n as u64).into_value(),
+        NumberOrHash::Hash(h) => WordLoHi::from(*h).into_value(),
     }
 }

--- a/zkevm-circuits/src/evm_circuit/execution/add_sub.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/add_sub.rs
@@ -11,7 +11,7 @@ use crate::{
         witness::{Block, Call, ExecStep, Transaction},
     },
     util::{
-        word::{Word, WordExpr},
+        word::{WordExpr, WordLoHi},
         Expr,
     },
 };
@@ -54,9 +54,9 @@ impl<F: Field> ExecutionGadget<F> for AddSubGadget<F> {
         // ADD: Pop a and b from the stack, push c on the stack
         // SUB: Pop c and b from the stack, push a on the stack
 
-        cb.stack_pop(Word::select(is_sub.expr().0, c.to_word(), a.to_word()));
+        cb.stack_pop(WordLoHi::select(is_sub.expr().0, c.to_word(), a.to_word()));
         cb.stack_pop(b.to_word());
-        cb.stack_push(Word::select(is_sub.expr().0, a.to_word(), c.to_word()));
+        cb.stack_push(WordLoHi::select(is_sub.expr().0, a.to_word(), c.to_word()));
 
         // State transition
         let step_state_transition = StepStateTransition {

--- a/zkevm-circuits/src/evm_circuit/execution/addmod.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/addmod.rs
@@ -17,7 +17,7 @@ use crate::{
         witness::{Block, Call, ExecStep, Transaction},
     },
     util::{
-        word::{Word, Word32Cell, WordExpr},
+        word::{Word32Cell, WordExpr, WordLoHi},
         Expr,
     },
 };
@@ -94,7 +94,7 @@ impl<F: Field> ExecutionGadget<F> for AddModGadget<F> {
         cb.require_equal_word(
             "check a_reduced + b 512 bit carry if n != 0",
             sum_areduced_b_overflow.to_word(),
-            Word::from_lo_unchecked(sum_areduced_b.carry().clone().unwrap().expr())
+            WordLoHi::from_lo_unchecked(sum_areduced_b.carry().clone().unwrap().expr())
                 .mul_selector(not::expr(n_is_zero.expr())),
         );
 
@@ -220,7 +220,7 @@ impl<F: Field> ExecutionGadget<F> for AddModGadget<F> {
         self.cmp_areduced_n.assign(region, offset, a_reduced, n)?;
 
         self.n_is_zero
-            .assign_value(region, offset, Value::known(Word::from(n)))?;
+            .assign_value(region, offset, Value::known(WordLoHi::from(n)))?;
 
         Ok(())
     }

--- a/zkevm-circuits/src/evm_circuit/execution/address.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/address.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     table::CallContextFieldTag,
     util::{
-        word::{WordCell, WordExpr},
+        word::{WordExpr, WordLoHiCell},
         Expr,
     },
 };
@@ -22,7 +22,7 @@ use halo2_proofs::plonk::Error;
 #[derive(Clone, Debug)]
 pub(crate) struct AddressGadget<F> {
     same_context: SameContextGadget<F>,
-    address: WordCell<F>,
+    address: WordLoHiCell<F>,
 }
 
 impl<F: Field> ExecutionGadget<F> for AddressGadget<F> {

--- a/zkevm-circuits/src/evm_circuit/execution/balance.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/balance.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     table::{AccountFieldTag, CallContextFieldTag},
     util::{
-        word::{Word, Word32Cell, WordCell, WordExpr},
+        word::{Word32Cell, WordExpr, WordLoHi, WordLoHiCell},
         Expr,
     },
 };
@@ -29,8 +29,8 @@ pub(crate) struct BalanceGadget<F> {
     reversion_info: ReversionInfo<F>,
     tx_id: Cell<F>,
     is_warm: Cell<F>,
-    code_hash: WordCell<F>,
-    not_exists: IsZeroWordGadget<F, WordCell<F>>,
+    code_hash: WordLoHiCell<F>,
+    not_exists: IsZeroWordGadget<F, WordLoHiCell<F>>,
     balance: Word32Cell<F>,
 }
 
@@ -139,7 +139,7 @@ impl<F: Field> ExecutionGadget<F> for BalanceGadget<F> {
         self.code_hash
             .assign_u256(region, offset, code_hash.to_word())?;
         self.not_exists
-            .assign_value(region, offset, Value::known(Word::from(code_hash)))?;
+            .assign_value(region, offset, Value::known(WordLoHi::from(code_hash)))?;
         let balance = if code_hash.is_zero() {
             eth_types::Word::zero()
         } else {

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -22,7 +22,7 @@ use crate::{
     },
     table::{AccountFieldTag, BlockContextFieldTag, CallContextFieldTag},
     util::{
-        word::{Word, Word32Cell, WordCell, WordExpr},
+        word::{Word32Cell, WordExpr, WordLoHi, WordLoHiCell},
         Expr,
     },
 };
@@ -37,19 +37,19 @@ use halo2_proofs::{
 pub(crate) struct BeginTxGadget<F> {
     begin_tx: BeginTxHelperGadget<F>,
     tx: TxDataGadget<F>,
-    tx_caller_address_is_zero: IsZeroWordGadget<F, WordCell<F>>,
+    tx_caller_address_is_zero: IsZeroWordGadget<F, WordLoHiCell<F>>,
     call_callee_address: AccountAddress<F>,
     reversion_info: ReversionInfo<F>,
     sufficient_gas_left: RangeCheckGadget<F, N_BYTES_GAS>,
     transfer_with_gas_fee: TransferWithGasFeeGadget<F>,
-    code_hash: WordCell<F>,
-    is_empty_code_hash: IsEqualWordGadget<F, Word<Expression<F>>, Word<Expression<F>>>,
+    code_hash: WordLoHiCell<F>,
+    is_empty_code_hash: IsEqualWordGadget<F, WordLoHi<Expression<F>>, WordLoHi<Expression<F>>>,
     caller_nonce_hash_bytes: Word32Cell<F>,
     create: ContractCreateGadget<F, false>,
-    callee_not_exists: IsZeroWordGadget<F, WordCell<F>>,
+    callee_not_exists: IsZeroWordGadget<F, WordLoHiCell<F>>,
     is_caller_callee_equal: Cell<F>,
     // EIP-3651 (Warm COINBASE)
-    coinbase: WordCell<F>,
+    coinbase: WordLoHiCell<F>,
     // Caller, callee and a list addresses are added to the access list before
     // coinbase, and may be duplicate.
     // <https://github.com/ethereum/go-ethereum/blob/604e215d1bb070dff98fb76aa965064c74e3633f/core/state/statedb.go#LL1119C9-L1119C9>
@@ -74,7 +74,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
         cb.call_context_lookup_write(
             Some(call_id.expr()),
             CallContextFieldTag::IsSuccess,
-            Word::from_lo_unchecked(reversion_info.is_persistent()),
+            WordLoHi::from_lo_unchecked(reversion_info.is_persistent()),
         ); // rwc_delta += 1
 
         // Check gas_left is sufficient
@@ -102,8 +102,8 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
         cb.account_write(
             tx.caller_address.to_word(),
             AccountFieldTag::Nonce,
-            Word::from_lo_unchecked(tx.nonce.expr() + 1.expr()),
-            Word::from_lo_unchecked(tx.nonce.expr()),
+            WordLoHi::from_lo_unchecked(tx.nonce.expr() + 1.expr()),
+            WordLoHi::from_lo_unchecked(tx.nonce.expr()),
             None,
         ); // rwc_delta += 1
 
@@ -111,7 +111,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
         for addr in 1..=PRECOMPILE_COUNT {
             cb.account_access_list_write_unchecked(
                 tx_id.expr(),
-                Word::new([addr.expr(), 0.expr()]),
+                WordLoHi::new([addr.expr(), 0.expr()]),
                 1.expr(),
                 0.expr(),
                 None,
@@ -221,12 +221,12 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             cb.account_write(
                 call_callee_address.to_word(),
                 AccountFieldTag::Nonce,
-                Word::one(),
-                Word::zero(),
+                WordLoHi::one(),
+                WordLoHi::zero(),
                 Some(&mut reversion_info),
             );
             for (field_tag, value) in [
-                (CallContextFieldTag::Depth, Word::one()),
+                (CallContextFieldTag::Depth, WordLoHi::one()),
                 (
                     CallContextFieldTag::CallerAddress,
                     tx.caller_address.to_word(),
@@ -235,24 +235,24 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                     CallContextFieldTag::CalleeAddress,
                     call_callee_address.to_word(),
                 ),
-                (CallContextFieldTag::CallDataOffset, Word::zero()),
+                (CallContextFieldTag::CallDataOffset, WordLoHi::zero()),
                 (
                     CallContextFieldTag::CallDataLength,
-                    Word::from_lo_unchecked(tx.call_data_length.expr()),
+                    WordLoHi::from_lo_unchecked(tx.call_data_length.expr()),
                 ),
                 (CallContextFieldTag::Value, tx.value.to_word()),
-                (CallContextFieldTag::IsStatic, Word::zero()),
-                (CallContextFieldTag::LastCalleeId, Word::zero()),
+                (CallContextFieldTag::IsStatic, WordLoHi::zero()),
+                (CallContextFieldTag::LastCalleeId, WordLoHi::zero()),
                 (
                     CallContextFieldTag::LastCalleeReturnDataOffset,
-                    Word::zero(),
+                    WordLoHi::zero(),
                 ),
                 (
                     CallContextFieldTag::LastCalleeReturnDataLength,
-                    Word::zero(),
+                    WordLoHi::zero(),
                 ),
-                (CallContextFieldTag::IsRoot, Word::one()),
-                (CallContextFieldTag::IsCreate, Word::one()),
+                (CallContextFieldTag::IsRoot, WordLoHi::one()),
+                (CallContextFieldTag::IsCreate, WordLoHi::one()),
                 (
                     CallContextFieldTag::CodeHash,
                     cb.curr.state.code_hash.to_word(),
@@ -349,7 +349,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             |cb| {
                 // Setup first call's context.
                 for (field_tag, value) in [
-                    (CallContextFieldTag::Depth, Word::one()),
+                    (CallContextFieldTag::Depth, WordLoHi::one()),
                     (
                         CallContextFieldTag::CallerAddress,
                         tx.caller_address.to_word(),
@@ -358,26 +358,26 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                         CallContextFieldTag::CalleeAddress,
                         tx.callee_address.to_word(),
                     ),
-                    (CallContextFieldTag::CallDataOffset, Word::zero()),
+                    (CallContextFieldTag::CallDataOffset, WordLoHi::zero()),
                     (
                         CallContextFieldTag::CallDataLength,
-                        Word::from_lo_unchecked(tx.call_data_length.expr()),
+                        WordLoHi::from_lo_unchecked(tx.call_data_length.expr()),
                     ),
                     (CallContextFieldTag::Value, tx.value.to_word()),
-                    (CallContextFieldTag::IsStatic, Word::zero()),
-                    (CallContextFieldTag::LastCalleeId, Word::zero()),
+                    (CallContextFieldTag::IsStatic, WordLoHi::zero()),
+                    (CallContextFieldTag::LastCalleeId, WordLoHi::zero()),
                     (
                         CallContextFieldTag::LastCalleeReturnDataOffset,
-                        Word::zero(),
+                        WordLoHi::zero(),
                     ),
                     (
                         CallContextFieldTag::LastCalleeReturnDataLength,
-                        Word::zero(),
+                        WordLoHi::zero(),
                     ),
-                    (CallContextFieldTag::IsRoot, Word::one()),
+                    (CallContextFieldTag::IsRoot, WordLoHi::one()),
                     (
                         CallContextFieldTag::IsCreate,
-                        Word::from_lo_unchecked(tx.is_create.expr()),
+                        WordLoHi::from_lo_unchecked(tx.is_create.expr()),
                     ),
                     (CallContextFieldTag::CodeHash, code_hash.to_word()),
                 ] {

--- a/zkevm-circuits/src/evm_circuit/execution/block_ctx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/block_ctx.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     table::BlockContextFieldTag,
     util::{
-        word::{WordCell, WordExpr},
+        word::{WordExpr, WordLoHiCell},
         Expr,
     },
 };
@@ -23,7 +23,7 @@ use super::ExecutionGadget;
 #[derive(Clone, Debug)]
 pub(crate) struct BlockCtxGadget<F> {
     same_context: SameContextGadget<F>,
-    value: WordCell<F>,
+    value: WordLoHiCell<F>,
 }
 
 impl<F: Field> ExecutionGadget<F> for BlockCtxGadget<F> {

--- a/zkevm-circuits/src/evm_circuit/execution/blockhash.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/blockhash.rs
@@ -11,7 +11,7 @@ use crate::{
                 Transition::Delta,
             },
             math_gadget::LtGadget,
-            CachedRegion, Cell, Word,
+            CachedRegion, Cell, WordLoHi,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
@@ -28,7 +28,7 @@ pub(crate) struct BlockHashGadget<F> {
     same_context: SameContextGadget<F>,
     block_number: WordByteCapGadget<F, N_BYTES_U64>,
     current_block_number: Cell<F>,
-    block_hash: Word<Cell<F>>,
+    block_hash: WordLoHi<Cell<F>>,
     diff_lt: LtGadget<F, N_BYTES_U64>,
 }
 
@@ -42,7 +42,7 @@ impl<F: Field> ExecutionGadget<F> for BlockHashGadget<F> {
         cb.block_lookup(
             BlockContextFieldTag::Number.expr(),
             None,
-            Word::from_lo_unchecked(current_block_number.expr()),
+            WordLoHi::from_lo_unchecked(current_block_number.expr()),
         );
 
         let block_number = WordByteCapGadget::construct(cb, current_block_number.expr());

--- a/zkevm-circuits/src/evm_circuit/execution/byte.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/byte.rs
@@ -11,7 +11,7 @@ use crate::{
         witness::{Block, Call, ExecStep, Transaction},
     },
     util::{
-        word::{Word, Word32Cell, WordExpr},
+        word::{Word32Cell, WordExpr, WordLoHi},
         Expr,
     },
 };
@@ -70,7 +70,7 @@ impl<F: Field> ExecutionGadget<F> for ByteGadget<F> {
         // it only uses the LSB of a word.
         cb.stack_pop(index.to_word());
         cb.stack_pop(value.to_word());
-        cb.stack_push(Word::from_lo_unchecked(selected_byte));
+        cb.stack_push(WordLoHi::from_lo_unchecked(selected_byte));
 
         // State transition
         let step_state_transition = StepStateTransition {

--- a/zkevm-circuits/src/evm_circuit/execution/calldatacopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldatacopy.rs
@@ -19,7 +19,7 @@ use crate::{
     },
     table::CallContextFieldTag,
     util::{
-        word::{Word, WordExpr},
+        word::{WordExpr, WordLoHi},
         Expr,
     },
 };
@@ -69,12 +69,12 @@ impl<F: Field> ExecutionGadget<F> for CallDataCopyGadget<F> {
             cb.call_context_lookup_read(
                 None,
                 CallContextFieldTag::TxId,
-                Word::from_lo_unchecked(src_id.expr()),
+                WordLoHi::from_lo_unchecked(src_id.expr()),
             );
             cb.call_context_lookup_read(
                 None,
                 CallContextFieldTag::CallDataLength,
-                Word::from_lo_unchecked(call_data_length.expr()),
+                WordLoHi::from_lo_unchecked(call_data_length.expr()),
             );
             cb.require_zero(
                 "call_data_offset == 0 in the root call",
@@ -85,17 +85,17 @@ impl<F: Field> ExecutionGadget<F> for CallDataCopyGadget<F> {
             cb.call_context_lookup_read(
                 None,
                 CallContextFieldTag::CallerId,
-                Word::from_lo_unchecked(src_id.expr()),
+                WordLoHi::from_lo_unchecked(src_id.expr()),
             );
             cb.call_context_lookup_read(
                 None,
                 CallContextFieldTag::CallDataLength,
-                Word::from_lo_unchecked(call_data_length.expr()),
+                WordLoHi::from_lo_unchecked(call_data_length.expr()),
             );
             cb.call_context_lookup_read(
                 None,
                 CallContextFieldTag::CallDataOffset,
-                Word::from_lo_unchecked(call_data_offset.expr()),
+                WordLoHi::from_lo_unchecked(call_data_offset.expr()),
             );
         });
 
@@ -127,9 +127,9 @@ impl<F: Field> ExecutionGadget<F> for CallDataCopyGadget<F> {
             let src_addr_end = call_data_offset.expr() + call_data_length.expr();
 
             cb.copy_table_lookup(
-                Word::from_lo_unchecked(src_id.expr()),
+                WordLoHi::from_lo_unchecked(src_id.expr()),
                 src_tag,
-                Word::from_lo_unchecked(cb.curr.state.call_id.expr()),
+                WordLoHi::from_lo_unchecked(cb.curr.state.call_id.expr()),
                 CopyDataType::Memory.expr(),
                 src_addr,
                 src_addr_end,

--- a/zkevm-circuits/src/evm_circuit/execution/calldataload.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldataload.rs
@@ -23,7 +23,7 @@ use crate::{
     },
     table::{CallContextFieldTag, TxContextFieldTag},
     util::{
-        word::{Word, Word32, WordExpr},
+        word::{Word32, WordExpr, WordLoHi},
         Expr,
     },
 };
@@ -76,12 +76,12 @@ impl<F: Field> ExecutionGadget<F> for CallDataLoadGadget<F> {
                 cb.call_context_lookup_read(
                     None,
                     CallContextFieldTag::TxId,
-                    Word::from_lo_unchecked(src_id.expr()),
+                    WordLoHi::from_lo_unchecked(src_id.expr()),
                 );
                 cb.call_context_lookup_read(
                     None,
                     CallContextFieldTag::CallDataLength,
-                    Word::from_lo_unchecked(call_data_length.expr()),
+                    WordLoHi::from_lo_unchecked(call_data_length.expr()),
                 );
                 cb.require_equal(
                     "if is_root then call_data_offset == 0",
@@ -100,17 +100,17 @@ impl<F: Field> ExecutionGadget<F> for CallDataLoadGadget<F> {
                 cb.call_context_lookup_read(
                     None,
                     CallContextFieldTag::CallerId,
-                    Word::from_lo_unchecked(src_id.expr()),
+                    WordLoHi::from_lo_unchecked(src_id.expr()),
                 );
                 cb.call_context_lookup_read(
                     None,
                     CallContextFieldTag::CallDataLength,
-                    Word::from_lo_unchecked(call_data_length.expr()),
+                    WordLoHi::from_lo_unchecked(call_data_length.expr()),
                 );
                 cb.call_context_lookup_read(
                     None,
                     CallContextFieldTag::CallDataOffset,
-                    Word::from_lo_unchecked(call_data_offset.expr()),
+                    WordLoHi::from_lo_unchecked(call_data_offset.expr()),
                 );
             },
         );
@@ -141,7 +141,7 @@ impl<F: Field> ExecutionGadget<F> for CallDataLoadGadget<F> {
                             src_id.expr(),
                             TxContextFieldTag::CallData,
                             Some(src_addr.expr() + idx.expr()),
-                            Word::from_lo_unchecked(buffer_reader.byte(idx)),
+                            WordLoHi::from_lo_unchecked(buffer_reader.byte(idx)),
                         );
                     },
                 );

--- a/zkevm-circuits/src/evm_circuit/execution/calldatasize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldatasize.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     table::CallContextFieldTag,
     util::{
-        word::{WordCell, WordExpr},
+        word::{WordExpr, WordLoHiCell},
         Expr,
     },
 };
@@ -22,7 +22,7 @@ use halo2_proofs::plonk::Error;
 #[derive(Clone, Debug)]
 pub(crate) struct CallDataSizeGadget<F> {
     same_context: SameContextGadget<F>,
-    call_data_size: WordCell<F>,
+    call_data_size: WordLoHiCell<F>,
 }
 
 impl<F: Field> ExecutionGadget<F> for CallDataSizeGadget<F> {

--- a/zkevm-circuits/src/evm_circuit/execution/caller.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/caller.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     table::CallContextFieldTag,
     util::{
-        word::{WordCell, WordExpr},
+        word::{WordExpr, WordLoHiCell},
         Expr,
     },
 };
@@ -22,7 +22,7 @@ use halo2_proofs::plonk::Error;
 #[derive(Clone, Debug)]
 pub(crate) struct CallerGadget<F> {
     same_context: SameContextGadget<F>,
-    caller_address: WordCell<F>,
+    caller_address: WordLoHiCell<F>,
 }
 
 impl<F: Field> ExecutionGadget<F> for CallerGadget<F> {

--- a/zkevm-circuits/src/evm_circuit/execution/callvalue.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callvalue.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     table::CallContextFieldTag,
     util::{
-        word::{WordCell, WordExpr},
+        word::{WordExpr, WordLoHiCell},
         Expr,
     },
 };
@@ -24,7 +24,7 @@ pub(crate) struct CallValueGadget<F> {
     same_context: SameContextGadget<F>,
     // Value in rw_table->stack_op and call_context->call_value are both RLC
     // encoded, so no need to decode.
-    call_value: WordCell<F>,
+    call_value: WordLoHiCell<F>,
 }
 
 impl<F: Field> ExecutionGadget<F> for CallValueGadget<F> {

--- a/zkevm-circuits/src/evm_circuit/execution/chainid.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/chainid.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     table::BlockContextFieldTag,
     util::{
-        word::{WordCell, WordExpr},
+        word::{WordExpr, WordLoHiCell},
         Expr,
     },
 };
@@ -22,7 +22,7 @@ use halo2_proofs::plonk::Error;
 #[derive(Clone, Debug)]
 pub(crate) struct ChainIdGadget<F> {
     same_context: SameContextGadget<F>,
-    chain_id: WordCell<F>,
+    chain_id: WordLoHiCell<F>,
 }
 
 impl<F: Field> ExecutionGadget<F> for ChainIdGadget<F> {

--- a/zkevm-circuits/src/evm_circuit/execution/codecopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/codecopy.rs
@@ -20,7 +20,7 @@ use crate::{
         witness::{Block, Call, ExecStep, Transaction},
     },
     util::{
-        word::{Word, WordExpr},
+        word::{WordExpr, WordLoHi},
         Expr,
     },
 };
@@ -66,7 +66,7 @@ impl<F: Field> ExecutionGadget<F> for CodeCopyGadget<F> {
         // Pop items from stack.
         cb.stack_pop(dst_memory_offset.to_word());
         cb.stack_pop(code_offset.original_word().to_word());
-        cb.stack_pop(Word::from_lo_unchecked(length.expr()));
+        cb.stack_pop(WordLoHi::from_lo_unchecked(length.expr()));
 
         // Construct memory address in the destionation (memory) to which we copy code.
         let dst_memory_addr = MemoryAddressGadget::construct(cb, dst_memory_offset, length);
@@ -99,7 +99,7 @@ impl<F: Field> ExecutionGadget<F> for CodeCopyGadget<F> {
             cb.copy_table_lookup(
                 code_hash.to_word(),
                 CopyDataType::Bytecode.expr(),
-                Word::from_lo_unchecked(cb.curr.state.call_id.expr()),
+                WordLoHi::from_lo_unchecked(cb.curr.state.call_id.expr()),
                 CopyDataType::Memory.expr(),
                 src_addr,
                 code_size.expr(),

--- a/zkevm-circuits/src/evm_circuit/execution/comparator.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/comparator.rs
@@ -11,7 +11,7 @@ use crate::{
         witness::{Block, Call, ExecStep, Transaction},
     },
     util::{
-        word::{Word, WordCell, WordExpr},
+        word::{WordExpr, WordLoHi, WordLoHiCell},
         Expr,
     },
 };
@@ -21,12 +21,12 @@ use halo2_proofs::{circuit::Value, plonk::Error};
 #[derive(Clone, Debug)]
 pub(crate) struct ComparatorGadget<F> {
     same_context: SameContextGadget<F>,
-    a: WordCell<F>,
-    b: WordCell<F>,
+    a: WordLoHiCell<F>,
+    b: WordLoHiCell<F>,
     result: Cell<F>,
     is_eq: IsEqualGadget<F>,
     is_gt: IsEqualGadget<F>,
-    word_comparison: CmpWordsGadget<F, WordCell<F>, WordCell<F>>,
+    word_comparison: CmpWordsGadget<F, WordLoHiCell<F>, WordLoHiCell<F>>,
 }
 
 impl<F: Field> ExecutionGadget<F> for ComparatorGadget<F> {
@@ -62,9 +62,9 @@ impl<F: Field> ExecutionGadget<F> for ComparatorGadget<F> {
         // When swap is enabled we swap stack places between a and b.
         // We can push result here directly because
         // it only uses the LSB of a word.
-        cb.stack_pop(Word::select(is_gt.expr(), b.to_word(), a.to_word()));
-        cb.stack_pop(Word::select(is_gt.expr(), a.to_word(), b.to_word()));
-        cb.stack_push(Word::from_lo_unchecked(result.expr()));
+        cb.stack_pop(WordLoHi::select(is_gt.expr(), b.to_word(), a.to_word()));
+        cb.stack_pop(WordLoHi::select(is_gt.expr(), a.to_word(), b.to_word()));
+        cb.stack_push(WordLoHi::from_lo_unchecked(result.expr()));
 
         // State transition
         let step_state_transition = StepStateTransition {

--- a/zkevm-circuits/src/evm_circuit/execution/create.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/create.rs
@@ -19,13 +19,13 @@ use crate::{
             memory_gadget::{
                 CommonMemoryAddressGadget, MemoryAddressGadget, MemoryExpansionGadget,
             },
-            not, AccountAddress, CachedRegion, Cell, StepRws, Word, WordExpr,
+            not, AccountAddress, CachedRegion, Cell, StepRws,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
     table::{AccountFieldTag, CallContextFieldTag},
     util::{
-        word::{Word32Cell, WordCell},
+        word::{Word32Cell, WordExpr, WordLoHi, WordLoHiCell},
         Expr,
     },
 };
@@ -58,11 +58,11 @@ pub(crate) struct CreateGadget<F, const IS_CREATE2: bool, const S: ExecutionStat
     was_warm: Cell<F>,
     value: Word32Cell<F>,
 
-    caller_balance: WordCell<F>,
+    caller_balance: WordLoHiCell<F>,
     callee_reversion_info: ReversionInfo<F>,
     callee_nonce: Cell<F>,
-    prev_code_hash: WordCell<F>,
-    prev_code_hash_is_zero: IsZeroWordGadget<F, Word<Expression<F>>>,
+    prev_code_hash: WordLoHiCell<F>,
+    prev_code_hash_is_zero: IsZeroWordGadget<F, WordLoHi<Expression<F>>>,
     transfer: TransferGadget<F>,
     create: ContractCreateGadget<F, IS_CREATE2>,
 
@@ -74,7 +74,7 @@ pub(crate) struct CreateGadget<F, const IS_CREATE2: bool, const S: ExecutionStat
     is_depth_in_range: LtGadget<F, N_BYTES_U64>,
     is_insufficient_balance: LtWordGadget<F>,
     is_nonce_in_range: LtGadget<F, N_BYTES_U64>,
-    not_address_collision: IsZeroWordGadget<F, Word<Expression<F>>>,
+    not_address_collision: IsZeroWordGadget<F, WordLoHi<Expression<F>>>,
 
     memory_expansion: MemoryExpansionGadget<F, 1, N_BYTES_MEMORY_WORD_SIZE>,
     gas_left: ConstantDivisionGadget<F, N_BYTES_GAS>,
@@ -139,7 +139,7 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
         cb.account_read(
             create.caller_address(),
             AccountFieldTag::Nonce,
-            Word::from_lo_unchecked(caller_nonce.expr()),
+            WordLoHi::from_lo_unchecked(caller_nonce.expr()),
         );
 
         // Pre-check: call depth, user's nonce and user's balance
@@ -182,8 +182,8 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                 cb.account_write(
                     create.caller_address(),
                     AccountFieldTag::Nonce,
-                    Word::from_lo_unchecked(caller_nonce.expr() + 1.expr()),
-                    Word::from_lo_unchecked(caller_nonce.expr()),
+                    WordLoHi::from_lo_unchecked(caller_nonce.expr() + 1.expr()),
+                    WordLoHi::from_lo_unchecked(caller_nonce.expr()),
                     Some(&mut reversion_info),
                 );
 
@@ -214,14 +214,14 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                     cb.account_read(
                         contract_addr.to_word(),
                         AccountFieldTag::Nonce,
-                        Word::from_lo_unchecked(callee_nonce.expr()),
+                        WordLoHi::from_lo_unchecked(callee_nonce.expr()),
                     );
                 });
                 (
                     prev_code_hash_is_zero,
                     IsZeroWordGadget::construct(
                         cb,
-                        &Word::from_lo_unchecked(callee_nonce.expr()).add_unchecked(
+                        &WordLoHi::from_lo_unchecked(callee_nonce.expr()).add_unchecked(
                             prev_code_hash_word.clone().mul_unchecked(
                                 prev_code_hash_word.sub_unchecked(cb.empty_code_hash()),
                             ),
@@ -233,25 +233,27 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
         for (field_tag, value) in [
             (
                 CallContextFieldTag::ProgramCounter,
-                Word::from_lo_unchecked(cb.curr.state.program_counter.expr() + 1.expr()),
+                WordLoHi::from_lo_unchecked(cb.curr.state.program_counter.expr() + 1.expr()),
             ),
             (
                 CallContextFieldTag::StackPointer,
-                Word::from_lo_unchecked(
+                WordLoHi::from_lo_unchecked(
                     cb.curr.state.stack_pointer.expr() + 2.expr() + is_create2.expr(),
                 ),
             ),
             (
                 CallContextFieldTag::GasLeft,
-                Word::from_lo_unchecked(gas_left.quotient()),
+                WordLoHi::from_lo_unchecked(gas_left.quotient()),
             ),
             (
                 CallContextFieldTag::MemorySize,
-                Word::from_lo_unchecked(memory_expansion.next_memory_word_size()),
+                WordLoHi::from_lo_unchecked(memory_expansion.next_memory_word_size()),
             ),
             (
                 CallContextFieldTag::ReversibleWriteCounter,
-                Word::from_lo_unchecked(cb.curr.state.reversible_write_counter.expr() + 2.expr()),
+                WordLoHi::from_lo_unchecked(
+                    cb.curr.state.reversible_write_counter.expr() + 2.expr(),
+                ),
             ),
         ] {
             cb.call_context_lookup_write(None, field_tag, value);
@@ -266,7 +268,7 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                 // the init code is being copied from memory to bytecode, so a copy table lookup
                 // to verify that the associated fields for the copy event.
                 cb.copy_table_lookup(
-                    Word::from_lo_unchecked(current_call_id.expr()),
+                    WordLoHi::from_lo_unchecked(current_call_id.expr()),
                     CopyDataType::Memory.expr(),
                     create.code_hash(),
                     CopyDataType::Bytecode.expr(),
@@ -290,13 +292,13 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
             cb.call_context_lookup_write(
                 None,
                 CallContextFieldTag::LastCalleeId,
-                Word::from_lo_unchecked(callee_call_id.expr()),
+                WordLoHi::from_lo_unchecked(callee_call_id.expr()),
             );
             for field_tag in [
                 CallContextFieldTag::LastCalleeReturnDataOffset,
                 CallContextFieldTag::LastCalleeReturnDataLength,
             ] {
-                cb.call_context_lookup_write(None, field_tag, Word::zero());
+                cb.call_context_lookup_write(None, field_tag, WordLoHi::zero());
             }
 
             cb.require_step_state_transition(StepStateTransition {
@@ -342,8 +344,8 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                 cb.account_write(
                     contract_addr.to_word(),
                     AccountFieldTag::Nonce,
-                    Word::one(),
-                    Word::zero(),
+                    WordLoHi::one(),
+                    WordLoHi::zero(),
                     Some(&mut callee_reversion_info),
                 );
 
@@ -351,43 +353,43 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                     for (field_tag, value) in [
                         (
                             CallContextFieldTag::CallerId,
-                            Word::from_lo_unchecked(current_call_id.expr()),
+                            WordLoHi::from_lo_unchecked(current_call_id.expr()),
                         ),
                         (
                             CallContextFieldTag::IsSuccess,
-                            Word::from_lo_unchecked(is_success.expr()),
+                            WordLoHi::from_lo_unchecked(is_success.expr()),
                         ),
                         (
                             CallContextFieldTag::IsPersistent,
-                            Word::from_lo_unchecked(callee_reversion_info.is_persistent()),
+                            WordLoHi::from_lo_unchecked(callee_reversion_info.is_persistent()),
                         ),
                         (
                             CallContextFieldTag::TxId,
-                            Word::from_lo_unchecked(tx_id.expr()),
+                            WordLoHi::from_lo_unchecked(tx_id.expr()),
                         ),
                         (CallContextFieldTag::CallerAddress, create.caller_address()),
                         (CallContextFieldTag::CalleeAddress, contract_addr.to_word()),
                         (
                             CallContextFieldTag::RwCounterEndOfReversion,
-                            Word::from_lo_unchecked(
+                            WordLoHi::from_lo_unchecked(
                                 callee_reversion_info.rw_counter_end_of_reversion(),
                             ),
                         ),
                         (
                             CallContextFieldTag::Depth,
-                            Word::from_lo_unchecked(depth.expr() + 1.expr()),
+                            WordLoHi::from_lo_unchecked(depth.expr() + 1.expr()),
                         ),
                         (
                             CallContextFieldTag::IsRoot,
-                            Word::from_lo_unchecked(false.expr()),
+                            WordLoHi::from_lo_unchecked(false.expr()),
                         ),
                         (
                             CallContextFieldTag::IsStatic,
-                            Word::from_lo_unchecked(false.expr()),
+                            WordLoHi::from_lo_unchecked(false.expr()),
                         ),
                         (
                             CallContextFieldTag::IsCreate,
-                            Word::from_lo_unchecked(true.expr()),
+                            WordLoHi::from_lo_unchecked(true.expr()),
                         ),
                         (CallContextFieldTag::CodeHash, create.code_hash()),
                         (CallContextFieldTag::Value, value.to_word()),
@@ -414,13 +416,13 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                     cb.call_context_lookup_write(
                         None,
                         CallContextFieldTag::LastCalleeId,
-                        Word::from_lo_unchecked(callee_call_id.expr()),
+                        WordLoHi::from_lo_unchecked(callee_call_id.expr()),
                     );
                     for field_tag in [
                         CallContextFieldTag::LastCalleeReturnDataOffset,
                         CallContextFieldTag::LastCalleeReturnDataLength,
                     ] {
-                        cb.call_context_lookup_write(None, field_tag, Word::zero());
+                        cb.call_context_lookup_write(None, field_tag, WordLoHi::zero());
                     }
                     cb.require_step_state_transition(StepStateTransition {
                         rw_counter: Delta(cb.rw_counter_offset()),
@@ -457,13 +459,13 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                 cb.call_context_lookup_write(
                     None,
                     CallContextFieldTag::LastCalleeId,
-                    Word::from_lo_unchecked(callee_call_id.expr()),
+                    WordLoHi::from_lo_unchecked(callee_call_id.expr()),
                 );
                 for field_tag in [
                     CallContextFieldTag::LastCalleeReturnDataOffset,
                     CallContextFieldTag::LastCalleeReturnDataLength,
                 ] {
-                    cb.call_context_lookup_write(None, field_tag, Word::zero());
+                    cb.call_context_lookup_write(None, field_tag, WordLoHi::zero());
                 }
 
                 cb.require_step_state_transition(StepStateTransition {

--- a/zkevm-circuits/src/evm_circuit/execution/dummy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/dummy.rs
@@ -7,15 +7,15 @@ use crate::{
         util::{constraint_builder::EVMConstraintBuilder, CachedRegion},
         witness::{Block, Call, ExecStep, Transaction},
     },
-    util::word::{WordCell, WordExpr},
+    util::word::{WordExpr, WordLoHiCell},
 };
 use eth_types::Field;
 use halo2_proofs::plonk::Error;
 
 #[derive(Clone, Debug)]
 pub(crate) struct DummyGadget<F, const N_POP: usize, const N_PUSH: usize, const S: ExecutionState> {
-    pops: [WordCell<F>; N_POP],
-    pushes: [WordCell<F>; N_PUSH],
+    pops: [WordLoHiCell<F>; N_POP],
+    pushes: [WordLoHiCell<F>; N_PUSH],
     _marker: PhantomData<F>,
 }
 
@@ -27,8 +27,8 @@ impl<F: Field, const N_POP: usize, const N_PUSH: usize, const S: ExecutionState>
     const EXECUTION_STATE: ExecutionState = S;
 
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
-        let pops: [WordCell<F>; N_POP] = [(); N_POP].map(|_| cb.query_word_unchecked());
-        let pushes: [WordCell<F>; N_PUSH] = [(); N_PUSH].map(|_| cb.query_word_unchecked());
+        let pops: [WordLoHiCell<F>; N_POP] = [(); N_POP].map(|_| cb.query_word_unchecked());
+        let pushes: [WordLoHiCell<F>; N_PUSH] = [(); N_PUSH].map(|_| cb.query_word_unchecked());
         for pop in pops.iter() {
             cb.stack_pop(pop.to_word());
         }

--- a/zkevm-circuits/src/evm_circuit/execution/dup.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/dup.rs
@@ -10,7 +10,7 @@ use crate::{
         witness::{Block, Call, ExecStep, Transaction},
     },
     util::{
-        word::{WordCell, WordExpr},
+        word::{WordExpr, WordLoHiCell},
         Expr,
     },
 };
@@ -20,7 +20,7 @@ use halo2_proofs::plonk::Error;
 #[derive(Clone, Debug)]
 pub(crate) struct DupGadget<F> {
     same_context: SameContextGadget<F>,
-    value: WordCell<F>,
+    value: WordLoHiCell<F>,
 }
 
 impl<F: Field> ExecutionGadget<F> for DupGadget<F> {

--- a/zkevm-circuits/src/evm_circuit/execution/end_block.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/end_block.rs
@@ -12,7 +12,7 @@ use crate::{
         witness::{Block, Call, ExecStep, Transaction},
     },
     table::{CallContextFieldTag, TxContextFieldTag},
-    util::{word::Word, Expr},
+    util::{word::WordLoHi, Expr},
 };
 use eth_types::{Field, OpsIdentity};
 use gadgets::util::select;
@@ -59,7 +59,7 @@ impl<F: Field> ExecutionGadget<F> for EndBlockGadget<F> {
             cb.call_context_lookup_read(
                 None,
                 CallContextFieldTag::TxId,
-                Word::from_lo_unchecked(total_txs.expr()),
+                WordLoHi::from_lo_unchecked(total_txs.expr()),
             );
         });
 
@@ -74,7 +74,7 @@ impl<F: Field> ExecutionGadget<F> for EndBlockGadget<F> {
                 total_txs.expr() + 1.expr(),
                 TxContextFieldTag::CallerAddress,
                 None,
-                Word::zero(),
+                WordLoHi::zero(),
             );
             // Since every tx lookup done in the EVM circuit must succeed
             // and uses a unique tx_id, we know that at

--- a/zkevm-circuits/src/evm_circuit/execution/end_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/end_tx.rs
@@ -17,7 +17,7 @@ use crate::{
     },
     table::{AccountFieldTag, BlockContextFieldTag, CallContextFieldTag, TxContextFieldTag},
     util::{
-        word::{Word, WordCell, WordExpr},
+        word::{WordExpr, WordLoHi, WordLoHiCell},
         Expr,
     },
 };
@@ -32,13 +32,13 @@ pub(crate) struct EndTxGadget<F> {
     refund: Cell<F>,
     effective_refund: MinMaxGadget<F, N_BYTES_GAS>,
     mul_gas_price_by_refund: MulWordByU64Gadget<F>,
-    tx_caller_address: WordCell<F>,
+    tx_caller_address: WordLoHiCell<F>,
     gas_fee_refund: UpdateBalanceGadget<F, 2, true>,
     sub_gas_price_by_base_fee: AddWordsGadget<F, 2, true>,
     mul_effective_tip_by_gas_used: MulWordByU64Gadget<F>,
-    coinbase: WordCell<F>,
-    coinbase_code_hash: WordCell<F>,
-    coinbase_code_hash_is_zero: IsZeroWordGadget<F, WordCell<F>>,
+    coinbase: WordLoHiCell<F>,
+    coinbase_code_hash: WordLoHiCell<F>,
+    coinbase_code_hash_is_zero: IsZeroWordGadget<F, WordLoHiCell<F>>,
     coinbase_reward: TransferToGadget<F>,
     is_persistent: Cell<F>,
     end_tx: EndTxHelperGadget<F>,
@@ -66,7 +66,7 @@ impl<F: Field> ExecutionGadget<F> for EndTxGadget<F> {
             MAX_REFUND_QUOTIENT_OF_GAS_USED as u64,
         );
         let refund = cb.query_cell();
-        cb.tx_refund_read(tx_id.expr(), Word::from_lo_unchecked(refund.expr()));
+        cb.tx_refund_read(tx_id.expr(), WordLoHi::from_lo_unchecked(refund.expr()));
         let effective_refund = MinMaxGadget::construct(cb, max_refund.quotient(), refund.expr());
 
         // Add effective_refund * tx_gas_price back to caller's balance

--- a/zkevm-circuits/src/evm_circuit/execution/error_invalid_jump.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_invalid_jump.rs
@@ -12,7 +12,7 @@ use crate::{
         witness::{Block, Call, ExecStep, Transaction},
     },
     util::{
-        word::{Word, WordCell, WordExpr},
+        word::{WordExpr, WordLoHi, WordLoHiCell},
         Expr,
     },
 };
@@ -29,8 +29,8 @@ pub(crate) struct ErrorInvalidJumpGadget<F> {
     is_code: Cell<F>,
     is_jump_dest: IsEqualGadget<F>,
     is_jumpi: IsEqualGadget<F>,
-    condition: WordCell<F>,
-    is_condition_zero: IsZeroWordGadget<F, WordCell<F>>,
+    condition: WordLoHiCell<F>,
+    is_condition_zero: IsZeroWordGadget<F, WordLoHiCell<F>>,
     common_error_gadget: CommonErrorGadget<F>,
 }
 
@@ -160,8 +160,11 @@ impl<F: Field> ExecutionGadget<F> for ErrorInvalidJumpGadget<F> {
         )?;
 
         self.condition.assign_u256(region, offset, condition)?;
-        self.is_condition_zero
-            .assign_value(region, offset, Value::known(Word::from(condition)))?;
+        self.is_condition_zero.assign_value(
+            region,
+            offset,
+            Value::known(WordLoHi::from(condition)),
+        )?;
 
         self.common_error_gadget.assign(
             region,

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_memory_copy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_memory_copy.rs
@@ -17,7 +17,7 @@ use crate::{
     },
     table::CallContextFieldTag,
     util::{
-        word::{Word, WordCell, WordExpr},
+        word::{WordExpr, WordLoHi, WordLoHiCell},
         Expr,
     },
 };
@@ -39,7 +39,7 @@ pub(crate) struct ErrorOOGMemoryCopyGadget<F> {
     /// Extra stack pop for `EXTCODECOPY`
     external_address: AccountAddress<F>,
     /// Source offset
-    src_offset: WordCell<F>,
+    src_offset: WordLoHiCell<F>,
     /// Destination offset and size to copy
     dst_memory_addr: MemoryExpandedAddressGadget<F>,
     memory_expansion: MemoryExpansionGadget<F, 1, N_BYTES_MEMORY_WORD_SIZE>,
@@ -79,7 +79,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGMemoryCopyGadget<F> {
             cb.call_context_lookup_read(
                 None,
                 CallContextFieldTag::TxId,
-                Word::from_lo_unchecked(tx_id.expr()),
+                WordLoHi::from_lo_unchecked(tx_id.expr()),
             );
 
             // Check if EXTCODECOPY external address is warm.

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_sload_sstore.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_sload_sstore.rs
@@ -17,7 +17,7 @@ use crate::{
     },
     table::CallContextFieldTag,
     util::{
-        word::{Word, WordCell, WordExpr},
+        word::{WordExpr, WordLoHi, WordLoHiCell},
         Expr,
     },
 };
@@ -34,14 +34,14 @@ pub(crate) struct ErrorOOGSloadSstoreGadget<F> {
     opcode: Cell<F>,
     tx_id: Cell<F>,
     is_static: Cell<F>,
-    callee_address: WordCell<F>,
-    key: WordCell<F>,
-    value: WordCell<F>,
-    value_prev: WordCell<F>,
-    original_value: WordCell<F>,
+    callee_address: WordLoHiCell<F>,
+    key: WordLoHiCell<F>,
+    value: WordLoHiCell<F>,
+    value_prev: WordLoHiCell<F>,
+    original_value: WordLoHiCell<F>,
     is_warm: Cell<F>,
     is_sstore: PairSelectGadget<F>,
-    sstore_gas_cost: SstoreGasGadget<F, WordCell<F>>,
+    sstore_gas_cost: SstoreGasGadget<F, WordLoHiCell<F>>,
     insufficient_gas_cost: LtGadget<F, N_BYTES_GAS>,
     // Constrain for SSTORE reentrancy sentry.
     insufficient_gas_sentry: LtGadget<F, N_BYTES_GAS>,
@@ -81,7 +81,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGSloadSstoreGadget<F> {
             tx_id.expr(),
             callee_address.to_word(),
             key.to_word(),
-            Word::from_lo_unchecked(is_warm.expr()),
+            WordLoHi::from_lo_unchecked(is_warm.expr()),
         );
 
         let sload_gas_cost = SloadGasGadget::construct(cb, is_warm.expr());

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_static_memory.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_static_memory.rs
@@ -14,7 +14,7 @@ use crate::{
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
-    util::{word::Word, Expr},
+    util::{word::WordLoHi, Expr},
 };
 use eth_types::{evm_types::OpcodeId, Field, ToWord};
 use gadgets::util::or;
@@ -65,7 +65,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGStaticMemoryGadget<F> {
         cb.require_equal_word(
             "Memory length must be 32 for MLOAD and MSTORE, and 1 for MSTORE8",
             memory_address.length_word(),
-            Word::from_lo_unchecked(select::expr(is_mstore8.expr(), 1.expr(), 32.expr())),
+            WordLoHi::from_lo_unchecked(select::expr(is_mstore8.expr(), 1.expr(), 32.expr())),
         );
 
         let memory_expansion = MemoryExpansionGadget::construct(cb, [memory_address.address()]);

--- a/zkevm-circuits/src/evm_circuit/execution/error_precompile_failed.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_precompile_failed.rs
@@ -6,12 +6,12 @@ use crate::{
             constraint_builder::{ConstrainBuilderCommon, EVMConstraintBuilder},
             math_gadget::IsZeroGadget,
             memory_gadget::{CommonMemoryAddressGadget, MemoryAddressGadget},
-            sum, CachedRegion, Cell, Word,
+            sum, CachedRegion, Cell,
         },
     },
     table::CallContextFieldTag,
     util::{
-        word::{Word32Cell, WordExpr},
+        word::{Word32Cell, WordExpr, WordLoHi},
         Expr,
     },
     witness::{Block, Call, ExecStep, Transaction},
@@ -87,14 +87,14 @@ impl<F: Field> ExecutionGadget<F> for ErrorPrecompileFailedGadget<F> {
         cb.stack_pop(cd_length.to_word());
         cb.stack_pop(rd_offset.to_word());
         cb.stack_pop(rd_length.to_word());
-        cb.stack_push(Word::zero());
+        cb.stack_push(WordLoHi::zero());
 
         for (field_tag, value) in [
             (CallContextFieldTag::LastCalleeId, callee_call_id.expr()),
             (CallContextFieldTag::LastCalleeReturnDataOffset, 0.expr()),
             (CallContextFieldTag::LastCalleeReturnDataLength, 0.expr()),
         ] {
-            cb.call_context_lookup_write(None, field_tag, Word::from_lo_unchecked(value));
+            cb.call_context_lookup_write(None, field_tag, WordLoHi::from_lo_unchecked(value));
         }
 
         let cd_address = MemoryAddressGadget::construct(cb, cd_offset, cd_length);

--- a/zkevm-circuits/src/evm_circuit/execution/error_return_data_oo_bound.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_return_data_oo_bound.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     table::CallContextFieldTag,
     util::{
-        word::{Word, WordExpr},
+        word::{WordExpr, WordLoHi},
         Expr,
     },
 };
@@ -64,7 +64,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorReturnDataOutOfBoundGadget<F> {
         cb.call_context_lookup_read(
             None,
             CallContextFieldTag::LastCalleeReturnDataLength,
-            Word::from_lo_unchecked(return_data_length.expr()),
+            WordLoHi::from_lo_unchecked(return_data_length.expr()),
         );
 
         // Check if `data_offset` is Uint64 overflow.

--- a/zkevm-circuits/src/evm_circuit/execution/error_write_protection.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_write_protection.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     table::CallContextFieldTag,
     util::{
-        word::{Word, WordCell, WordExpr},
+        word::{WordExpr, WordLoHi, WordLoHiCell},
         Expr,
     },
 };
@@ -23,10 +23,10 @@ use halo2_proofs::{circuit::Value, plonk::Error};
 pub(crate) struct ErrorWriteProtectionGadget<F> {
     opcode: Cell<F>,
     is_call: IsZeroGadget<F>,
-    gas: WordCell<F>,
+    gas: WordLoHiCell<F>,
     code_address: AccountAddress<F>,
-    value: WordCell<F>,
-    is_value_zero: IsZeroWordGadget<F, WordCell<F>>,
+    value: WordLoHiCell<F>,
+    is_value_zero: IsZeroWordGadget<F, WordLoHiCell<F>>,
     common_error_gadget: CommonErrorGadget<F>,
 }
 
@@ -73,7 +73,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorWriteProtectionGadget<F> {
         });
 
         // current call context is readonly
-        cb.call_context_lookup_read(None, CallContextFieldTag::IsStatic, Word::one());
+        cb.call_context_lookup_read(None, CallContextFieldTag::IsStatic, WordLoHi::one());
 
         // constrain not root call as at least one previous staticcall preset.
         cb.require_zero(
@@ -125,7 +125,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorWriteProtectionGadget<F> {
             F::from(opcode.as_u64()) - F::from(OpcodeId::CALL.as_u64()),
         )?;
         self.is_value_zero
-            .assign(region, offset, Word::from(value))?;
+            .assign(region, offset, WordLoHi::from(value))?;
 
         self.common_error_gadget.assign(
             region,

--- a/zkevm-circuits/src/evm_circuit/execution/extcodecopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodecopy.rs
@@ -18,7 +18,7 @@ use crate::{
         witness::{Block, Call, ExecStep, Transaction},
     },
     table::{AccountFieldTag, CallContextFieldTag},
-    util::word::{Word, Word32Cell, WordExpr},
+    util::word::{Word32Cell, WordExpr, WordLoHi},
 };
 use bus_mapping::circuit_input_builder::CopyDataType;
 use eth_types::{evm_types::GasCost, Field, ToScalar};
@@ -40,7 +40,7 @@ pub(crate) struct ExtcodecopyGadget<F> {
     reversion_info: ReversionInfo<F>,
     is_warm: Cell<F>,
     code_hash: Word32Cell<F>,
-    not_exists: IsZeroWordGadget<F, Word<Expression<F>>>,
+    not_exists: IsZeroWordGadget<F, WordLoHi<Expression<F>>>,
     code_size: Cell<F>,
     copy_rwc_inc: Cell<F>,
     memory_expansion: MemoryExpansionGadget<F, 1, N_BYTES_MEMORY_WORD_SIZE>,
@@ -126,7 +126,7 @@ impl<F: Field> ExecutionGadget<F> for ExtcodecopyGadget<F> {
             cb.copy_table_lookup(
                 code_hash.to_word(),
                 CopyDataType::Bytecode.expr(),
-                Word::from_lo_unchecked(cb.curr.state.call_id.expr()),
+                WordLoHi::from_lo_unchecked(cb.curr.state.call_id.expr()),
                 CopyDataType::Memory.expr(),
                 src_addr,
                 code_size.expr(),

--- a/zkevm-circuits/src/evm_circuit/execution/extcodehash.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodehash.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     table::{AccountFieldTag, CallContextFieldTag},
     util::{
-        word::{Word32Cell, WordCell, WordExpr},
+        word::{Word32Cell, WordExpr, WordLoHiCell},
         Expr,
     },
 };
@@ -28,7 +28,7 @@ pub(crate) struct ExtcodehashGadget<F> {
     tx_id: Cell<F>,
     reversion_info: ReversionInfo<F>,
     is_warm: Cell<F>,
-    code_hash: WordCell<F>,
+    code_hash: WordLoHiCell<F>,
 }
 
 impl<F: Field> ExecutionGadget<F> for ExtcodehashGadget<F> {

--- a/zkevm-circuits/src/evm_circuit/execution/extcodesize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodesize.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     table::{AccountFieldTag, CallContextFieldTag},
     util::{
-        word::{Word, Word32Cell, WordCell, WordExpr},
+        word::{Word32Cell, WordExpr, WordLoHi, WordLoHiCell},
         Expr,
     },
 };
@@ -30,8 +30,8 @@ pub(crate) struct ExtcodesizeGadget<F> {
     reversion_info: ReversionInfo<F>,
     tx_id: Cell<F>,
     is_warm: Cell<F>,
-    code_hash: WordCell<F>,
-    not_exists: IsZeroWordGadget<F, WordCell<F>>,
+    code_hash: WordLoHiCell<F>,
+    not_exists: IsZeroWordGadget<F, WordLoHiCell<F>>,
     code_size: U64Cell<F>,
 }
 
@@ -143,7 +143,7 @@ impl<F: Field> ExecutionGadget<F> for ExtcodesizeGadget<F> {
         let code_hash = block.get_rws(step, 5).account_codehash_pair().0;
         self.code_hash.assign_u256(region, offset, code_hash)?;
         self.not_exists
-            .assign(region, offset, Word::from(code_hash))?;
+            .assign(region, offset, WordLoHi::from(code_hash))?;
 
         let code_size = block.get_rws(step, 6).stack_value().as_u64();
         self.code_size

--- a/zkevm-circuits/src/evm_circuit/execution/gasprice.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/gasprice.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     table::{CallContextFieldTag, TxContextFieldTag},
     util::{
-        word::{WordCell, WordExpr},
+        word::{WordExpr, WordLoHiCell},
         Expr,
     },
 };
@@ -22,7 +22,7 @@ use halo2_proofs::{circuit::Value, plonk::Error};
 #[derive(Clone, Debug)]
 pub(crate) struct GasPriceGadget<F> {
     tx_id: Cell<F>,
-    gas_price: WordCell<F>,
+    gas_price: WordLoHiCell<F>,
     same_context: SameContextGadget<F>,
 }
 

--- a/zkevm-circuits/src/evm_circuit/execution/invalid_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/invalid_tx.rs
@@ -7,12 +7,12 @@ use crate::{
             constraint_builder::{ConstrainBuilderCommon, EVMConstraintBuilder},
             math_gadget::{IsEqualGadget, LtGadget, LtWordGadget},
             tx::{BeginTxHelperGadget, EndTxHelperGadget, TxDataGadget},
-            CachedRegion, Cell, StepRws, Word,
+            CachedRegion, Cell, StepRws,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
     table::AccountFieldTag,
-    util::word::{Word32Cell, WordExpr},
+    util::word::{Word32Cell, WordExpr, WordLoHi},
 };
 use eth_types::{Field, ToScalar};
 use gadgets::util::{not, or, Expr, Scalar};
@@ -45,7 +45,7 @@ impl<F: Field> ExecutionGadget<F> for InvalidTxGadget<F> {
         cb.account_read(
             tx.caller_address.to_word(),
             AccountFieldTag::Nonce,
-            Word::from_lo_unchecked(account_nonce.expr()),
+            WordLoHi::from_lo_unchecked(account_nonce.expr()),
         );
         let is_nonce_match = IsEqualGadget::construct(cb, account_nonce.expr(), tx.nonce.expr());
 

--- a/zkevm-circuits/src/evm_circuit/execution/is_zero.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/is_zero.rs
@@ -10,7 +10,7 @@ use crate::{
         witness::{Block, Call, ExecStep, Transaction},
     },
     util::{
-        word::{Word, WordCell, WordExpr},
+        word::{WordExpr, WordLoHi, WordLoHiCell},
         Expr,
     },
 };
@@ -21,8 +21,8 @@ use halo2_proofs::{circuit::Value, plonk::Error};
 #[derive(Clone, Debug)]
 pub(crate) struct IsZeroGadget<F> {
     same_context: SameContextGadget<F>,
-    value: WordCell<F>,
-    is_zero_word: math_gadget::IsZeroWordGadget<F, WordCell<F>>,
+    value: WordLoHiCell<F>,
+    is_zero_word: math_gadget::IsZeroWordGadget<F, WordLoHiCell<F>>,
 }
 
 impl<F: Field> ExecutionGadget<F> for IsZeroGadget<F> {
@@ -37,7 +37,7 @@ impl<F: Field> ExecutionGadget<F> for IsZeroGadget<F> {
         let is_zero_word = math_gadget::IsZeroWordGadget::construct(cb, &value);
 
         cb.stack_pop(value.to_word());
-        cb.stack_push(Word::from_lo_unchecked(is_zero_word.expr()));
+        cb.stack_push(WordLoHi::from_lo_unchecked(is_zero_word.expr()));
 
         // State transition
         let step_state_transition = StepStateTransition {
@@ -70,7 +70,7 @@ impl<F: Field> ExecutionGadget<F> for IsZeroGadget<F> {
         let value = block.get_rws(step, 0).stack_value();
         self.value.assign_u256(region, offset, value)?;
         self.is_zero_word
-            .assign_value(region, offset, Value::known(Word::from(value)))?;
+            .assign_value(region, offset, Value::known(WordLoHi::from(value)))?;
 
         Ok(())
     }

--- a/zkevm-circuits/src/evm_circuit/execution/jumpi.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/jumpi.rs
@@ -15,7 +15,7 @@ use crate::{
         witness::{Block, Call, ExecStep, Transaction},
     },
     util::{
-        word::{Word, WordCell, WordExpr},
+        word::{WordExpr, WordLoHi, WordLoHiCell},
         Expr,
     },
 };
@@ -26,8 +26,8 @@ use halo2_proofs::{circuit::Value, plonk::Error};
 pub(crate) struct JumpiGadget<F> {
     same_context: SameContextGadget<F>,
     dest: WordByteRangeGadget<F, N_BYTES_PROGRAM_COUNTER>,
-    condition: WordCell<F>,
-    is_condition_zero: IsZeroWordGadget<F, WordCell<F>>,
+    condition: WordLoHiCell<F>,
+    is_condition_zero: IsZeroWordGadget<F, WordLoHiCell<F>>,
 }
 
 impl<F: Field> ExecutionGadget<F> for JumpiGadget<F> {
@@ -100,8 +100,11 @@ impl<F: Field> ExecutionGadget<F> for JumpiGadget<F> {
 
         self.dest.assign(region, offset, destination)?;
         self.condition.assign_u256(region, offset, condition)?;
-        self.is_condition_zero
-            .assign_value(region, offset, Value::known(Word::from(condition)))?;
+        self.is_condition_zero.assign_value(
+            region,
+            offset,
+            Value::known(WordLoHi::from(condition)),
+        )?;
 
         Ok(())
     }

--- a/zkevm-circuits/src/evm_circuit/execution/logs.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/logs.rs
@@ -19,7 +19,7 @@ use crate::{
     table::{CallContextFieldTag, TxLogFieldTag},
     util::{
         build_tx_log_expression,
-        word::{Word, Word32Cell, WordCell, WordExpr},
+        word::{Word32Cell, WordExpr, WordLoHi, WordLoHiCell},
         Expr,
     },
 };
@@ -39,7 +39,7 @@ pub(crate) struct LogGadget<F> {
     topics: [Word32Cell<F>; 4],
     topic_selectors: [Cell<F>; 4],
 
-    contract_address: WordCell<F>,
+    contract_address: WordLoHiCell<F>,
     is_static_call: Cell<F>,
     is_persistent: Cell<F>,
     tx_id: Cell<F>,
@@ -139,9 +139,9 @@ impl<F: Field> ExecutionGadget<F> for LogGadget<F> {
         let cond = memory_address.has_length() * is_persistent.expr();
         cb.condition(cond.clone(), |cb| {
             cb.copy_table_lookup(
-                Word::from_lo_unchecked(cb.curr.state.call_id.expr()),
+                WordLoHi::from_lo_unchecked(cb.curr.state.call_id.expr()),
                 CopyDataType::Memory.expr(),
-                Word::from_lo_unchecked(tx_id.expr()),
+                WordLoHi::from_lo_unchecked(tx_id.expr()),
                 CopyDataType::TxLog.expr(),
                 memory_address.offset(),
                 memory_address.address(),

--- a/zkevm-circuits/src/evm_circuit/execution/msize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/msize.rs
@@ -13,7 +13,7 @@ use crate::{
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
-    util::{word::Word, Expr},
+    util::{word::WordLoHi, Expr},
 };
 use bus_mapping::evm::OpcodeId;
 use eth_types::Field;
@@ -42,7 +42,7 @@ impl<F: Field> ExecutionGadget<F> for MsizeGadget<F> {
         );
 
         // Push the value on the stack
-        cb.stack_push(Word::from_lo_unchecked(value.expr()));
+        cb.stack_push(WordLoHi::from_lo_unchecked(value.expr()));
 
         // State transition
         let step_state_transition = StepStateTransition {

--- a/zkevm-circuits/src/evm_circuit/execution/mul_div_mod.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/mul_div_mod.rs
@@ -14,7 +14,7 @@ use crate::{
         witness::{Block, Call, ExecStep, Transaction},
     },
     util::{
-        word::{Word, Word32Cell, WordExpr},
+        word::{Word32Cell, WordExpr, WordLoHi},
         Expr,
     },
 };
@@ -71,7 +71,7 @@ impl<F: Field> ExecutionGadget<F> for MulDivModGadget<F> {
         // The second pop is multiplicand for MUL and divisor for DIV/MOD
         // The push is product for MUL, quotient for DIV, and residue for MOD
         // Note that for DIV/MOD, when divisor == 0, the push value is also 0.
-        cb.stack_pop(Word::select(is_mul.clone(), a.to_word(), d.to_word()));
+        cb.stack_pop(WordLoHi::select(is_mul.clone(), a.to_word(), d.to_word()));
         cb.stack_pop(b.to_word());
         cb.stack_push(
             d.to_word()
@@ -152,7 +152,8 @@ impl<F: Field> ExecutionGadget<F> for MulDivModGadget<F> {
         self.words[3].assign_u256(region, offset, d)?;
         self.mul_add_words.assign(region, offset, [a, b, c, d])?;
         self.lt_word.assign(region, offset, c, b)?;
-        self.divisor_is_zero.assign(region, offset, Word::from(b))?;
+        self.divisor_is_zero
+            .assign(region, offset, WordLoHi::from(b))?;
         Ok(())
     }
 }

--- a/zkevm-circuits/src/evm_circuit/execution/mulmod.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/mulmod.rs
@@ -14,7 +14,7 @@ use crate::{
         witness::{Block, Call, ExecStep, Transaction},
     },
     util::{
-        word::{Word, Word32Cell, WordExpr},
+        word::{Word32Cell, WordExpr, WordLoHi},
         Expr,
     },
 };
@@ -157,7 +157,7 @@ impl<F: Field> ExecutionGadget<F> for MulModGadget<F> {
 
         self.lt.assign(region, offset, r, n)?;
 
-        self.n_is_zero.assign(region, offset, Word::from(n))?;
+        self.n_is_zero.assign(region, offset, WordLoHi::from(n))?;
         Ok(())
     }
 }

--- a/zkevm-circuits/src/evm_circuit/execution/pop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/pop.rs
@@ -10,7 +10,7 @@ use crate::{
         witness::{Block, Call, ExecStep, Transaction},
     },
     util::{
-        word::{WordCell, WordExpr},
+        word::{WordExpr, WordLoHiCell},
         Expr,
     },
 };
@@ -21,7 +21,7 @@ use halo2_proofs::plonk::Error;
 #[derive(Clone, Debug)]
 pub(crate) struct PopGadget<F> {
     same_context: SameContextGadget<F>,
-    value: WordCell<F>,
+    value: WordLoHiCell<F>,
 }
 
 impl<F: Field> ExecutionGadget<F> for PopGadget<F> {

--- a/zkevm-circuits/src/evm_circuit/execution/return_revert.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/return_revert.rs
@@ -19,7 +19,7 @@ use crate::{
     },
     table::{AccountFieldTag, CallContextFieldTag},
     util::{
-        word::{Word, Word32Cell, WordCell, WordExpr},
+        word::{Word32Cell, WordExpr, WordLoHi, WordLoHiCell},
         Expr,
     },
 };
@@ -55,7 +55,7 @@ pub(crate) struct ReturnRevertGadget<F> {
     code_hash: Word32Cell<F>,
 
     caller_id: Cell<F>,
-    address: WordCell<F>,
+    address: WordLoHiCell<F>,
     reversion_info: ReversionInfo<F>,
 }
 
@@ -137,7 +137,7 @@ impl<F: Field> ExecutionGadget<F> for ReturnRevertGadget<F> {
             let code_hash = cb.query_word32();
             let deployed_code_rlc = cb.query_cell_phase2();
             cb.copy_table_lookup(
-                Word::from_lo_unchecked(cb.curr.state.call_id.expr()),
+                WordLoHi::from_lo_unchecked(cb.curr.state.call_id.expr()),
                 CopyDataType::Memory.expr(),
                 code_hash.to_word(),
                 CopyDataType::Bytecode.expr(),
@@ -179,7 +179,7 @@ impl<F: Field> ExecutionGadget<F> for ReturnRevertGadget<F> {
             cb.call_context_lookup_read(
                 None,
                 CallContextFieldTag::IsPersistent,
-                Word::from_lo_unchecked(is_success.expr()),
+                WordLoHi::from_lo_unchecked(is_success.expr()),
             );
             cb.require_step_state_transition(StepStateTransition {
                 program_counter: To(0.expr()),
@@ -234,9 +234,9 @@ impl<F: Field> ExecutionGadget<F> for ReturnRevertGadget<F> {
                 * not::expr(copy_rw_increase_is_zero.expr()),
             |cb| {
                 cb.copy_table_lookup(
-                    Word::from_lo_unchecked(cb.curr.state.call_id.expr()),
+                    WordLoHi::from_lo_unchecked(cb.curr.state.call_id.expr()),
                     CopyDataType::Memory.expr(),
-                    Word::from_lo_unchecked(cb.next.state.call_id.expr()),
+                    WordLoHi::from_lo_unchecked(cb.next.state.call_id.expr()),
                     CopyDataType::Memory.expr(),
                     range.offset(),
                     range.address(),

--- a/zkevm-circuits/src/evm_circuit/execution/returndatacopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/returndatacopy.rs
@@ -20,7 +20,7 @@ use crate::{
     },
     table::CallContextFieldTag,
     util::{
-        word::{Word, WordExpr},
+        word::{WordExpr, WordLoHi},
         Expr,
     },
 };
@@ -71,8 +71,8 @@ impl<F: Field> ExecutionGadget<F> for ReturnDataCopyGadget<F> {
 
         // 1. Pop dest_offset, offset, length from stack
         cb.stack_pop(dest_offset.to_word());
-        cb.stack_pop(Word::from_lo_unchecked(data_offset.expr()));
-        cb.stack_pop(Word::from_lo_unchecked(size.expr()));
+        cb.stack_pop(WordLoHi::from_lo_unchecked(data_offset.expr()));
+        cb.stack_pop(WordLoHi::from_lo_unchecked(size.expr()));
 
         // 2. Add lookup constraint in the call context for the returndatacopy field.
         let last_callee_id = cb.query_cell();
@@ -81,17 +81,17 @@ impl<F: Field> ExecutionGadget<F> for ReturnDataCopyGadget<F> {
         cb.call_context_lookup_read(
             None,
             CallContextFieldTag::LastCalleeId,
-            Word::from_lo_unchecked(last_callee_id.expr()),
+            WordLoHi::from_lo_unchecked(last_callee_id.expr()),
         );
         cb.call_context_lookup_read(
             None,
             CallContextFieldTag::LastCalleeReturnDataOffset,
-            Word::from_lo_unchecked(return_data_offset.expr()),
+            WordLoHi::from_lo_unchecked(return_data_offset.expr()),
         );
         cb.call_context_lookup_read(
             None,
             CallContextFieldTag::LastCalleeReturnDataLength,
-            Word::from_lo_unchecked(return_data_size.expr()),
+            WordLoHi::from_lo_unchecked(return_data_size.expr()),
         );
 
         // 3. contraints for copy: copy overflow check
@@ -118,9 +118,9 @@ impl<F: Field> ExecutionGadget<F> for ReturnDataCopyGadget<F> {
         let copy_rwc_inc = cb.query_cell();
         cb.condition(dst_memory_addr.has_length(), |cb| {
             cb.copy_table_lookup(
-                Word::from_lo_unchecked(last_callee_id.expr()),
+                WordLoHi::from_lo_unchecked(last_callee_id.expr()),
                 CopyDataType::Memory.expr(),
-                Word::from_lo_unchecked(cb.curr.state.call_id.expr()),
+                WordLoHi::from_lo_unchecked(cb.curr.state.call_id.expr()),
                 CopyDataType::Memory.expr(),
                 return_data_offset.expr() + data_offset.expr(),
                 return_data_offset.expr() + return_data_size.expr(),

--- a/zkevm-circuits/src/evm_circuit/execution/returndatasize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/returndatasize.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     table::CallContextFieldTag,
     util::{
-        word::{WordCell, WordExpr},
+        word::{WordExpr, WordLoHiCell},
         Expr,
     },
 };
@@ -22,7 +22,7 @@ use halo2_proofs::plonk::Error;
 #[derive(Clone, Debug)]
 pub(crate) struct ReturnDataSizeGadget<F> {
     same_context: SameContextGadget<F>,
-    return_data_size: WordCell<F>,
+    return_data_size: WordLoHiCell<F>,
 }
 
 impl<F: Field> ExecutionGadget<F> for ReturnDataSizeGadget<F> {

--- a/zkevm-circuits/src/evm_circuit/execution/sdiv_smod.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sdiv_smod.rs
@@ -16,7 +16,7 @@ use crate::{
         witness::{Block, Call, ExecStep, Transaction},
     },
     util::{
-        word::{Word, Word32Cell, WordExpr},
+        word::{Word32Cell, WordExpr, WordLoHi},
         Expr,
     },
 };
@@ -58,7 +58,7 @@ impl<F: Field> ExecutionGadget<F> for SignedDivModGadget<F> {
 
         cb.stack_pop(dividend_abs.x().to_word());
         cb.stack_pop(divisor_abs.x().to_word());
-        cb.stack_push(Word::select(
+        cb.stack_push(WordLoHi::select(
             is_sdiv,
             quotient_abs
                 .x()
@@ -218,11 +218,11 @@ impl<F: Field> ExecutionGadget<F> for SignedDivModGadget<F> {
             u64::from(dividend_abs.to_le_bytes()[31]).into(),
         )?;
         self.quotient_is_zero
-            .assign(region, offset, Word::from(quotient))?;
+            .assign(region, offset, WordLoHi::from(quotient))?;
         self.divisor_is_zero
-            .assign(region, offset, Word::from(divisor))?;
+            .assign(region, offset, WordLoHi::from(divisor))?;
         self.remainder_is_zero
-            .assign(region, offset, Word::from(remainder))?;
+            .assign(region, offset, WordLoHi::from(remainder))?;
         Ok(())
     }
 }

--- a/zkevm-circuits/src/evm_circuit/execution/selfbalance.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/selfbalance.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     table::{AccountFieldTag, CallContextFieldTag},
     util::{
-        word::{WordCell, WordExpr},
+        word::{WordExpr, WordLoHiCell},
         Expr,
     },
 };
@@ -22,8 +22,8 @@ use halo2_proofs::plonk::Error;
 #[derive(Clone, Debug)]
 pub(crate) struct SelfbalanceGadget<F> {
     same_context: SameContextGadget<F>,
-    callee_address: WordCell<F>,
-    self_balance: WordCell<F>,
+    callee_address: WordLoHiCell<F>,
+    self_balance: WordLoHiCell<F>,
 }
 
 impl<F: Field> ExecutionGadget<F> for SelfbalanceGadget<F> {

--- a/zkevm-circuits/src/evm_circuit/execution/sha3.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sha3.rs
@@ -20,7 +20,7 @@ use crate::{
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
-    util::word::{Word, WordCell, WordExpr},
+    util::word::{WordExpr, WordLoHi, WordLoHiCell},
 };
 
 use super::ExecutionGadget;
@@ -29,7 +29,7 @@ use super::ExecutionGadget;
 pub(crate) struct Sha3Gadget<F> {
     same_context: SameContextGadget<F>,
     memory_address: MemoryAddressGadget<F>,
-    sha3_digest: WordCell<F>,
+    sha3_digest: WordLoHiCell<F>,
     copy_rwc_inc: Cell<F>,
     rlc_acc: Cell<F>,
     memory_expansion: MemoryExpansionGadget<F, 1, N_BYTES_MEMORY_WORD_SIZE>,
@@ -59,9 +59,9 @@ impl<F: Field> ExecutionGadget<F> for Sha3Gadget<F> {
 
         cb.condition(memory_address.has_length(), |cb| {
             cb.copy_table_lookup(
-                Word::from_lo_unchecked(cb.curr.state.call_id.expr()),
+                WordLoHi::from_lo_unchecked(cb.curr.state.call_id.expr()),
                 CopyDataType::Memory.expr(),
-                Word::from_lo_unchecked(cb.curr.state.call_id.expr()),
+                WordLoHi::from_lo_unchecked(cb.curr.state.call_id.expr()),
                 CopyDataType::RlcAcc.expr(),
                 memory_address.offset(),
                 memory_address.address(),

--- a/zkevm-circuits/src/evm_circuit/execution/shl_shr.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/shl_shr.rs
@@ -15,7 +15,7 @@ use crate::{
         witness::{Block, Call, ExecStep, Transaction},
     },
     util::{
-        word::{Word, Word32Cell, WordExpr},
+        word::{Word32Cell, WordExpr, WordLoHi},
         Expr,
     },
 };
@@ -102,7 +102,7 @@ impl<F: Field> ExecutionGadget<F> for ShlShrGadget<F> {
             "shift == shift.cells[0] when divisor != 0",
             shift
                 .to_word()
-                .sub_unchecked(Word::from_lo_unchecked(shift.limbs[0].expr()))
+                .sub_unchecked(WordLoHi::from_lo_unchecked(shift.limbs[0].expr()))
                 .mul_selector(1.expr() - divisor_is_zero.expr()),
         );
 
@@ -207,9 +207,9 @@ impl<F: Field> ExecutionGadget<F> for ShlShrGadget<F> {
             .assign(region, offset, [quotient, divisor, remainder, dividend])?;
         self.shf_lt256.assign(region, offset, F::from(shf_lt256))?;
         self.divisor_is_zero
-            .assign(region, offset, Word::from(divisor))?;
+            .assign(region, offset, WordLoHi::from(divisor))?;
         self.remainder_is_zero
-            .assign(region, offset, Word::from(remainder))?;
+            .assign(region, offset, WordLoHi::from(remainder))?;
         self.remainder_lt_divisor
             .assign(region, offset, remainder, divisor)?;
         Ok(())

--- a/zkevm-circuits/src/evm_circuit/execution/signed_comparator.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/signed_comparator.rs
@@ -12,7 +12,7 @@ use crate::{
         witness::{Block, Call, ExecStep, Transaction},
     },
     util::{
-        word::{Word, Word32Cell, WordExpr},
+        word::{Word32Cell, WordExpr, WordLoHi},
         Expr,
     },
 };
@@ -109,9 +109,9 @@ impl<F: Field> ExecutionGadget<F> for SignedComparatorGadget<F> {
         let result = a_neg_b_pos.clone() + (1.expr() - a_neg_b_pos - b_neg_a_pos) * a_lt_b.expr();
 
         // Pop a and b from the stack, push the result on the stack.
-        cb.stack_pop(Word::select(is_sgt.expr(), b.to_word(), a.to_word()));
-        cb.stack_pop(Word::select(is_sgt.expr(), a.to_word(), b.to_word()));
-        cb.stack_push(Word::from_lo_unchecked(result));
+        cb.stack_pop(WordLoHi::select(is_sgt.expr(), b.to_word(), a.to_word()));
+        cb.stack_pop(WordLoHi::select(is_sgt.expr(), a.to_word(), b.to_word()));
+        cb.stack_push(WordLoHi::from_lo_unchecked(result));
 
         // The read-write counter changes by three since we're reading two words
         // from stack and writing one. The program counter shifts only by one

--- a/zkevm-circuits/src/evm_circuit/execution/sload.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sload.rs
@@ -13,7 +13,7 @@ use crate::{
     },
     table::CallContextFieldTag,
     util::{
-        word::{Word, WordCell, WordExpr},
+        word::{WordExpr, WordLoHi, WordLoHiCell},
         Expr,
     },
 };
@@ -25,10 +25,10 @@ pub(crate) struct SloadGadget<F> {
     same_context: SameContextGadget<F>,
     tx_id: Cell<F>,
     reversion_info: ReversionInfo<F>,
-    callee_address: WordCell<F>,
-    key: WordCell<F>,
-    value: WordCell<F>,
-    committed_value: WordCell<F>,
+    callee_address: WordLoHiCell<F>,
+    key: WordLoHiCell<F>,
+    value: WordLoHiCell<F>,
+    committed_value: WordLoHiCell<F>,
     is_warm: Cell<F>,
 }
 
@@ -65,14 +65,14 @@ impl<F: Field> ExecutionGadget<F> for SloadGadget<F> {
             tx_id.expr(),
             callee_address.to_word(),
             key.to_word(),
-            Word::from_lo_unchecked(is_warm.expr()),
+            WordLoHi::from_lo_unchecked(is_warm.expr()),
         );
         cb.account_storage_access_list_write(
             tx_id.expr(),
             callee_address.to_word(),
             key.to_word(),
-            Word::from_lo_unchecked(true.expr()),
-            Word::from_lo_unchecked(is_warm.expr()),
+            WordLoHi::from_lo_unchecked(true.expr()),
+            WordLoHi::from_lo_unchecked(is_warm.expr()),
             Some(&mut reversion_info),
         );
 

--- a/zkevm-circuits/src/evm_circuit/execution/sstore.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sstore.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     table::CallContextFieldTag,
     util::{
-        word::{Word, Word32Cell, WordCell, WordExpr},
+        word::{Word32Cell, WordExpr, WordLoHi, WordLoHiCell},
         Expr,
     },
 };
@@ -33,7 +33,7 @@ pub(crate) struct SstoreGadget<F> {
     tx_id: Cell<F>,
     is_static: Cell<F>,
     reversion_info: ReversionInfo<F>,
-    callee_address: WordCell<F>,
+    callee_address: WordLoHiCell<F>,
     key: Word32Cell<F>,
     value: Word32Cell<F>,
     value_prev: Word32Cell<F>,
@@ -88,14 +88,14 @@ impl<F: Field> ExecutionGadget<F> for SstoreGadget<F> {
             tx_id.expr(),
             callee_address.to_word(),
             key.to_word(),
-            Word::from_lo_unchecked(is_warm.expr()),
+            WordLoHi::from_lo_unchecked(is_warm.expr()),
         );
         cb.account_storage_access_list_write(
             tx_id.expr(),
             callee_address.to_word(),
             key.to_word(),
-            Word::from_lo_unchecked(true.expr()),
-            Word::from_lo_unchecked(is_warm.expr()),
+            WordLoHi::from_lo_unchecked(true.expr()),
+            WordLoHi::from_lo_unchecked(is_warm.expr()),
             Some(&mut reversion_info),
         );
 
@@ -129,7 +129,7 @@ impl<F: Field> ExecutionGadget<F> for SstoreGadget<F> {
         );
         cb.tx_refund_write(
             tx_id.expr(),
-            Word::from_lo_unchecked(tx_refund.expr()),
+            WordLoHi::from_lo_unchecked(tx_refund.expr()),
             tx_refund_prev.to_word(),
             Some(&mut reversion_info),
         );
@@ -231,12 +231,13 @@ impl<F: Field> ExecutionGadget<F> for SstoreGadget<F> {
 pub(crate) struct SstoreTxRefundGadget<F> {
     tx_refund_old: U64Cell<F>,
     tx_refund_new: Expression<F>,
-    value_prev_is_zero_gadget: IsZeroWordGadget<F, Word<Expression<F>>>,
-    value_is_zero_gadget: IsZeroWordGadget<F, Word<Expression<F>>>,
-    original_is_zero_gadget: IsZeroWordGadget<F, Word<Expression<F>>>,
-    original_eq_value_gadget: IsEqualWordGadget<F, Word<Expression<F>>, Word<Expression<F>>>,
-    prev_eq_value_gadget: IsEqualWordGadget<F, Word<Expression<F>>, Word<Expression<F>>>,
-    original_eq_prev_gadget: IsEqualWordGadget<F, Word<Expression<F>>, Word<Expression<F>>>,
+    value_prev_is_zero_gadget: IsZeroWordGadget<F, WordLoHi<Expression<F>>>,
+    value_is_zero_gadget: IsZeroWordGadget<F, WordLoHi<Expression<F>>>,
+    original_is_zero_gadget: IsZeroWordGadget<F, WordLoHi<Expression<F>>>,
+    original_eq_value_gadget:
+        IsEqualWordGadget<F, WordLoHi<Expression<F>>, WordLoHi<Expression<F>>>,
+    prev_eq_value_gadget: IsEqualWordGadget<F, WordLoHi<Expression<F>>, WordLoHi<Expression<F>>>,
+    original_eq_prev_gadget: IsEqualWordGadget<F, WordLoHi<Expression<F>>, WordLoHi<Expression<F>>>,
 }
 
 impl<F: Field> SstoreTxRefundGadget<F> {
@@ -267,20 +268,20 @@ impl<F: Field> SstoreTxRefundGadget<F> {
         let original_eq_prev = original_eq_prev_gadget.expr();
 
         // (value_prev != value) && (original_value != value) && (value ==
-        // Word::from(0))
+        // WordLoHi::from(0))
         let delete_slot =
             not::expr(prev_eq_value.clone()) * not::expr(original_is_zero.clone()) * value_is_zero;
         // (value_prev != value) && (original_value == value) && (original_value !=
-        // Word::from(0))
+        // WordLoHi::from(0))
         let reset_existing = not::expr(prev_eq_value.clone())
             * original_eq_value.clone()
             * not::expr(original_is_zero.clone());
         // (value_prev != value) && (original_value == value) && (original_value ==
-        // Word::from(0))
+        // WordLoHi::from(0))
         let reset_inexistent =
             not::expr(prev_eq_value.clone()) * original_eq_value * (original_is_zero);
         // (value_prev != value) && (original_value != value_prev) && (value_prev ==
-        // Word::from(0))
+        // WordLoHi::from(0))
         let recreate_slot =
             not::expr(prev_eq_value) * not::expr(original_eq_prev) * (value_prev_is_zero);
 
@@ -321,28 +322,28 @@ impl<F: Field> SstoreTxRefundGadget<F> {
         self.tx_refund_old
             .assign(region, offset, Some(tx_refund_old.to_le_bytes()))?;
         self.value_prev_is_zero_gadget
-            .assign(region, offset, Word::from(value_prev))?;
+            .assign(region, offset, WordLoHi::from(value_prev))?;
         self.value_is_zero_gadget
-            .assign(region, offset, Word::from(value))?;
+            .assign(region, offset, WordLoHi::from(value))?;
         self.original_is_zero_gadget
-            .assign(region, offset, Word::from(original_value))?;
+            .assign(region, offset, WordLoHi::from(original_value))?;
         self.original_eq_value_gadget.assign(
             region,
             offset,
-            Word::from(original_value),
-            Word::from(value),
+            WordLoHi::from(original_value),
+            WordLoHi::from(value),
         )?;
         self.prev_eq_value_gadget.assign(
             region,
             offset,
-            Word::from(value_prev),
-            Word::from(value),
+            WordLoHi::from(value_prev),
+            WordLoHi::from(value),
         )?;
         self.original_eq_prev_gadget.assign(
             region,
             offset,
-            Word::from(original_value),
-            Word::from(value_prev),
+            WordLoHi::from(original_value),
+            WordLoHi::from(value_prev),
         )?;
         debug_assert_eq!(
             calc_expected_tx_refund(tx_refund_old, value, value_prev, original_value),

--- a/zkevm-circuits/src/evm_circuit/execution/stop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/stop.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     table::CallContextFieldTag,
     util::{
-        word::{Word, WordExpr},
+        word::{WordExpr, WordLoHi},
         Expr,
     },
 };
@@ -63,7 +63,7 @@ impl<F: Field> ExecutionGadget<F> for StopGadget<F> {
         );
 
         // Call ends with STOP must be successful
-        cb.call_context_lookup_read(None, CallContextFieldTag::IsSuccess, Word::one());
+        cb.call_context_lookup_read(None, CallContextFieldTag::IsSuccess, WordLoHi::one());
 
         let is_to_end_tx = cb.next.execution_state_selector([ExecutionState::EndTx]);
         cb.require_equal(

--- a/zkevm-circuits/src/evm_circuit/execution/swap.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/swap.rs
@@ -10,7 +10,7 @@ use crate::{
         witness::{Block, Call, ExecStep, Transaction},
     },
     util::{
-        word::{WordCell, WordExpr},
+        word::{WordExpr, WordLoHiCell},
         Expr,
     },
 };
@@ -20,7 +20,7 @@ use halo2_proofs::plonk::Error;
 #[derive(Clone, Debug)]
 pub(crate) struct SwapGadget<F> {
     same_context: SameContextGadget<F>,
-    values: [WordCell<F>; 2],
+    values: [WordLoHiCell<F>; 2],
 }
 
 impl<F: Field> ExecutionGadget<F> for SwapGadget<F> {

--- a/zkevm-circuits/src/evm_circuit/step.rs
+++ b/zkevm-circuits/src/evm_circuit/step.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     util::{
         cell_manager::{CMFixedWidthStrategy, CellManager},
-        word::{Word, WordCell},
+        word::{WordLoHi, WordLoHiCell},
         Expr,
     },
 };
@@ -751,7 +751,7 @@ pub(crate) struct StepState<F> {
     /// In the case of a contract creation internal call, this denotes the hash
     /// of the chunk of bytes from caller's memory that represent the
     /// contract init code.
-    pub(crate) code_hash: WordCell<F>,
+    pub(crate) code_hash: WordLoHiCell<F>,
     /// The program counter
     pub(crate) program_counter: Cell<F>,
     /// The stack pointer
@@ -795,7 +795,7 @@ impl<F: Field> Step<F> {
                 call_id: cell_manager.query_cell(meta, CellType::StoragePhase1),
                 is_root: cell_manager.query_cell(meta, CellType::StoragePhase1),
                 is_create: cell_manager.query_cell(meta, CellType::StoragePhase1),
-                code_hash: Word::new([
+                code_hash: WordLoHi::new([
                     cell_manager.query_cell(meta, CellType::StoragePhase1),
                     cell_manager.query_cell(meta, CellType::StoragePhase1),
                 ]),

--- a/zkevm-circuits/src/evm_circuit/table.rs
+++ b/zkevm-circuits/src/evm_circuit/table.rs
@@ -3,7 +3,7 @@
 use crate::{
     evm_circuit::step::{ExecutionState, ResponsibleOp},
     impl_expr,
-    util::word::Word,
+    util::word::WordLoHi,
 };
 use bus_mapping::{evm::OpcodeId, precompile::PrecompileCalls};
 use eth_types::Field;
@@ -207,13 +207,13 @@ pub(crate) struct RwValues<F> {
     /// the cell value of the [`bus_mapping::operation::Target`]
     field_tag: Expression<F>,
     /// Storage key of two limbs
-    storage_key: Word<Expression<F>>,
+    storage_key: WordLoHi<Expression<F>>,
     /// The current storage value
-    value: Word<Expression<F>>,
+    value: WordLoHi<Expression<F>>,
     /// The previous storage value
-    value_prev: Word<Expression<F>>,
+    value_prev: WordLoHi<Expression<F>>,
     /// The initial storage value before the current transaction
-    init_val: Word<Expression<F>>,
+    init_val: WordLoHi<Expression<F>>,
 }
 
 impl<F: Field> RwValues<F> {
@@ -223,10 +223,10 @@ impl<F: Field> RwValues<F> {
         id: Expression<F>,
         address: Expression<F>,
         field_tag: Expression<F>,
-        storage_key: Word<Expression<F>>,
-        value: Word<Expression<F>>,
-        value_prev: Word<Expression<F>>,
-        init_val: Word<Expression<F>>,
+        storage_key: WordLoHi<Expression<F>>,
+        value: WordLoHi<Expression<F>>,
+        value_prev: WordLoHi<Expression<F>>,
+        init_val: WordLoHi<Expression<F>>,
     ) -> Self {
         Self {
             id,
@@ -269,7 +269,7 @@ pub(crate) enum Lookup<F> {
         /// field_tag is Calldata, otherwise should be set to 0.
         index: Expression<F>,
         /// Value of the field.
-        value: Word<Expression<F>>,
+        value: WordLoHi<Expression<F>>,
     },
     /// Lookup to read-write table, which contains read-write access records of
     /// time-aware data.
@@ -289,7 +289,7 @@ pub(crate) enum Lookup<F> {
     /// contract code.
     Bytecode {
         /// Hash to specify which code to read.
-        hash: Word<Expression<F>>,
+        hash: WordLoHi<Expression<F>>,
         /// Tag to specify whether its the bytecode length or byte value in the
         /// bytecode.
         tag: Expression<F>,
@@ -309,18 +309,18 @@ pub(crate) enum Lookup<F> {
         /// should be set to 0.
         number: Expression<F>,
         /// Value of the field.
-        value: Word<Expression<F>>,
+        value: WordLoHi<Expression<F>>,
     },
     /// Lookup to copy table.
     CopyTable {
         /// Whether the row is the first row of the copy event.
         is_first: Expression<F>,
         /// The source ID for the copy event.
-        src_id: Word<Expression<F>>,
+        src_id: WordLoHi<Expression<F>>,
         /// The source tag for the copy event.
         src_tag: Expression<F>,
         /// The destination ID for the copy event.
-        dst_id: Word<Expression<F>>,
+        dst_id: WordLoHi<Expression<F>>,
         /// The destination tag for the copy event.
         dst_tag: Expression<F>,
         /// The source address where bytes are copied from.
@@ -349,7 +349,7 @@ pub(crate) enum Lookup<F> {
         input_len: Expression<F>,
         /// Output (hash) until this state. hash will be split into multiple expression in little
         /// endian.
-        output: Word<Expression<F>>,
+        output: WordLoHi<Expression<F>>,
     },
     /// Lookup to exponentiation table.
     ExpTable {

--- a/zkevm-circuits/src/evm_circuit/util.rs
+++ b/zkevm-circuits/src/evm_circuit/util.rs
@@ -1,5 +1,5 @@
 pub use crate::util::{
-    word::{Word, WordExpr},
+    word::{WordExpr, WordLoHi},
     Challenges, Expr,
 };
 use crate::{
@@ -145,8 +145,8 @@ impl<'r, 'b, F: Field> CachedRegion<'r, 'b, F> {
             .map(|r| rlc::value(le_bytes, r))
     }
 
-    pub fn code_hash(&self, n: U256) -> Word<Value<F>> {
-        Word::from(n).into_value()
+    pub fn code_hash(&self, n: U256) -> WordLoHi<Value<F>> {
+        WordLoHi::from(n).into_value()
     }
 
     /// Constrains a cell to have a constant value.

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -22,7 +22,7 @@ use crate::{
     },
     table::{AccountFieldTag, CallContextFieldTag},
     util::{
-        word::{Word, Word32, Word32Cell, WordCell, WordExpr},
+        word::{Word32, Word32Cell, WordExpr, WordLoHi, WordLoHiCell},
         Expr,
     },
     witness::{Block, Call, ExecStep},
@@ -100,7 +100,7 @@ pub(crate) struct RestoreContextGadget<F> {
     caller_id: Cell<F>,
     caller_is_root: Cell<F>,
     caller_is_create: Cell<F>,
-    caller_code_hash: WordCell<F>,
+    caller_code_hash: WordLoHiCell<F>,
     caller_program_counter: Cell<F>,
     caller_stack_pointer: Cell<F>,
     caller_gas_left: Cell<F>,
@@ -191,7 +191,7 @@ impl<F: Field> RestoreContextGadget<F> {
             cb.call_context_lookup_write(
                 Some(caller_id.expr()),
                 field_tag,
-                Word::from_lo_unchecked(value),
+                WordLoHi::from_lo_unchecked(value),
             );
         }
 
@@ -308,7 +308,7 @@ impl<F: Field, const N_ADDENDS: usize, const INCREASE: bool>
 {
     pub(crate) fn construct(
         cb: &mut EVMConstraintBuilder<F>,
-        address: Word<Expression<F>>,
+        address: WordLoHi<Expression<F>>,
         updates: Vec<Word32Cell<F>>,
         reversion_info: Option<&mut ReversionInfo<F>>,
     ) -> Self {
@@ -378,7 +378,7 @@ impl<F: Field> TransferToGadget<F> {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn construct(
         cb: &mut EVMConstraintBuilder<F>,
-        receiver_address: Word<Expression<F>>,
+        receiver_address: WordLoHi<Expression<F>>,
         receiver_exists: Expression<F>,
         must_create: Expression<F>,
         value: Word32Cell<F>,
@@ -415,7 +415,7 @@ impl<F: Field> TransferToGadget<F> {
 
     pub(crate) fn create_account(
         cb: &mut EVMConstraintBuilder<F>,
-        receiver_address: Word<Expression<F>>,
+        receiver_address: WordLoHi<Expression<F>>,
         receiver_exists: Expression<F>,
         must_create: Expression<F>,
         value_is_zero: Expression<F>,
@@ -431,7 +431,7 @@ impl<F: Field> TransferToGadget<F> {
                     receiver_address.clone(),
                     AccountFieldTag::CodeHash,
                     cb.empty_code_hash(),
-                    Word::zero(),
+                    WordLoHi::zero(),
                     reversion_info,
                 );
             },
@@ -453,7 +453,7 @@ impl<F: Field> TransferToGadget<F> {
             receiver_balance,
         )?;
         self.value_is_zero
-            .assign_value(region, offset, Value::known(Word::from(value)))?;
+            .assign_value(region, offset, Value::known(WordLoHi::from(value)))?;
         Ok(())
     }
 
@@ -487,8 +487,8 @@ impl<F: Field> TransferWithGasFeeGadget<F> {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn construct(
         cb: &mut EVMConstraintBuilder<F>,
-        sender_address: Word<Expression<F>>,
-        receiver_address: Word<Expression<F>>,
+        sender_address: WordLoHi<Expression<F>>,
+        receiver_address: WordLoHi<Expression<F>>,
         receiver_exists: Expression<F>,
         must_create: Expression<F>,
         value: Word32Cell<F>,
@@ -591,7 +591,7 @@ impl<F: Field> TransferWithGasFeeGadget<F> {
             value,
         )?;
         self.value_is_zero
-            .assign_value(region, offset, Value::known(Word::from(value)))?;
+            .assign_value(region, offset, Value::known(WordLoHi::from(value)))?;
         Ok(())
     }
 }
@@ -610,11 +610,11 @@ pub(crate) struct TransferGadget<F> {
 impl<F: Field> TransferGadget<F> {
     pub(crate) fn construct(
         cb: &mut EVMConstraintBuilder<F>,
-        sender_address: Word<Expression<F>>,
-        receiver_address: Word<Expression<F>>,
+        sender_address: WordLoHi<Expression<F>>,
+        receiver_address: WordLoHi<Expression<F>>,
         receiver_exists: Expression<F>,
         must_create: Expression<F>,
-        // _prev_code_hash: Word<Expression<F>>,
+        // _prev_code_hash: WordLoHi<Expression<F>>,
         value: Word32Cell<F>,
         reversion_info: &mut ReversionInfo<F>,
     ) -> Self {
@@ -687,7 +687,7 @@ impl<F: Field> TransferGadget<F> {
             value,
         )?;
         self.value_is_zero
-            .assign_value(region, offset, Value::known(Word::from(value)))?;
+            .assign_value(region, offset, Value::known(WordLoHi::from(value)))?;
         Ok(())
     }
 
@@ -711,10 +711,10 @@ pub(crate) struct CommonCallGadget<F, MemAddrGadget, const IS_SUCCESS_CALL: bool
 
     value_is_zero: IsZeroWordGadget<F, Word32Cell<F>>,
     pub has_value: Expression<F>,
-    pub callee_code_hash: WordCell<F>,
-    pub is_empty_code_hash: IsEqualWordGadget<F, WordCell<F>, Word<Expression<F>>>,
+    pub callee_code_hash: WordLoHiCell<F>,
+    pub is_empty_code_hash: IsEqualWordGadget<F, WordLoHiCell<F>, WordLoHi<Expression<F>>>,
 
-    pub callee_not_exists: IsZeroWordGadget<F, WordCell<F>>,
+    pub callee_not_exists: IsZeroWordGadget<F, WordLoHiCell<F>>,
 
     // save information
     is_call: Expression<F>,
@@ -767,9 +767,9 @@ impl<F: Field, MemAddrGadget: CommonMemoryAddressGadget<F>, const IS_SUCCESS_CAL
         cb.stack_pop(rd_address.offset_word());
         cb.stack_pop(rd_address.length_word());
         cb.stack_push(if IS_SUCCESS_CALL {
-            Word::from_lo_unchecked(is_success.expr()) // is_success is bool
+            WordLoHi::from_lo_unchecked(is_success.expr()) // is_success is bool
         } else {
-            Word::zero()
+            WordLoHi::zero()
         });
 
         // Recomposition of random linear combination to integer
@@ -816,7 +816,7 @@ impl<F: Field, MemAddrGadget: CommonMemoryAddressGadget<F>, const IS_SUCCESS_CAL
         }
     }
 
-    pub fn callee_address(&self) -> Word<Expression<F>> {
+    pub fn callee_address(&self) -> WordLoHi<Expression<F>> {
         self.callee_address.to_word()
     }
 
@@ -883,19 +883,19 @@ impl<F: Field, MemAddrGadget: CommonMemoryAddressGadget<F>, const IS_SUCCESS_CAL
         )?;
 
         self.value_is_zero
-            .assign(region, offset, Word::from(value))?;
+            .assign(region, offset, WordLoHi::from(value))?;
         self.callee_code_hash
             .assign_u256(region, offset, callee_code_hash)?;
         self.is_empty_code_hash.assign_value(
             region,
             offset,
-            Value::known(Word::from(callee_code_hash)),
-            Value::known(Word::from(CodeDB::empty_code_hash().to_word())),
+            Value::known(WordLoHi::from(callee_code_hash)),
+            Value::known(WordLoHi::from(CodeDB::empty_code_hash().to_word())),
         )?;
         self.callee_not_exists.assign_value(
             region,
             offset,
-            Value::known(Word::from(callee_code_hash)),
+            Value::known(WordLoHi::from(callee_code_hash)),
         )?;
         Ok(memory_expansion_gas_cost)
     }
@@ -1022,19 +1022,19 @@ impl<F: Field, T: WordExpr<F> + Clone> SstoreGasGadget<F, T> {
         self.value_eq_prev.assign_value(
             region,
             offset,
-            Value::known(Word::from(value)),
-            Value::known(Word::from(value_prev)),
+            Value::known(WordLoHi::from(value)),
+            Value::known(WordLoHi::from(value_prev)),
         )?;
         self.original_eq_prev.assign_value(
             region,
             offset,
-            Value::known(Word::from(original_value)),
-            Value::known(Word::from(value_prev)),
+            Value::known(WordLoHi::from(original_value)),
+            Value::known(WordLoHi::from(value_prev)),
         )?;
         self.original_is_zero.assign_value(
             region,
             offset,
-            Value::known(Word::from(original_value)),
+            Value::known(WordLoHi::from(original_value)),
         )?;
         Ok(())
     }
@@ -1074,7 +1074,7 @@ pub(crate) fn cal_sstore_gas_cost_for_assignment(
 
 #[derive(Clone, Debug)]
 pub(crate) struct CommonErrorGadget<F> {
-    rw_counter_end_of_reversion: WordCell<F>,
+    rw_counter_end_of_reversion: WordLoHiCell<F>,
     restore_context: RestoreContextGadget<F>,
 }
 
@@ -1099,7 +1099,7 @@ impl<F: Field> CommonErrorGadget<F> {
         let rw_counter_end_of_reversion = cb.query_word_unchecked(); // rw_counter_end_of_reversion just used for read lookup, therefore skip range check
 
         // current call must be failed.
-        cb.call_context_lookup_read(None, CallContextFieldTag::IsSuccess, Word::zero());
+        cb.call_context_lookup_read(None, CallContextFieldTag::IsSuccess, WordLoHi::zero());
 
         cb.call_context_lookup_read(
             None,
@@ -1285,7 +1285,7 @@ impl<F: Field, const VALID_BYTES: usize> WordByteRangeGadget<F, VALID_BYTES> {
         not::expr(self.not_overflow())
     }
 
-    pub(crate) fn original(&self) -> Word<Expression<F>> {
+    pub(crate) fn original(&self) -> WordLoHi<Expression<F>> {
         self.original.to_word()
     }
 

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     util::{
         build_tx_log_expression, query_expression,
-        word::{Word, Word32, Word32Cell, WordCell, WordExpr},
+        word::{Word32, Word32Cell, WordExpr, WordLoHi, WordLoHiCell},
         Challenges, Expr,
     },
 };
@@ -59,7 +59,7 @@ pub(crate) struct StepStateTransition<F: Field> {
     pub(crate) call_id: Transition<Expression<F>>,
     pub(crate) is_root: Transition<Expression<F>>,
     pub(crate) is_create: Transition<Expression<F>>,
-    pub(crate) code_hash: Transition<Word<Expression<F>>>,
+    pub(crate) code_hash: Transition<WordLoHi<Expression<F>>>,
     pub(crate) program_counter: Transition<Expression<F>>,
     pub(crate) stack_pointer: Transition<Expression<F>>,
     pub(crate) gas_left: Transition<Expression<F>>,
@@ -164,15 +164,15 @@ pub(crate) trait ConstrainBuilderCommon<F: Field> {
         self.add_constraint(name, constraint);
     }
 
-    fn require_zero_word(&mut self, name: &'static str, word: Word<Expression<F>>) {
-        self.require_equal_word(name, word, Word::zero());
+    fn require_zero_word(&mut self, name: &'static str, word: WordLoHi<Expression<F>>) {
+        self.require_equal_word(name, word, WordLoHi::zero());
     }
 
     fn require_equal_word(
         &mut self,
         name: &'static str,
-        lhs: Word<Expression<F>>,
-        rhs: Word<Expression<F>>,
+        lhs: WordLoHi<Expression<F>>,
+        rhs: WordLoHi<Expression<F>>,
     ) {
         let (lhs_lo, lhs_hi) = lhs.to_lo_hi();
         let (rhs_lo, rhs_hi) = rhs.to_lo_hi();
@@ -443,8 +443,8 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
     }
 
     // default query_word is 2 limbs. Each limb is not guaranteed to be 128 bits.
-    pub fn query_word_unchecked(&mut self) -> WordCell<F> {
-        Word::new(
+    pub fn query_word_unchecked(&mut self) -> WordLoHiCell<F> {
+        WordLoHi::new(
             self.query_cells(CellType::StoragePhase1, 2)
                 .try_into()
                 .unwrap(),
@@ -511,7 +511,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         rlc::expr(&bytes, self.challenges.keccak_input())
     }
 
-    pub(crate) fn empty_code_hash(&self) -> Word<Expression<F>> {
+    pub(crate) fn empty_code_hash(&self) -> WordLoHi<Expression<F>> {
         Word32::new(EMPTY_CODE_HASH_LE.map(|byte| byte.expr())).to_word()
     }
 
@@ -664,7 +664,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
 
     pub(crate) fn bytecode_lookup(
         &mut self,
-        code_hash: Word<Expression<F>>,
+        code_hash: WordLoHi<Expression<F>>,
         index: Expression<F>,
         is_code: Expression<F>,
         value: Expression<F>,
@@ -681,7 +681,11 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         )
     }
 
-    pub(crate) fn bytecode_length(&mut self, code_hash: Word<Expression<F>>, value: Expression<F>) {
+    pub(crate) fn bytecode_length(
+        &mut self,
+        code_hash: WordLoHi<Expression<F>>,
+        value: Expression<F>,
+    ) {
         self.add_lookup(
             "Bytecode (length)",
             Lookup::Bytecode {
@@ -704,7 +708,12 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
     ) -> Cell<F> {
         let cell = self.query_cell();
         // lookup read, unchecked is safe
-        self.tx_context_lookup(id, field_tag, index, Word::from_lo_unchecked(cell.expr()));
+        self.tx_context_lookup(
+            id,
+            field_tag,
+            index,
+            WordLoHi::from_lo_unchecked(cell.expr()),
+        );
         cell
     }
     pub(crate) fn tx_context_as_word32(
@@ -723,7 +732,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         id: Expression<F>,
         field_tag: TxContextFieldTag,
         index: Option<Expression<F>>,
-    ) -> WordCell<F> {
+    ) -> WordLoHiCell<F> {
         let word = self.query_word_unchecked();
         self.tx_context_lookup(id, field_tag, index, word.to_word());
         word
@@ -734,7 +743,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         id: Expression<F>,
         field_tag: TxContextFieldTag,
         index: Option<Expression<F>>,
-        value: Word<Expression<F>>,
+        value: WordLoHi<Expression<F>>,
     ) {
         self.add_lookup(
             "Tx lookup",
@@ -752,7 +761,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         &mut self,
         tag: Expression<F>,
         number: Option<Expression<F>>,
-        val: Word<Expression<F>>,
+        val: WordLoHi<Expression<F>>,
     ) {
         self.add_lookup(
             "Block lookup",
@@ -853,7 +862,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
     pub(crate) fn account_access_list_write_unchecked(
         &mut self,
         tx_id: Expression<F>,
-        account_address: Word<Expression<F>>,
+        account_address: WordLoHi<Expression<F>>,
         value: Expression<F>,
         value_prev: Expression<F>,
         reversion_info: Option<&mut ReversionInfo<F>>,
@@ -865,10 +874,10 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 tx_id,
                 account_address.compress(),
                 0.expr(),
-                Word::zero(),
-                Word::from_lo_unchecked(value),
-                Word::from_lo_unchecked(value_prev),
-                Word::zero(),
+                WordLoHi::zero(),
+                WordLoHi::from_lo_unchecked(value),
+                WordLoHi::from_lo_unchecked(value_prev),
+                WordLoHi::zero(),
             ),
             reversion_info,
         );
@@ -877,7 +886,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
     pub(crate) fn account_access_list_read(
         &mut self,
         tx_id: Expression<F>,
-        account_address: Word<Expression<F>>,
+        account_address: WordLoHi<Expression<F>>,
         value: Expression<F>,
     ) {
         self.rw_lookup(
@@ -888,20 +897,20 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 tx_id,
                 account_address.compress(),
                 0.expr(),
-                Word::zero(),
-                Word::from_lo_unchecked(value.clone()),
-                Word::from_lo_unchecked(value),
-                Word::zero(),
+                WordLoHi::zero(),
+                WordLoHi::from_lo_unchecked(value.clone()),
+                WordLoHi::from_lo_unchecked(value),
+                WordLoHi::zero(),
             ),
         );
     }
     pub(crate) fn account_storage_access_list_write(
         &mut self,
         tx_id: Expression<F>,
-        account_address: Word<Expression<F>>,
-        storage_key: Word<Expression<F>>,
-        value: Word<Expression<F>>,
-        value_prev: Word<Expression<F>>,
+        account_address: WordLoHi<Expression<F>>,
+        storage_key: WordLoHi<Expression<F>>,
+        value: WordLoHi<Expression<F>>,
+        value_prev: WordLoHi<Expression<F>>,
         reversion_info: Option<&mut ReversionInfo<F>>,
     ) {
         self.reversible_write(
@@ -914,7 +923,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 storage_key,
                 value,
                 value_prev,
-                Word::zero(),
+                WordLoHi::zero(),
             ),
             reversion_info,
         );
@@ -923,9 +932,9 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
     pub(crate) fn account_storage_access_list_read(
         &mut self,
         tx_id: Expression<F>,
-        account_address: Word<Expression<F>>,
-        storage_key: Word<Expression<F>>,
-        value: Word<Expression<F>>,
+        account_address: WordLoHi<Expression<F>>,
+        storage_key: WordLoHi<Expression<F>>,
+        value: WordLoHi<Expression<F>>,
     ) {
         self.rw_lookup(
             "TxAccessListAccountStorage read",
@@ -938,14 +947,14 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 storage_key,
                 value.clone(),
                 value,
-                Word::zero(),
+                WordLoHi::zero(),
             ),
         );
     }
 
     // Tx Refund
 
-    pub(crate) fn tx_refund_read(&mut self, tx_id: Expression<F>, value: Word<Expression<F>>) {
+    pub(crate) fn tx_refund_read(&mut self, tx_id: Expression<F>, value: WordLoHi<Expression<F>>) {
         self.rw_lookup(
             "TxRefund read",
             false.expr(),
@@ -954,10 +963,10 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 tx_id,
                 0.expr(),
                 0.expr(),
-                Word::zero(),
+                WordLoHi::zero(),
                 value.clone(),
                 value,
-                Word::zero(),
+                WordLoHi::zero(),
             ),
         );
     }
@@ -965,8 +974,8 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
     pub(crate) fn tx_refund_write(
         &mut self,
         tx_id: Expression<F>,
-        value: Word<Expression<F>>,
-        value_prev: Word<Expression<F>>,
+        value: WordLoHi<Expression<F>>,
+        value_prev: WordLoHi<Expression<F>>,
         reversion_info: Option<&mut ReversionInfo<F>>,
     ) {
         self.reversible_write(
@@ -976,10 +985,10 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 tx_id,
                 0.expr(),
                 0.expr(),
-                Word::zero(),
+                WordLoHi::zero(),
                 value,
                 value_prev,
-                Word::zero(),
+                WordLoHi::zero(),
             ),
             reversion_info,
         );
@@ -988,9 +997,9 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
     // Account
     pub(crate) fn account_read(
         &mut self,
-        account_address: Word<Expression<F>>,
+        account_address: WordLoHi<Expression<F>>,
         field_tag: AccountFieldTag,
-        value: Word<Expression<F>>,
+        value: WordLoHi<Expression<F>>,
     ) {
         self.rw_lookup(
             "Account read",
@@ -1000,20 +1009,20 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 0.expr(),
                 account_address.compress(),
                 field_tag.expr(),
-                Word::zero(),
+                WordLoHi::zero(),
                 value.clone(),
                 value,
-                Word::zero(),
+                WordLoHi::zero(),
             ),
         );
     }
 
     pub(crate) fn account_write(
         &mut self,
-        account_address: Word<Expression<F>>,
+        account_address: WordLoHi<Expression<F>>,
         field_tag: AccountFieldTag,
-        value: Word<Expression<F>>,
-        value_prev: Word<Expression<F>>,
+        value: WordLoHi<Expression<F>>,
+        value_prev: WordLoHi<Expression<F>>,
         reversion_info: Option<&mut ReversionInfo<F>>,
     ) {
         self.reversible_write(
@@ -1023,10 +1032,10 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 0.expr(),
                 account_address.compress(),
                 field_tag.expr(),
-                Word::zero(),
+                WordLoHi::zero(),
                 value,
                 value_prev,
-                Word::zero(),
+                WordLoHi::zero(),
             ),
             reversion_info,
         );
@@ -1035,11 +1044,11 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
     // Account Storage
     pub(crate) fn account_storage_read(
         &mut self,
-        account_address: Word<Expression<F>>,
-        key: Word<Expression<F>>,
-        value: Word<Expression<F>>,
+        account_address: WordLoHi<Expression<F>>,
+        key: WordLoHi<Expression<F>>,
+        value: WordLoHi<Expression<F>>,
         tx_id: Expression<F>,
-        committed_value: Word<Expression<F>>,
+        committed_value: WordLoHi<Expression<F>>,
     ) {
         self.rw_lookup(
             "account_storage_read",
@@ -1060,12 +1069,12 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn account_storage_write(
         &mut self,
-        account_address: Word<Expression<F>>,
-        key: Word<Expression<F>>,
-        value: Word<Expression<F>>,
-        value_prev: Word<Expression<F>>,
+        account_address: WordLoHi<Expression<F>>,
+        key: WordLoHi<Expression<F>>,
+        value: WordLoHi<Expression<F>>,
+        value_prev: WordLoHi<Expression<F>>,
         tx_id: Expression<F>,
-        committed_value: Word<Expression<F>>,
+        committed_value: WordLoHi<Expression<F>>,
         reversion_info: Option<&mut ReversionInfo<F>>,
     ) {
         self.reversible_write(
@@ -1098,7 +1107,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         self.call_context_lookup_read(
             call_id,
             field_tag,
-            Word::from_lo_unchecked(cell.expr()), // lookup read, unchecked is safe
+            WordLoHi::from_lo_unchecked(cell.expr()), // lookup read, unchecked is safe
         );
         cell
     }
@@ -1107,7 +1116,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         &mut self,
         call_id: Option<Expression<F>>,
         field_tag: CallContextFieldTag,
-    ) -> Word<Cell<F>> {
+    ) -> WordLoHi<Cell<F>> {
         let word = self.query_word_unchecked();
         self.call_context_lookup_read(call_id, field_tag, word.to_word());
         word
@@ -1117,7 +1126,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         &mut self,
         call_id: Option<Expression<F>>,
         field_tag: CallContextFieldTag,
-        value: Word<Expression<F>>,
+        value: WordLoHi<Expression<F>>,
     ) {
         self.rw_lookup(
             "CallContext lookup",
@@ -1127,10 +1136,10 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 call_id.unwrap_or_else(|| self.curr.state.call_id.expr()),
                 0.expr(),
                 field_tag.expr(),
-                Word::zero(),
+                WordLoHi::zero(),
                 value,
-                Word::zero(),
-                Word::zero(),
+                WordLoHi::zero(),
+                WordLoHi::zero(),
             ),
         );
     }
@@ -1142,7 +1151,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         rw_counter: Expression<F>,
         call_id: Option<Expression<F>>,
         field_tag: CallContextFieldTag,
-        value: Word<Expression<F>>,
+        value: WordLoHi<Expression<F>>,
     ) {
         self.rw_lookup_with_counter(
             "CallContext lookup",
@@ -1153,10 +1162,10 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 call_id.unwrap_or_else(|| self.curr.state.call_id.expr()),
                 0.expr(),
                 field_tag.expr(),
-                Word::zero(),
+                WordLoHi::zero(),
                 value,
-                Word::zero(),
-                Word::zero(),
+                WordLoHi::zero(),
+                WordLoHi::zero(),
             ),
         );
     }
@@ -1165,7 +1174,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         &mut self,
         call_id: Option<Expression<F>>,
         field_tag: CallContextFieldTag,
-        value: Word<Expression<F>>,
+        value: WordLoHi<Expression<F>>,
     ) {
         self.rw_lookup(
             "CallContext lookup",
@@ -1175,10 +1184,10 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 call_id.unwrap_or_else(|| self.curr.state.call_id.expr()),
                 0.expr(),
                 field_tag.expr(),
-                Word::zero(),
+                WordLoHi::zero(),
                 value,
-                Word::zero(),
-                Word::zero(),
+                WordLoHi::zero(),
+                WordLoHi::zero(),
             ),
         );
     }
@@ -1198,13 +1207,13 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 self.call_context_lookup_write(
                     call_id.clone(),
                     field_tag,
-                    Word::from_lo_unchecked(cell.expr()),
+                    WordLoHi::from_lo_unchecked(cell.expr()),
                 );
             } else {
                 self.call_context_lookup_read(
                     call_id.clone(),
                     field_tag,
-                    Word::from_lo_unchecked(cell.expr()),
+                    WordLoHi::from_lo_unchecked(cell.expr()),
                 );
             }
 
@@ -1237,12 +1246,12 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
     }
 
     // Stack
-    pub(crate) fn stack_pop(&mut self, value: Word<Expression<F>>) {
+    pub(crate) fn stack_pop(&mut self, value: WordLoHi<Expression<F>>) {
         self.stack_lookup(false.expr(), self.stack_pointer_offset.clone(), value);
         self.stack_pointer_offset = self.stack_pointer_offset.clone() + self.condition_expr();
     }
 
-    pub(crate) fn stack_push(&mut self, value: Word<Expression<F>>) {
+    pub(crate) fn stack_push(&mut self, value: WordLoHi<Expression<F>>) {
         self.stack_pointer_offset = self.stack_pointer_offset.clone() - self.condition_expr();
         self.stack_lookup(true.expr(), self.stack_pointer_offset.expr(), value);
     }
@@ -1251,7 +1260,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         &mut self,
         is_write: Expression<F>,
         stack_pointer_offset: Expression<F>,
-        value: Word<Expression<F>>,
+        value: WordLoHi<Expression<F>>,
     ) {
         self.rw_lookup(
             "Stack lookup",
@@ -1261,10 +1270,10 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 self.curr.state.call_id.expr(),
                 self.curr.state.stack_pointer.expr() + stack_pointer_offset,
                 0.expr(),
-                Word::zero(),
+                WordLoHi::zero(),
                 value,
-                Word::zero(),
-                Word::zero(),
+                WordLoHi::zero(),
+                WordLoHi::zero(),
             ),
         );
     }
@@ -1286,11 +1295,11 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 call_id.unwrap_or_else(|| self.curr.state.call_id.expr()),
                 memory_address,
                 0.expr(),
-                Word::zero(),
+                WordLoHi::zero(),
                 // TODO assure range check since write=true also possible
-                Word::from_lo_unchecked(byte),
-                Word::zero(),
-                Word::zero(),
+                WordLoHi::from_lo_unchecked(byte),
+                WordLoHi::zero(),
+                WordLoHi::zero(),
             ),
         );
     }
@@ -1301,7 +1310,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         log_id: Expression<F>,
         field_tag: TxLogFieldTag,
         index: Expression<F>,
-        value: Word<Expression<F>>,
+        value: WordLoHi<Expression<F>>,
     ) {
         self.rw_lookup(
             "log data lookup",
@@ -1311,10 +1320,10 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 tx_id,
                 build_tx_log_expression(index, field_tag.expr(), log_id),
                 0.expr(),
-                Word::zero(),
+                WordLoHi::zero(),
                 value,
-                Word::zero(),
-                Word::zero(),
+                WordLoHi::zero(),
+                WordLoHi::zero(),
             ),
         );
     }
@@ -1335,11 +1344,11 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 tx_id,
                 0.expr(),
                 tag.expr(),
-                Word::zero(),
+                WordLoHi::zero(),
                 // TODO assure range check since write=true also possible
-                Word::from_lo_unchecked(value),
-                Word::zero(),
-                Word::zero(),
+                WordLoHi::from_lo_unchecked(value),
+                WordLoHi::zero(),
+                WordLoHi::zero(),
             ),
         );
     }
@@ -1356,10 +1365,10 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 0.expr(),
                 0.expr(),
                 0.expr(),
-                Word::zero(),
-                Word::zero(),
-                Word::zero(),
-                Word::zero(),
+                WordLoHi::zero(),
+                WordLoHi::zero(),
+                WordLoHi::zero(),
+                WordLoHi::zero(),
             ),
         );
     }
@@ -1369,9 +1378,9 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn copy_table_lookup(
         &mut self,
-        src_id: Word<Expression<F>>,
+        src_id: WordLoHi<Expression<F>>,
         src_tag: Expression<F>,
-        dst_id: Word<Expression<F>>,
+        dst_id: WordLoHi<Expression<F>>,
         dst_tag: Expression<F>,
         src_addr: Expression<F>,
         src_addr_end: Expression<F>,
@@ -1428,7 +1437,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         &mut self,
         input_rlc: Expression<F>,
         input_len: Expression<F>,
-        output: Word<Expression<F>>,
+        output: WordLoHi<Expression<F>>,
     ) {
         self.add_lookup(
             "keccak lookup",

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/cmp_words.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/cmp_words.rs
@@ -80,7 +80,7 @@ impl<F: Field, T1: WordExpr<F>, T2: WordExpr<F>> CmpWordsGadget<F, T1, T2> {
 mod tests {
     use super::{test_util::*, *};
     use crate::{
-        evm_circuit::util::constraint_builder::ConstrainBuilderCommon, util::word::WordCell,
+        evm_circuit::util::constraint_builder::ConstrainBuilderCommon, util::word::WordLoHiCell,
     };
     use eth_types::Word;
     use halo2_proofs::{halo2curves::bn256::Fr, plonk::Error};
@@ -88,9 +88,9 @@ mod tests {
     #[derive(Clone)]
     /// CmpWordGadgetTestContainer: require(a == b if CHECK_EQ else a < b)
     struct CmpWordGadgetTestContainer<F, const CHECK_EQ: bool> {
-        cmp_gadget: CmpWordsGadget<F, WordCell<F>, WordCell<F>>,
-        a_word: WordCell<F>,
-        b_word: WordCell<F>,
+        cmp_gadget: CmpWordsGadget<F, WordLoHiCell<F>, WordLoHiCell<F>>,
+        a_word: WordLoHiCell<F>,
+        b_word: WordLoHiCell<F>,
     }
 
     impl<F: Field, const CHECK_EQ: bool> MathGadgetContainer<F>

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/is_equal_word.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/is_equal_word.rs
@@ -11,7 +11,7 @@ use crate::{
     evm_circuit::util::{
         constraint_builder::EVMConstraintBuilder, transpose_val_ret, CachedRegion,
     },
-    util::word::{Word, WordExpr},
+    util::word::{WordExpr, WordLoHi},
 };
 
 use super::IsZeroGadget;
@@ -46,8 +46,8 @@ impl<F: Field, T1: WordExpr<F>, T2: WordExpr<F>> IsEqualWordGadget<F, T1, T2> {
         &self,
         region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
-        lhs: Word<F>,
-        rhs: Word<F>,
+        lhs: WordLoHi<F>,
+        rhs: WordLoHi<F>,
     ) -> Result<F, Error> {
         let (lhs_lo, lhs_hi) = lhs.to_lo_hi();
         let (rhs_lo, rhs_hi) = rhs.to_lo_hi();
@@ -60,8 +60,8 @@ impl<F: Field, T1: WordExpr<F>, T2: WordExpr<F>> IsEqualWordGadget<F, T1, T2> {
         &self,
         region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
-        lhs: Value<Word<F>>,
-        rhs: Value<Word<F>>,
+        lhs: Value<WordLoHi<F>>,
+        rhs: Value<WordLoHi<F>>,
     ) -> Result<Value<F>, Error> {
         transpose_val_ret(
             lhs.zip(rhs)
@@ -76,7 +76,7 @@ impl<F: Field, T1: WordExpr<F>, T2: WordExpr<F>> IsEqualWordGadget<F, T1, T2> {
         lhs: eth_types::Word,
         rhs: eth_types::Word,
     ) -> Result<F, Error> {
-        self.assign(region, offset, Word::from(lhs), Word::from(rhs))
+        self.assign(region, offset, WordLoHi::from(lhs), WordLoHi::from(rhs))
     }
 }
 

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/is_zero_word.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/is_zero_word.rs
@@ -12,7 +12,7 @@ use crate::{
         constraint_builder::{ConstrainBuilderCommon, EVMConstraintBuilder},
         transpose_val_ret, CachedRegion, Cell, CellType,
     },
-    util::word::{Word, WordExpr},
+    util::word::{WordExpr, WordLoHi},
 };
 
 /// Returns `1` when `word == 0`, and returns `0` otherwise.
@@ -69,7 +69,7 @@ impl<F: Field, T: WordExpr<F>> IsZeroWordGadget<F, T> {
         &self,
         region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
-        value: Word<F>,
+        value: WordLoHi<F>,
     ) -> Result<F, Error> {
         let (value_lo, value_hi) = value.to_lo_hi();
         let inverse_lo = value_lo.invert().unwrap_or(F::from(0));
@@ -91,14 +91,14 @@ impl<F: Field, T: WordExpr<F>> IsZeroWordGadget<F, T> {
         offset: usize,
         value: eth_types::Word,
     ) -> Result<F, Error> {
-        self.assign(region, offset, Word::from(value))
+        self.assign(region, offset, WordLoHi::from(value))
     }
 
     pub(crate) fn assign_value(
         &self,
         region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
-        value: Value<Word<F>>,
+        value: Value<WordLoHi<F>>,
     ) -> Result<Value<F>, Error> {
         transpose_val_ret(value.map(|value| self.assign(region, offset, value)))
     }

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/lt_word.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/lt_word.rs
@@ -2,7 +2,7 @@ use crate::{
     evm_circuit::util::{
         constraint_builder::EVMConstraintBuilder, math_gadget::*, split_u256, CachedRegion,
     },
-    util::word::{self},
+    util::word::WordLoHi,
 };
 use eth_types::{Field, Word};
 use halo2_proofs::plonk::{Error, Expression};
@@ -18,8 +18,8 @@ pub struct LtWordGadget<F> {
 impl<F: Field> LtWordGadget<F> {
     pub(crate) fn construct<T: Expr<F> + Clone>(
         cb: &mut EVMConstraintBuilder<F>,
-        lhs: &word::Word<T>,
-        rhs: &word::Word<T>,
+        lhs: &WordLoHi<T>,
+        rhs: &WordLoHi<T>,
     ) -> Self {
         let (lhs_lo, lhs_hi) = lhs.to_lo_hi();
         let (rhs_lo, rhs_hi) = rhs.to_lo_hi();

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/modulo.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/modulo.rs
@@ -5,7 +5,7 @@ use crate::{
         CachedRegion,
     },
     util::{
-        word::{self, Word32Cell, WordExpr},
+        word::{Word32Cell, WordExpr, WordLoHi},
         Expr,
     },
 };
@@ -82,17 +82,17 @@ impl<F: Field> ModGadget<F> {
 
         self.k.assign_u256(region, offset, k)?;
         self.a_or_zero.assign_u256(region, offset, a_or_zero)?;
-        self.n_is_zero.assign(region, offset, word::Word::from(n))?;
+        self.n_is_zero.assign(region, offset, WordLoHi::from(n))?;
         self.a_or_is_zero
-            .assign(region, offset, word::Word::from(a_or_zero))?;
+            .assign(region, offset, WordLoHi::from(a_or_zero))?;
         self.mul_add_words
             .assign(region, offset, [k, n, r, a_or_zero])?;
         self.lt.assign(region, offset, r, n)?;
         self.eq.assign_value(
             region,
             offset,
-            Value::known(word::Word::from(a)),
-            Value::known(word::Word::from(a_or_zero)),
+            Value::known(WordLoHi::from(a)),
+            Value::known(WordLoHi::from(a_or_zero)),
         )?;
 
         Ok(())

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/mul_add_words.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/mul_add_words.rs
@@ -4,7 +4,7 @@ use crate::{
         from_bytes, pow_of_two_expr, split_u256, split_u256_limb64, CachedRegion, Cell,
     },
     util::{
-        word::{Word, Word32Cell, Word4, WordExpr},
+        word::{Word32Cell, Word4, WordExpr, WordLoHi},
         Expr,
     },
 };
@@ -68,8 +68,8 @@ impl<F: Field> MulAddWordsGadget<F> {
             b_limbs.push(word4_b.limbs[i].expr());
         }
 
-        let word_c: Word<Expression<F>> = c.to_word();
-        let word_d: Word<Expression<F>> = d.to_word();
+        let word_c: WordLoHi<Expression<F>> = c.to_word();
+        let word_d: WordLoHi<Expression<F>> = d.to_word();
 
         let t0 = a_limbs[0].clone() * b_limbs[0].clone();
         let t1 = a_limbs[0].clone() * b_limbs[1].clone() + a_limbs[1].clone() * b_limbs[0].clone();

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/mul_add_words512.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/mul_add_words512.rs
@@ -4,7 +4,7 @@ use crate::{
         from_bytes, pow_of_two_expr, split_u256, split_u256_limb64, CachedRegion, Cell,
     },
     util::{
-        word::{self, Word4, WordExpr},
+        word::{Word32Cell, Word4, WordExpr},
         Expr,
     },
 };
@@ -57,8 +57,8 @@ impl<F: Field> MulAddWords512Gadget<F> {
     /// Addend is the optional c.
     pub(crate) fn construct(
         cb: &mut EVMConstraintBuilder<F>,
-        words: [&word::Word32Cell<F>; 4],
-        addend: Option<&word::Word32Cell<F>>,
+        words: [&Word32Cell<F>; 4],
+        addend: Option<&Word32Cell<F>>,
     ) -> Self {
         let carry_0 = cb.query_bytes();
         let carry_1 = cb.query_bytes();
@@ -207,11 +207,11 @@ mod tests {
     /// MulAddWords512GadgetContainer: require(a * b + c == d * 2**256 + e)
     struct MulAddWords512GadgetContainer<F> {
         math_gadget: MulAddWords512Gadget<F>,
-        a: word::Word32Cell<F>,
-        b: word::Word32Cell<F>,
-        d: word::Word32Cell<F>,
-        e: word::Word32Cell<F>,
-        addend: word::Word32Cell<F>,
+        a: Word32Cell<F>,
+        b: Word32Cell<F>,
+        d: Word32Cell<F>,
+        e: Word32Cell<F>,
+        addend: Word32Cell<F>,
     }
 
     impl<F: Field> MathGadgetContainer<F> for MulAddWords512GadgetContainer<F> {

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/rlp.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/rlp.rs
@@ -1,7 +1,3 @@
-use crate::{
-    evm_circuit::util::rlc,
-    util::word::{Word32Cell, WordExpr},
-};
 use eth_types::{Address, Field, ToScalar, Word};
 use gadgets::util::{and, expr_from_bytes, not, select, sum, Expr};
 use halo2_proofs::{
@@ -14,10 +10,10 @@ use crate::{
         param::{N_BYTES_U64, N_BYTES_WORD},
         util::{
             constraint_builder::{ConstrainBuilderCommon, EVMConstraintBuilder},
-            AccountAddress, CachedRegion, Cell, RandomLinearCombination,
+            rlc, AccountAddress, CachedRegion, Cell, RandomLinearCombination,
         },
     },
-    util::word,
+    util::word::{Word32Cell, WordExpr, WordLoHi},
 };
 
 use super::IsZeroGadget;
@@ -260,7 +256,7 @@ impl<F: Field, const IS_CREATE2: bool> ContractCreateGadget<F, IS_CREATE2> {
     }
 
     /// Caller address' value.
-    pub(crate) fn caller_address(&self) -> word::Word<Expression<F>> {
+    pub(crate) fn caller_address(&self) -> WordLoHi<Expression<F>> {
         self.caller_address.to_word()
     }
 
@@ -270,7 +266,7 @@ impl<F: Field, const IS_CREATE2: bool> ContractCreateGadget<F, IS_CREATE2> {
     }
 
     /// Code hash word RLC.
-    pub(crate) fn code_hash(&self) -> word::Word<Expression<F>> {
+    pub(crate) fn code_hash(&self) -> WordLoHi<Expression<F>> {
         self.code_hash.to_word()
     }
 
@@ -287,7 +283,7 @@ impl<F: Field, const IS_CREATE2: bool> ContractCreateGadget<F, IS_CREATE2> {
         )
     }
 
-    pub(crate) fn salt(&self) -> word::Word<Expression<F>> {
+    pub(crate) fn salt(&self) -> WordLoHi<Expression<F>> {
         self.salt.to_word()
     }
 

--- a/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
@@ -14,7 +14,7 @@ use crate::{
         },
     },
     util::{
-        word::{Word, WordCell},
+        word::{WordLoHi, WordLoHiCell},
         Expr,
     },
 };
@@ -55,10 +55,10 @@ pub(crate) trait CommonMemoryAddressGadget<F: Field> {
     ) -> Result<u64, Error>;
 
     /// Return original word of memory offset.
-    fn offset_word(&self) -> Word<Expression<F>>;
+    fn offset_word(&self) -> WordLoHi<Expression<F>>;
 
     /// Return original word of memory length.
-    fn length_word(&self) -> Word<Expression<F>>;
+    fn length_word(&self) -> WordLoHi<Expression<F>>;
 
     /// Return valid memory length of Uint64.
     fn length(&self) -> Expression<F>;
@@ -74,7 +74,7 @@ pub(crate) trait CommonMemoryAddressGadget<F: Field> {
 #[derive(Clone, Debug)]
 pub(crate) struct MemoryAddressGadget<F> {
     memory_offset_bytes: MemoryAddress<F>,
-    memory_offset: WordCell<F>,
+    memory_offset: WordLoHiCell<F>,
     memory_length: MemoryAddress<F>,
     memory_length_is_zero: IsZeroGadget<F>,
 }
@@ -82,7 +82,7 @@ pub(crate) struct MemoryAddressGadget<F> {
 impl<F: Field> MemoryAddressGadget<F> {
     pub(crate) fn construct(
         cb: &mut EVMConstraintBuilder<F>,
-        memory_offset: WordCell<F>,
+        memory_offset: WordLoHiCell<F>,
         memory_length: MemoryAddress<F>,
     ) -> Self {
         let memory_length_is_zero = IsZeroGadget::construct(cb, memory_length.sum_expr());
@@ -92,7 +92,7 @@ impl<F: Field> MemoryAddressGadget<F> {
         cb.condition(has_length, |cb| {
             cb.require_equal_word(
                 "Offset decomposition into 5 bytes",
-                Word::from_lo_unchecked(memory_offset_bytes.expr()),
+                WordLoHi::from_lo_unchecked(memory_offset_bytes.expr()),
                 memory_offset.to_word(),
             );
         });
@@ -157,11 +157,11 @@ impl<F: Field> CommonMemoryAddressGadget<F> for MemoryAddressGadget<F> {
         })
     }
 
-    fn offset_word(&self) -> Word<Expression<F>> {
+    fn offset_word(&self) -> WordLoHi<Expression<F>> {
         self.memory_offset.to_word()
     }
 
-    fn length_word(&self) -> Word<Expression<F>> {
+    fn length_word(&self) -> WordLoHi<Expression<F>> {
         self.memory_length.to_word()
     }
 
@@ -260,12 +260,12 @@ impl<F: Field> CommonMemoryAddressGadget<F> for MemoryExpandedAddressGadget<F> {
         Ok(address)
     }
 
-    fn offset_word(&self) -> Word<Expression<F>> {
+    fn offset_word(&self) -> WordLoHi<Expression<F>> {
         let addends = self.offset_length_sum.addends();
         addends[0].to_word()
     }
 
-    fn length_word(&self) -> Word<Expression<F>> {
+    fn length_word(&self) -> WordLoHi<Expression<F>> {
         let addends = self.offset_length_sum.addends();
         addends[1].to_word()
     }

--- a/zkevm-circuits/src/evm_circuit/util/tx.rs
+++ b/zkevm-circuits/src/evm_circuit/util/tx.rs
@@ -9,12 +9,12 @@ use crate::{
             math_gadget::{
                 AddWordsGadget, ConstantDivisionGadget, IsEqualGadget, MulWordByU64Gadget,
             },
-            CachedRegion, Cell, Word,
+            CachedRegion, Cell,
         },
         witness::{Block, Transaction},
     },
     table::{CallContextFieldTag, TxContextFieldTag, TxReceiptFieldTag},
-    util::word::{Word32Cell, WordCell},
+    util::word::{Word32Cell, WordLoHi, WordLoHiCell},
 };
 use bus_mapping::operation::Target;
 use eth_types::{evm_types::GasCost, Field};
@@ -42,7 +42,7 @@ impl<F: Field> BeginTxHelperGadget<F> {
         cb.call_context_lookup_write(
             Some(call_id.expr()),
             CallContextFieldTag::TxId,
-            Word::from_lo_unchecked(tx_id.expr()),
+            WordLoHi::from_lo_unchecked(tx_id.expr()),
         ); // rwc_delta += 1
 
         // Add first BeginTx step constraint to have id == 1
@@ -133,7 +133,7 @@ impl<F: Field> EndTxHelperGadget<F> {
                 Some(next_step_rwc),
                 CallContextFieldTag::TxId,
                 // tx_id has been lookup and range_check above
-                Word::from_lo_unchecked(tx_id.expr() + 1.expr()),
+                WordLoHi::from_lo_unchecked(tx_id.expr() + 1.expr()),
             );
             // minus 1.expr() because `call_context_lookup_write_with_counter` do not bump
             // rwc
@@ -196,8 +196,8 @@ impl<F: Field> EndTxHelperGadget<F> {
 #[derive(Clone, Debug)]
 pub(crate) struct TxDataGadget<F> {
     pub(crate) nonce: Cell<F>,
-    pub(crate) caller_address: WordCell<F>,
-    pub(crate) callee_address: WordCell<F>,
+    pub(crate) caller_address: WordLoHiCell<F>,
+    pub(crate) callee_address: WordLoHiCell<F>,
     pub(crate) is_create: Cell<F>,
     pub(crate) gas: Cell<F>,
     pub(crate) call_data_length: Cell<F>,

--- a/zkevm-circuits/src/instance.rs
+++ b/zkevm-circuits/src/instance.rs
@@ -7,7 +7,7 @@ use std::{iter, ops::Deref};
 use eth_types::{geth_types::Transaction, Address, ToBigEndian, Word, H256};
 use itertools::Itertools;
 
-use crate::{util::word, witness::Block};
+use crate::{util::word::WordLoHi, witness::Block};
 
 pub(super) const ZERO_BYTE_GAS_COST: u64 = 4;
 pub(super) const NONZERO_BYTE_GAS_COST: u64 = 16;
@@ -289,11 +289,11 @@ impl PublicData {
         max_txs: usize,
         max_withdrawals: usize,
         max_calldata: usize,
-    ) -> word::Word<F> {
+    ) -> WordLoHi<F> {
         let mut keccak = Keccak::default();
         keccak.update(&self.get_pi_bytes(max_txs, max_withdrawals, max_calldata));
         let digest = keccak.digest();
-        word::Word::from(Word::from_big_endian(&digest))
+        WordLoHi::from(Word::from_big_endian(&digest))
     }
 }
 

--- a/zkevm-circuits/src/keccak_circuit.rs
+++ b/zkevm-circuits/src/keccak_circuit.rs
@@ -32,7 +32,7 @@ use crate::{
     table::{KeccakTable, LookupTable},
     util::{
         cell_manager::{CMFixedHeightStrategy, Cell, CellManager, CellType},
-        word::{self, WordExpr},
+        word::{Word32, WordExpr},
         Challenges, SubCircuit, SubCircuitConfig,
     },
     witness,
@@ -580,7 +580,7 @@ impl<F: Field> SubCircuitConfig<F> for KeccakCircuitConfig<F> {
             cb.condition(start_new_hash, |cb| {
                 cb.require_equal_word(
                     "output check",
-                    word::Word32::new(hash_bytes_le.try_into().expect("32 limbs")).to_word(),
+                    Word32::new(hash_bytes_le.try_into().expect("32 limbs")).to_word(),
                     hash_word.map(|col| meta.query_advice(col, Rotation::cur())),
                 );
             });

--- a/zkevm-circuits/src/keccak_circuit/keccak_packed_multi.rs
+++ b/zkevm-circuits/src/keccak_circuit/keccak_packed_multi.rs
@@ -1,7 +1,7 @@
 use super::{param::*, util::*, DEFAULT_CELL_TYPE};
 use crate::util::{
     cell_manager::{CMFixedHeightStrategy, Cell, CellManager},
-    word::Word,
+    word::WordLoHi,
     Challenges,
 };
 use eth_types::Field;
@@ -81,7 +81,7 @@ pub(crate) struct KeccakRow<F: Field> {
     pub(crate) cell_values: Vec<F>,
     pub(crate) length: usize,
     pub(crate) data_rlc: Value<F>,
-    pub(crate) hash: Word<Value<F>>,
+    pub(crate) hash: WordLoHi<Value<F>>,
 }
 
 /// Part
@@ -562,7 +562,7 @@ pub(crate) fn keccak<F: Field>(
         let mut cell_managers = Vec::new();
         let mut regions = Vec::new();
 
-        let mut hash = Word::default();
+        let mut hash = WordLoHi::default();
         let mut round_lengths = Vec::new();
         let mut round_data_rlcs = Vec::new();
         for round in 0..NUM_ROUNDS + 1 {
@@ -795,13 +795,13 @@ pub(crate) fn keccak<F: Field>(
                     .rev()
                     .collect::<Vec<_>>();
 
-                let word: Word<Value<F>> = Word::from(eth_types::Word::from_little_endian(
+                let word: WordLoHi<Value<F>> = WordLoHi::from(eth_types::Word::from_little_endian(
                     hash_bytes_le.as_slice(),
                 ))
                 .map(Value::known);
                 word
             } else {
-                Word::default().into_value()
+                WordLoHi::default().into_value()
             };
 
             // The words to squeeze out
@@ -888,7 +888,7 @@ pub(crate) fn multi_keccak<F: Field>(
             is_final: false,
             length: 0usize,
             data_rlc: Value::known(F::ZERO),
-            hash: Word::default().into_value(),
+            hash: WordLoHi::default().into_value(),
             cell_values: Vec::new(),
         });
     }

--- a/zkevm-circuits/src/keccak_circuit/test.rs
+++ b/zkevm-circuits/src/keccak_circuit/test.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{
     evm_circuit::util::rlc,
-    util::{unusable_rows, word::Word},
+    util::{unusable_rows, word::WordLoHi},
 };
 use bus_mapping::state_db::EMPTY_CODE_HASH_LE;
 use eth_types::{Field, H256, U256};
@@ -86,7 +86,7 @@ fn verify<F: Field>(k: u32, inputs: Vec<Vec<u8>>, digests: Vec<String>, success:
     for (input, digest, hash) in izip!(&inputs, &digests, &hash_lookup_table) {
         let len = F::from(input.len() as u64);
         let digest_slice: [u8; 32] = hex::decode(digest).unwrap().try_into().unwrap();
-        let (lo, hi): (F, F) = Word::from(H256::from(digest_slice)).to_lo_hi();
+        let (lo, hi): (F, F) = WordLoHi::from(H256::from(digest_slice)).to_lo_hi();
 
         let expected = (rlc_input(input), len, lo, hi);
 
@@ -95,7 +95,8 @@ fn verify<F: Field>(k: u32, inputs: Vec<Vec<u8>>, digests: Vec<String>, success:
         assert_eq!(hash.2, expected.2);
         assert_eq!(hash.3, expected.3);
     }
-    let (lo, hi) = Word::from(U256::from_little_endian(EMPTY_CODE_HASH_LE.as_slice())).to_lo_hi();
+    let (lo, hi) =
+        WordLoHi::from(U256::from_little_endian(EMPTY_CODE_HASH_LE.as_slice())).to_lo_hi();
 
     // Check that other digests are the digest of the empty message.
     let empty_hash = (F::ZERO, F::ZERO, lo, hi);

--- a/zkevm-circuits/src/mpt_circuit/branch.rs
+++ b/zkevm-circuits/src/mpt_circuit/branch.rs
@@ -13,7 +13,7 @@ use crate::{
     circuit,
     circuit_tools::{
         cached_region::CachedRegion,
-        cell_manager::{Cell, WordCell},
+        cell_manager::{Cell, WordLoHiCell},
         constraint_builder::RLCChainableRev,
         gadgets::LtGadget,
     },
@@ -22,7 +22,7 @@ use crate::{
         param::{HASH_WIDTH, RLP_NIL},
         MPTConfig, MptMemory, RlpItemType,
     },
-    util::word::{self, Word},
+    util::word::WordLoHi,
 };
 
 #[derive(Clone, Debug)]
@@ -33,7 +33,7 @@ pub(crate) struct BranchState<F> {
     pub(crate) key_mult_post_drifted: Expression<F>,
     pub(crate) num_nibbles: Expression<F>,
     pub(crate) is_key_odd: Expression<F>,
-    pub(crate) mod_word: [Word<Expression<F>>; 2],
+    pub(crate) mod_word: [WordLoHi<Expression<F>>; 2],
     pub(crate) mod_rlc: [Expression<F>; 2],
 }
 
@@ -42,7 +42,7 @@ pub(crate) struct BranchGadget<F> {
     rlp_list: [RLPListDataGadget<F>; 2],
     is_modified: [Cell<F>; ARITY],
     is_drifted: [Cell<F>; ARITY],
-    mod_word: [WordCell<F>; 2],
+    mod_word: [WordLoHiCell<F>; 2],
     mod_rlc: [Cell<F>; 2],
     is_not_hashed: [LtGadget<F, 2>; 2],
 
@@ -57,7 +57,7 @@ impl<F: Field> BranchGadget<F> {
         cb: &mut MPTConstraintBuilder<F>,
         ctx: MPTContext<F>,
         is_placeholder: &[Cell<F>; 2],
-        parent_hash: &[word::Word<Expression<F>>; 2],
+        parent_hash: &[WordLoHi<Expression<F>>; 2],
         parent_rlc: &[Expression<F>; 2],
         is_root: &[Expression<F>; 2],
         key_rlc: Expression<F>,
@@ -299,7 +299,7 @@ impl<F: Field> BranchGadget<F> {
         is_key_odd: &mut bool,
         node: &Node,
         rlp_values: &[RLPItemWitness],
-    ) -> Result<(F, F, F, [word::Word<F>; 2], [F; 2]), Error> {
+    ) -> Result<(F, F, F, [WordLoHi<F>; 2], [F; 2]), Error> {
         let branch = &node.extension_branch.clone().unwrap().branch;
 
         for is_s in [true, false] {
@@ -351,7 +351,7 @@ impl<F: Field> BranchGadget<F> {
         let key_mult_post_branch = *key_mult * mult;
 
         // Set the branch we'll take
-        let mut mod_node_hash_word = [word::Word::zero(); 2];
+        let mut mod_node_hash_word = [WordLoHi::zero(); 2];
         let mut mod_node_hash_rlc = [0.scalar(); 2];
         for is_s in [true, false] {
             (

--- a/zkevm-circuits/src/mpt_circuit/extension.rs
+++ b/zkevm-circuits/src/mpt_circuit/extension.rs
@@ -22,7 +22,7 @@ use crate::{
         param::HASH_WIDTH,
         FixedTableTag, MPTConfig, MptMemory, RlpItemType,
     },
-    util::word::Word,
+    util::word::WordLoHi,
 };
 
 #[derive(Clone, Debug)]
@@ -32,7 +32,7 @@ pub(crate) struct ExtState<F> {
     pub(crate) num_nibbles: Expression<F>,
     pub(crate) is_key_odd: Expression<F>,
 
-    pub(crate) branch_rlp_word: [Word<Expression<F>>; 2],
+    pub(crate) branch_rlp_word: [WordLoHi<Expression<F>>; 2],
     pub(crate) branch_rlp_rlc: [Expression<F>; 2],
 }
 
@@ -100,7 +100,7 @@ impl<F: Field> ExtensionGadget<F> {
             require!((FixedTableTag::ExtOddKey.expr(), first_byte, config.is_key_part_odd.expr()) =>> @FIXED);
 
             let mut branch_rlp_rlc = vec![0.expr(); 2];
-            let mut branch_rlp_word = vec![Word::zero(); 2];
+            let mut branch_rlp_word = vec![WordLoHi::zero(); 2];
             for is_s in [true, false] {
                 // In C we have the key nibbles, we check below only for S.
                 if is_s {

--- a/zkevm-circuits/src/mpt_circuit/extension_branch.rs
+++ b/zkevm-circuits/src/mpt_circuit/extension_branch.rs
@@ -17,7 +17,7 @@ use crate::{
         helpers::{key_memory, parent_memory, Indexable, KeyData, ParentData},
         MPTConfig, MptMemory,
     },
-    util::word::Word,
+    util::word::WordLoHi,
 };
 
 #[derive(Clone, Debug, Default)]
@@ -114,8 +114,8 @@ impl<F: Field> ExtensionBranchConfig<F> {
                 )
             }};
             let parent_word = [
-                Word::<Expression<F>>::new([parent_word_s_lo, parent_word_s_hi]),
-                Word::<Expression<F>>::new([parent_word_c_lo, parent_word_c_hi]),
+                WordLoHi::<Expression<F>>::new([parent_word_s_lo, parent_word_s_hi]),
+                WordLoHi::<Expression<F>>::new([parent_word_c_lo, parent_word_c_hi]),
             ];
             let parent_rlc = [parent_rlc_s, parent_rlc_c];
             let is_root = [is_root_s, is_root_c];
@@ -158,7 +158,7 @@ impl<F: Field> ExtensionBranchConfig<F> {
                         branch.mod_rlc[is_s.idx()].expr(),
                         false.expr(),
                         false.expr(),
-                        Word::zero(),
+                        WordLoHi::zero(),
                     );
                  } elsex {
                     // For the placeholder branch / extension node the values did not change, we reuse
@@ -291,7 +291,7 @@ impl<F: Field> ExtensionBranchConfig<F> {
                     mod_node_hash_rlc[is_s.idx()],
                     false,
                     false,
-                    Word::zero(),
+                    WordLoHi::zero(),
                 )?;
             } else {
                 KeyData::witness_store(

--- a/zkevm-circuits/src/mpt_circuit/helpers.rs
+++ b/zkevm-circuits/src/mpt_circuit/helpers.rs
@@ -2,7 +2,7 @@ use crate::{
     assign, circuit,
     circuit_tools::{
         cached_region::{CachedRegion, ChallengeSet},
-        cell_manager::{Cell, CellManager, CellType, WordCell},
+        cell_manager::{Cell, CellManager, CellType, WordLoHiCell},
         constraint_builder::{
             ConstraintBuilder, RLCChainable, RLCChainableRev, RLCChainableValue, RLCable,
         },
@@ -22,10 +22,7 @@ use crate::{
         rlp_gadgets::{get_ext_odd_nibble, get_terminal_odd_nibble},
     },
     table::LookupTable,
-    util::{
-        word::{self, Word},
-        Challenges, Expr,
-    },
+    util::{word::WordLoHi, Challenges, Expr},
 };
 use eth_types::{Field, OpsIdentity, Word as U256};
 use gadgets::util::{not, or, pow, xor, Scalar};
@@ -557,20 +554,20 @@ impl<F: Field> KeyData<F> {
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct ParentData<F> {
-    pub(crate) hash: WordCell<F>,
+    pub(crate) hash: WordLoHiCell<F>,
     pub(crate) rlc: Cell<F>,
     pub(crate) is_root: Cell<F>,
     pub(crate) is_placeholder: Cell<F>,
-    pub(crate) drifted_parent_hash: WordCell<F>,
+    pub(crate) drifted_parent_hash: WordLoHiCell<F>,
 }
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct ParentDataWitness<F> {
-    pub(crate) hash: word::Word<F>,
+    pub(crate) hash: WordLoHi<F>,
     pub(crate) rlc: F,
     pub(crate) is_root: bool,
     pub(crate) is_placeholder: bool,
-    pub(crate) drifted_parent_hash: word::Word<F>,
+    pub(crate) drifted_parent_hash: WordLoHi<F>,
 }
 
 impl<F: Field> ParentData<F> {
@@ -607,11 +604,11 @@ impl<F: Field> ParentData<F> {
     pub(crate) fn store<MB: MemoryBank<F, MptCellType>>(
         cb: &mut MPTConstraintBuilder<F>,
         memory: &mut MB,
-        hash: word::Word<Expression<F>>,
+        hash: WordLoHi<Expression<F>>,
         rlc: Expression<F>,
         is_root: Expression<F>,
         is_placeholder: Expression<F>,
-        drifted_parent_hash: word::Word<Expression<F>>,
+        drifted_parent_hash: WordLoHi<Expression<F>>,
     ) {
         memory.store(
             &mut cb.base,
@@ -632,11 +629,11 @@ impl<F: Field> ParentData<F> {
         _region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         memory: &mut MB,
-        hash: word::Word<F>,
+        hash: WordLoHi<F>,
         rlc: F,
         force_hashed: bool,
         is_placeholder: bool,
-        drifted_parent_hash: word::Word<F>,
+        drifted_parent_hash: WordLoHi<F>,
     ) -> Result<(), Error> {
         memory.witness_store(
             offset,
@@ -675,11 +672,11 @@ impl<F: Field> ParentData<F> {
             .assign(region, offset, values[6])?;
 
         Ok(ParentDataWitness {
-            hash: word::Word::new([values[0], values[1]]),
+            hash: WordLoHi::new([values[0], values[1]]),
             rlc: values[2],
             is_root: values[3] == 1.scalar(),
             is_placeholder: values[4] == 1.scalar(),
-            drifted_parent_hash: word::Word::new([values[5], values[6]]),
+            drifted_parent_hash: WordLoHi::new([values[5], values[6]]),
         })
     }
 }
@@ -689,8 +686,8 @@ pub(crate) struct MainData<F> {
     pub(crate) proof_type: Cell<F>,
     pub(crate) is_below_account: Cell<F>,
     pub(crate) address: Cell<F>,
-    pub(crate) new_root: WordCell<F>,
-    pub(crate) old_root: WordCell<F>,
+    pub(crate) new_root: WordLoHiCell<F>,
+    pub(crate) old_root: WordLoHiCell<F>,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -698,8 +695,8 @@ pub(crate) struct MainDataWitness<F> {
     pub(crate) proof_type: usize,
     pub(crate) is_below_account: bool,
     pub(crate) address: F,
-    pub(crate) new_root: word::Word<F>,
-    pub(crate) old_root: word::Word<F>,
+    pub(crate) new_root: WordLoHi<F>,
+    pub(crate) old_root: WordLoHi<F>,
 }
 
 impl<F: Field> MainData<F> {
@@ -749,8 +746,8 @@ impl<F: Field> MainData<F> {
         proof_type: usize,
         is_below_account: bool,
         address: F,
-        new_root: word::Word<F>,
-        old_root: word::Word<F>,
+        new_root: WordLoHi<F>,
+        old_root: WordLoHi<F>,
     ) -> Result<(), Error> {
         let values = [
             proof_type.scalar(),
@@ -787,8 +784,8 @@ impl<F: Field> MainData<F> {
             proof_type: values[0].get_lower_32() as usize,
             is_below_account: values[1] == 1.scalar(),
             address: values[2],
-            new_root: word::Word::new([values[3], values[4]]),
-            old_root: word::Word::new([values[5], values[6]]),
+            new_root: WordLoHi::new([values[3], values[4]]),
+            old_root: WordLoHi::new([values[5], values[6]]),
         })
     }
 }
@@ -992,7 +989,7 @@ impl<F: Field> MPTConstraintBuilder<F> {
     }
 
     // default query_word is 2 limbs. Each limb is not guaranteed to be 128 bits.
-    pub(crate) fn query_word_unchecked(&mut self) -> WordCell<F> {
+    pub(crate) fn query_word_unchecked(&mut self) -> WordLoHiCell<F> {
         self.base.query_word_unchecked()
     }
 
@@ -1069,20 +1066,20 @@ pub struct IsPlaceholderLeafGadget<F> {
 impl<F: Field> IsPlaceholderLeafGadget<F> {
     pub(crate) fn construct(
         cb: &mut MPTConstraintBuilder<F>,
-        parent_word: Word<Expression<F>>,
+        parent_word: WordLoHi<Expression<F>>,
     ) -> Self {
         circuit!([meta, cb.base], {
-            let empty_hash = Word::<F>::from(U256::from_big_endian(&EMPTY_TRIE_HASH));
+            let empty_hash = WordLoHi::<F>::from(U256::from_big_endian(&EMPTY_TRIE_HASH));
             let is_empty_trie = IsEqualWordGadget::construct(
                 &mut cb.base,
                 &parent_word,
-                &Word::<Expression<F>>::new([
+                &WordLoHi::<Expression<F>>::new([
                     Expression::Constant(empty_hash.lo()),
                     Expression::Constant(empty_hash.hi()),
                 ]),
             );
             let is_nil_in_branch_at_mod_index =
-                IsEqualWordGadget::construct(&mut cb.base, &parent_word, &Word::zero());
+                IsEqualWordGadget::construct(&mut cb.base, &parent_word, &WordLoHi::zero());
 
             Self {
                 is_empty_trie,
@@ -1102,16 +1099,16 @@ impl<F: Field> IsPlaceholderLeafGadget<F> {
         &self,
         region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
-        hash: Word<F>,
+        hash: WordLoHi<F>,
     ) -> Result<(), Error> {
-        let empty_hash = Word::<F>::from(U256::from_big_endian(&EMPTY_TRIE_HASH));
+        let empty_hash = WordLoHi::<F>::from(U256::from_big_endian(&EMPTY_TRIE_HASH));
         self.is_empty_trie
             .assign(region, offset, hash, empty_hash)?;
         self.is_nil_in_branch_at_mod_index.assign(
             region,
             offset,
             hash,
-            Word::<F>::from(U256::zero()),
+            WordLoHi::<F>::from(U256::zero()),
         )?;
         Ok(())
     }
@@ -1309,7 +1306,7 @@ pub struct MainRLPGadget<F> {
     mult_diff: Cell<F>,
     hash_rlc: Cell<F>,
     rlc_rlp: Cell<F>,
-    word: WordCell<F>,
+    word: WordLoHiCell<F>,
     tag: Cell<F>,
     max_len: Cell<F>,
     is_rlp: Cell<F>,
@@ -1587,7 +1584,7 @@ impl<F: Field> MainRLPGadget<F> {
                 .collect(),
             is_short: Some(self.rlp.value.is_short.rot(meta, rot)),
             is_long: Some(self.rlp.value.is_long.rot(meta, rot)),
-            word: Some(Word::new([
+            word: Some(WordLoHi::new([
                 self.word.lo().rot(meta, rot),
                 self.word.hi().rot(meta, rot),
             ])),
@@ -1635,7 +1632,7 @@ pub struct RLPItemView<F> {
     rlc_rlp: Option<Expression<F>>,
     is_short: Option<Expression<F>>,
     is_long: Option<Expression<F>>,
-    word: Option<Word<Expression<F>>>,
+    word: Option<WordLoHi<Expression<F>>>,
 }
 
 impl<F: Field> RLPItemView<F> {
@@ -1685,7 +1682,7 @@ impl<F: Field> RLPItemView<F> {
         not::expr(self.is_short() + self.is_long())
     }
 
-    pub(crate) fn word(&self) -> Word<Expression<F>> {
+    pub(crate) fn word(&self) -> WordLoHi<Expression<F>> {
         assert!(self.can_use_word);
         self.word.clone().unwrap()
     }

--- a/zkevm-circuits/src/mpt_circuit/rlp_gadgets.rs
+++ b/zkevm-circuits/src/mpt_circuit/rlp_gadgets.rs
@@ -12,7 +12,7 @@ use crate::{
         param::{RLP_LIST_LONG, RLP_LIST_SHORT, RLP_SHORT},
         FixedTableTag,
     },
-    util::{word, Expr},
+    util::{word::WordLoHi, Expr},
 };
 use eth_types::Field;
 use gadgets::util::{not, pow, Scalar};
@@ -833,8 +833,8 @@ impl RLPItemWitness {
         }
     }
 
-    pub(crate) fn word<F: Field>(&self) -> word::Word<F> {
-        // word::Word::from(Word::from_big_endian(&self.bytes[1..33]))
+    pub(crate) fn word<F: Field>(&self) -> WordLoHi<F> {
+        // WordLoHi::from(WordLoHi::from_big_endian(&self.bytes[1..33]))
         let (lo, hi) = if self.is_string() {
             if self.is_short() {
                 let lo: F = self.bytes[0].scalar();
@@ -890,6 +890,6 @@ impl RLPItemWitness {
             );
             (lo, hi)
         };
-        word::Word::new([lo, hi])
+        WordLoHi::new([lo, hi])
     }
 }

--- a/zkevm-circuits/src/mpt_circuit/start.rs
+++ b/zkevm-circuits/src/mpt_circuit/start.rs
@@ -13,7 +13,7 @@ use crate::{
         },
         MPTConfig, MPTContext, MptMemory, RlpItemType,
     },
-    util::word::Word,
+    util::word::WordLoHi,
 };
 use eth_types::{Field, OpsIdentity};
 use gadgets::util::Scalar;
@@ -40,7 +40,7 @@ impl<F: Field> StartConfig<F> {
 
             config.proof_type = cb.query_cell();
 
-            let mut root = vec![Word::zero(); 2];
+            let mut root = vec![WordLoHi::zero(); 2];
             for is_s in [true, false] {
                 root[is_s.idx()] = root_items[is_s.idx()].word();
             }
@@ -96,7 +96,7 @@ impl<F: Field> StartConfig<F> {
         self.proof_type
             .assign(region, offset, start.proof_type.scalar())?;
 
-        let mut root = vec![Word::zero(); 2];
+        let mut root = vec![WordLoHi::zero(); 2];
         for is_s in [true, false] {
             root[is_s.idx()] = rlp_values[is_s.idx()].word();
         }

--- a/zkevm-circuits/src/pi_circuit.rs
+++ b/zkevm-circuits/src/pi_circuit.rs
@@ -33,7 +33,7 @@ use crate::{
     },
     table::{BlockTable, KeccakTable, LookupTable, TxFieldTag, TxTable, WdTable},
     tx_circuit::TX_LEN,
-    util::{word::Word, Challenges, SubCircuit, SubCircuitConfig},
+    util::{word::WordLoHi, Challenges, SubCircuit, SubCircuitConfig},
     witness,
 };
 use gadgets::{
@@ -617,7 +617,7 @@ impl<F: Field> PiCircuitConfig<F> {
             offset,
             || Value::known(F::ZERO),
         )?;
-        Word::default().into_value().assign_advice(
+        WordLoHi::default().into_value().assign_advice(
             region,
             || "tx_value",
             self.tx_table.value,
@@ -698,7 +698,7 @@ impl<F: Field> PiCircuitConfig<F> {
             F::ZERO
         };
         let tag = F::from(tag as u64);
-        let tx_value = Word::new([
+        let tx_value = WordLoHi::new([
             from_bytes::value(
                 &tx_value_bytes_le[..min(N_BYTES_HALF_WORD, tx_value_bytes_le.len())],
             ),
@@ -811,7 +811,7 @@ impl<F: Field> PiCircuitConfig<F> {
         let tx_id_diff_inv = tx_id_diff.invert().unwrap_or(F::ZERO);
         let tag = F::from(TxFieldTag::CallData as u64);
         let index = F::from(index as u64);
-        let tx_value: Word<Value<F>> = Word::from(tx_value_byte).into_value();
+        let tx_value: WordLoHi<Value<F>> = WordLoHi::from(tx_value_byte).into_value();
         let tx_value_inv = tx_value.map(|t| t.map(|x| x.invert().unwrap_or(F::ZERO)));
         let is_final = if is_final { F::ONE } else { F::ZERO };
 
@@ -910,7 +910,7 @@ impl<F: Field> PiCircuitConfig<F> {
             offset,
             || Value::known(F::from(wd.validator_id)),
         )?;
-        let address_assigned_cell = Word::<F>::from(wd.address).into_value().assign_advice(
+        let address_assigned_cell = WordLoHi::<F>::from(wd.address).into_value().assign_advice(
             region,
             || "address",
             self.wd_table.address,
@@ -1095,7 +1095,7 @@ impl<F: Field> PiCircuitConfig<F> {
 
         Ok((
             rpi_bytes_keccakrlc_cells[0].clone(),
-            Word::new(
+            WordLoHi::new(
                 (0..2) // padding rpi_value_lc_cells to 2 limbs if less then 2
                     .map(|i| rpi_value_lc_cells.get(i).unwrap_or(&zero_cell).clone())
                     .collect_vec()
@@ -1123,7 +1123,7 @@ impl<F: Field> PiCircuitConfig<F> {
         let mut block_copy_cells = vec![];
 
         // coinbase
-        let block_value = Word::from(block_values.coinbase)
+        let block_value = WordLoHi::from(block_values.coinbase)
             .into_value()
             .assign_advice(
                 region,
@@ -1150,7 +1150,7 @@ impl<F: Field> PiCircuitConfig<F> {
         *block_table_offset += 1;
 
         // gas_limit
-        let block_value = Word::from(block_values.gas_limit)
+        let block_value = WordLoHi::from(block_values.gas_limit)
             .into_value()
             .assign_advice(
                 region,
@@ -1171,12 +1171,14 @@ impl<F: Field> PiCircuitConfig<F> {
         *block_table_offset += 1;
 
         // number
-        let block_value = Word::from(block_values.number).into_value().assign_advice(
-            region,
-            || "number",
-            self.block_table.value,
-            *block_table_offset,
-        )?;
+        let block_value = WordLoHi::from(block_values.number)
+            .into_value()
+            .assign_advice(
+                region,
+                || "number",
+                self.block_table.value,
+                *block_table_offset,
+            )?;
         let (_, word) = self.assign_raw_bytes(
             region,
             &block_values.number.to_le_bytes(),
@@ -1190,7 +1192,7 @@ impl<F: Field> PiCircuitConfig<F> {
         *block_table_offset += 1;
 
         // timestamp
-        let block_value = Word::from(block_values.timestamp)
+        let block_value = WordLoHi::from(block_values.timestamp)
             .into_value()
             .assign_advice(
                 region,
@@ -1211,7 +1213,7 @@ impl<F: Field> PiCircuitConfig<F> {
         *block_table_offset += 1;
 
         // difficulty
-        let block_value = Word::from(block_values.difficulty)
+        let block_value = WordLoHi::from(block_values.difficulty)
             .into_value()
             .assign_advice(
                 region,
@@ -1232,7 +1234,7 @@ impl<F: Field> PiCircuitConfig<F> {
         *block_table_offset += 1;
 
         // base_fee
-        let block_value = Word::from(block_values.base_fee)
+        let block_value = WordLoHi::from(block_values.base_fee)
             .into_value()
             .assign_advice(
                 region,
@@ -1253,7 +1255,7 @@ impl<F: Field> PiCircuitConfig<F> {
         *block_table_offset += 1;
 
         // chain_id
-        let block_value = Word::from(block_values.chain_id)
+        let block_value = WordLoHi::from(block_values.chain_id)
             .into_value()
             .assign_advice(
                 region,
@@ -1274,7 +1276,7 @@ impl<F: Field> PiCircuitConfig<F> {
         *block_table_offset += 1;
 
         // withdrawals_root
-        let block_value = Word::from(block_values.withdrawals_root)
+        let block_value = WordLoHi::from(block_values.withdrawals_root)
             .into_value()
             .assign_advice(
                 region,
@@ -1295,7 +1297,7 @@ impl<F: Field> PiCircuitConfig<F> {
         *block_table_offset += 1;
 
         for prev_hash in block_values.history_hashes {
-            let block_value = Word::from(prev_hash).into_value().assign_advice(
+            let block_value = WordLoHi::from(prev_hash).into_value().assign_advice(
                 region,
                 || "prev_hash",
                 self.block_table.value,
@@ -1402,8 +1404,8 @@ impl<F: Field> PiCircuitConfig<F> {
     fn assign_rpi_digest_word(
         &self,
         region: &mut Region<'_, F>,
-        digest_word: Word<F>,
-    ) -> Result<Word<AssignedCell<F, F>>, Error> {
+        digest_word: WordLoHi<F>,
+    ) -> Result<WordLoHi<AssignedCell<F, F>>, Error> {
         let lo_assigned_cell = region.assign_advice(
             || "rpi_digest_bytes_limbs_lo",
             self.rpi_digest_bytes_limbs,
@@ -1416,7 +1418,7 @@ impl<F: Field> PiCircuitConfig<F> {
             1,
             || digest_word.into_value().hi(),
         )?;
-        Ok(Word::new([lo_assigned_cell, hi_assigned_cell]))
+        Ok(WordLoHi::new([lo_assigned_cell, hi_assigned_cell]))
     }
 }
 
@@ -1562,7 +1564,7 @@ impl<F: Field> SubCircuit<F> for PiCircuit<F> {
                 let mut block_table_offset = 0;
 
                 // assign empty row in block table
-                let zero_word = Word::default().into_value().assign_advice(
+                let zero_word = WordLoHi::default().into_value().assign_advice(
                     &mut region,
                     || "zero",
                     config.block_table.value,
@@ -1619,7 +1621,7 @@ impl<F: Field> SubCircuit<F> for PiCircuit<F> {
                 // Add empty row
                 // assign first tx_value empty row, and to obtain zero cell via hi() part.
                 // we use hi() part to copy-constrains other tx_table value `hi` cells.
-                let zero_cell = Word::default()
+                let zero_cell = WordLoHi::default()
                     .into_value()
                     .assign_advice(&mut region, || "tx_value", config.tx_table.value, 0)?
                     .hi();

--- a/zkevm-circuits/src/pi_circuit/param.rs
+++ b/zkevm-circuits/src/pi_circuit/param.rs
@@ -1,10 +1,10 @@
 use halo2_proofs::circuit::AssignedCell;
 
-use crate::util::word::Word;
+use crate::util::word::WordLoHi;
 
 /// Fixed by the spec
 pub(super) const BYTE_POW_BASE: u64 = 256;
 pub(super) const EMPTY_TX_ROW_COUNT: usize = 1;
 pub(super) const N_BYTES_ONE: usize = 1;
 
-pub(super) type AssignedByteCells<F> = (AssignedCell<F, F>, Word<AssignedCell<F, F>>);
+pub(super) type AssignedByteCells<F> = (AssignedCell<F, F>, WordLoHi<AssignedCell<F, F>>);

--- a/zkevm-circuits/src/state_circuit.rs
+++ b/zkevm-circuits/src/state_circuit.rs
@@ -19,7 +19,7 @@ use self::{
 };
 use crate::{
     table::{AccountFieldTag, LookupTable, MPTProofType, MptTable, RwTable, UXTable},
-    util::{word, Challenges, Expr, SubCircuit, SubCircuitConfig},
+    util::{word::WordLoHi, Challenges, Expr, SubCircuit, SubCircuitConfig},
     witness::{self, MptUpdates, Rw, RwMap},
 };
 use constraint_builder::{ConstraintBuilder, Queries};
@@ -56,14 +56,14 @@ pub struct StateCircuitConfig<F> {
     // Assigned value at the start of the block. For Rw::Account and
     // Rw::AccountStorage rows this is the committed value in the MPT, for
     // others, it is 0.
-    initial_value: word::Word<Column<Advice>>,
+    initial_value: WordLoHi<Column<Advice>>,
     // For Rw::AccountStorage, identify non-existing if both committed value and
     // new value are zero. Will do lookup for MPTProofType::StorageDoesNotExist if
     // non-existing, otherwise do lookup for MPTProofType::StorageChanged.
     is_non_exist: BatchedIsZeroConfig,
     // Intermediary witness used to reduce mpt lookup expression degree
     mpt_proof_type: Column<Advice>,
-    state_root: word::Word<Column<Advice>>,
+    state_root: WordLoHi<Column<Advice>>,
     lexicographic_ordering: LexicographicOrderingConfig,
     not_first_access: Column<Advice>,
     lookups: LookupsConfig,
@@ -118,7 +118,7 @@ impl<F: Field> SubCircuitConfig<F> for StateCircuitConfig<F> {
             [rw_table.storage_key.lo(), rw_table.storage_key.hi()],
             lookups,
         );
-        let initial_value = word::Word::new([meta.advice_column(), meta.advice_column()]);
+        let initial_value = WordLoHi::new([meta.advice_column(), meta.advice_column()]);
 
         let is_non_exist = BatchedIsZeroChip::configure(
             meta,
@@ -134,7 +134,7 @@ impl<F: Field> SubCircuitConfig<F> for StateCircuitConfig<F> {
             },
         );
         let mpt_proof_type = meta.advice_column_in(SecondPhase);
-        let state_root = word::Word::new([meta.advice_column(), meta.advice_column()]);
+        let state_root = WordLoHi::new([meta.advice_column(), meta.advice_column()]);
 
         let sort_keys = SortKeysConfig {
             tag,
@@ -283,7 +283,7 @@ impl<F: Field> StateCircuitConfig<F> {
             }
 
             // The initial value can be determined from the mpt updates or is 0.
-            let initial_value = word::Word::<F>::from(
+            let initial_value = WordLoHi::<F>::from(
                 updates
                     .get(row)
                     .map(|u| u.value_assignments().1)
@@ -305,8 +305,8 @@ impl<F: Field> StateCircuitConfig<F> {
                     .unwrap_or_default();
                 let value = row.value_assignment();
                 (
-                    word::Word::<F>::from(committed_value),
-                    word::Word::<F>::from(value),
+                    WordLoHi::<F>::from(committed_value),
+                    WordLoHi::<F>::from(value),
                 )
             };
 
@@ -353,9 +353,12 @@ impl<F: Field> StateCircuitConfig<F> {
             // State root assignment is at previous row (offset - 1) because the state root
             // changes on the last access row.
             if offset != 0 {
-                word::Word::<F>::from(state_root)
-                    .into_value()
-                    .assign_advice(region, || "state root", self.state_root, offset - 1)?;
+                WordLoHi::<F>::from(state_root).into_value().assign_advice(
+                    region,
+                    || "state root",
+                    self.state_root,
+                    offset - 1,
+                )?;
             }
 
             if offset == rows_len - 1 {
@@ -368,9 +371,12 @@ impl<F: Field> StateCircuitConfig<F> {
                         new_root
                     };
                 }
-                word::Word::<F>::from(state_root)
-                    .into_value()
-                    .assign_advice(region, || "last row state_root", self.state_root, offset)?;
+                WordLoHi::<F>::from(state_root).into_value().assign_advice(
+                    region,
+                    || "last row state_root",
+                    self.state_root,
+                    offset,
+                )?;
             }
         }
 
@@ -529,8 +535,8 @@ fn queries<F: Field>(meta: &mut VirtualCells<'_, F>, c: &StateCircuitConfig<F>) 
     assert_eq!(mpt_update_table_expressions.len(), 12);
 
     let meta_query_word =
-        |metap: &mut VirtualCells<'_, F>, word_column: word::Word<Column<Advice>>, at: Rotation| {
-            word::Word::new([
+        |metap: &mut VirtualCells<'_, F>, word_column: WordLoHi<Column<Advice>>, at: Rotation| {
+            WordLoHi::new([
                 metap.query_advice(word_column.lo(), at),
                 metap.query_advice(word_column.hi(), at),
             ])
@@ -557,24 +563,24 @@ fn queries<F: Field>(meta: &mut VirtualCells<'_, F>, c: &StateCircuitConfig<F>) 
         // TODO: clean this up
         mpt_update_table: MptUpdateTableQueries {
             address: mpt_update_table_expressions[0].clone(),
-            storage_key: word::Word::new([
+            storage_key: WordLoHi::new([
                 mpt_update_table_expressions[1].clone(),
                 mpt_update_table_expressions[2].clone(),
             ]),
             proof_type: mpt_update_table_expressions[3].clone(),
-            new_root: word::Word::new([
+            new_root: WordLoHi::new([
                 mpt_update_table_expressions[4].clone(),
                 mpt_update_table_expressions[5].clone(),
             ]),
-            old_root: word::Word::new([
+            old_root: WordLoHi::new([
                 mpt_update_table_expressions[6].clone(),
                 mpt_update_table_expressions[7].clone(),
             ]),
-            new_value: word::Word::new([
+            new_value: WordLoHi::new([
                 mpt_update_table_expressions[8].clone(),
                 mpt_update_table_expressions[9].clone(),
             ]),
-            old_value: word::Word::new([
+            old_value: WordLoHi::new([
                 mpt_update_table_expressions[10].clone(),
                 mpt_update_table_expressions[11].clone(),
             ]),

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -4,11 +4,7 @@ use crate::{
     copy_circuit::util::number_or_hash_to_word,
     evm_circuit::util::rlc,
     impl_expr,
-    util::{
-        build_tx_log_address, keccak,
-        word::{self, Word},
-        Challenges,
-    },
+    util::{build_tx_log_address, keccak, word::WordLoHi, Challenges},
     witness::{Block, BlockContext, MptUpdateRow, MptUpdates, Rw, RwMap, RwRow, Transaction},
 };
 use bus_mapping::circuit_input_builder::{CopyDataType, CopyEvent, CopyStep};

--- a/zkevm-circuits/src/table/block_table.rs
+++ b/zkevm-circuits/src/table/block_table.rs
@@ -36,7 +36,7 @@ pub struct BlockTable {
     /// Index
     pub index: Column<Fixed>,
     /// Value
-    pub value: word::Word<Column<Advice>>,
+    pub value: WordLoHi<Column<Advice>>,
 }
 
 impl BlockTable {
@@ -45,7 +45,7 @@ impl BlockTable {
         Self {
             tag: meta.fixed_column(),
             index: meta.fixed_column(),
-            value: word::Word::new([meta.advice_column(), meta.advice_column()]),
+            value: WordLoHi::new([meta.advice_column(), meta.advice_column()]),
         }
     }
 
@@ -75,7 +75,7 @@ impl BlockTable {
                         || row[1],
                     )?;
 
-                    word::Word::new([row[2], row[3]]).assign_advice(
+                    WordLoHi::new([row[2], row[3]]).assign_advice(
                         &mut region,
                         || format!("block table value {}", offset),
                         self.value,

--- a/zkevm-circuits/src/table/bytecode_table.rs
+++ b/zkevm-circuits/src/table/bytecode_table.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::util;
 use bus_mapping::state_db::CodeDB;
 
 /// Tag to identify the field in a Bytecode Table row
@@ -16,7 +15,7 @@ impl_expr!(BytecodeFieldTag);
 #[derive(Clone, Debug)]
 pub struct BytecodeTable {
     /// Code Hash
-    pub code_hash: word::Word<Column<Advice>>,
+    pub code_hash: WordLoHi<Column<Advice>>,
     /// Tag
     pub tag: Column<Advice>,
     /// Index
@@ -31,7 +30,7 @@ impl BytecodeTable {
     /// Construct a new BytecodeTable
     pub fn construct<F: Field>(meta: &mut ConstraintSystem<F>) -> Self {
         let [tag, index, is_code, value] = array::from_fn(|_| meta.advice_column());
-        let code_hash = word::Word::new([meta.advice_column(), meta.advice_column()]);
+        let code_hash = WordLoHi::new([meta.advice_column(), meta.advice_column()]);
         Self {
             code_hash,
             tag,
@@ -66,7 +65,7 @@ impl BytecodeTable {
                     <BytecodeTable as LookupTable<F>>::advice_columns(self);
                 for bytecode in bytecodes.clone().into_iter() {
                     let rows = {
-                        let code_hash = util::word::Word::from(bytecode.hash());
+                        let code_hash = WordLoHi::from(bytecode.hash());
                         std::iter::once([
                             code_hash.lo(),
                             code_hash.hi(),

--- a/zkevm-circuits/src/table/copy_table.rs
+++ b/zkevm-circuits/src/table/copy_table.rs
@@ -14,7 +14,7 @@ pub struct CopyTable {
     /// 1. Call ID/Caller ID for CopyDataType::Memory
     /// 2. The hi/lo limbs of bytecode hash for CopyDataType::Bytecode
     /// 3. Transaction ID for CopyDataType::TxCalldata, CopyDataType::TxLog
-    pub id: word::Word<Column<Advice>>,
+    pub id: WordLoHi<Column<Advice>>,
     /// The source/destination address for this copy step.  Can be memory
     /// address, byte index in the bytecode, tx call data, and tx log data.
     pub addr: Column<Advice>,
@@ -45,7 +45,7 @@ impl CopyTable {
     pub fn construct<F: Field>(meta: &mut ConstraintSystem<F>, q_enable: Column<Fixed>) -> Self {
         Self {
             is_first: meta.advice_column(),
-            id: word::Word::new([meta.advice_column(), meta.advice_column()]),
+            id: WordLoHi::new([meta.advice_column(), meta.advice_column()]),
             q_enable,
             tag: BinaryNumberChip::configure(meta, q_enable, None),
             addr: meta.advice_column(),

--- a/zkevm-circuits/src/table/keccak_table.rs
+++ b/zkevm-circuits/src/table/keccak_table.rs
@@ -10,7 +10,7 @@ pub struct KeccakTable {
     /// Byte array input length
     pub input_len: Column<Advice>,
     /// Output hash word
-    pub output: word::Word<Column<Advice>>,
+    pub output: WordLoHi<Column<Advice>>,
 }
 
 impl<F: Field> LookupTable<F> for KeccakTable {
@@ -42,7 +42,7 @@ impl KeccakTable {
             is_enabled: meta.advice_column(),
             input_rlc: meta.advice_column_in(SecondPhase),
             input_len: meta.advice_column(),
-            output: word::Word::new([meta.advice_column(), meta.advice_column()]),
+            output: WordLoHi::new([meta.advice_column(), meta.advice_column()]),
         }
     }
 
@@ -55,7 +55,7 @@ impl KeccakTable {
             .keccak_input()
             .map(|challenge| rlc::value(input.iter().rev(), challenge));
         let input_len = F::from(input.len() as u64);
-        let output = word::Word::from(keccak(input));
+        let output = WordLoHi::from(keccak(input));
 
         vec![[
             Value::known(F::ONE),
@@ -130,7 +130,7 @@ impl KeccakTable {
         &self,
         value_rlc: Column<Advice>,
         length: Column<Advice>,
-        code_hash: Word<Column<Advice>>,
+        code_hash: WordLoHi<Column<Advice>>,
     ) -> Vec<(Column<Advice>, Column<Advice>)> {
         vec![
             (value_rlc, self.input_rlc),

--- a/zkevm-circuits/src/table/mpt_table.rs
+++ b/zkevm-circuits/src/table/mpt_table.rs
@@ -46,17 +46,17 @@ pub struct MptTable {
     /// Account address
     pub address: Column<Advice>,
     /// Storage address
-    pub storage_key: word::Word<Column<Advice>>,
+    pub storage_key: WordLoHi<Column<Advice>>,
     /// Proof type
     pub proof_type: Column<Advice>,
     /// New MPT root
-    pub new_root: word::Word<Column<Advice>>,
+    pub new_root: WordLoHi<Column<Advice>>,
     /// Previous MPT root
-    pub old_root: word::Word<Column<Advice>>,
+    pub old_root: WordLoHi<Column<Advice>>,
     /// New value
-    pub new_value: word::Word<Column<Advice>>,
+    pub new_value: WordLoHi<Column<Advice>>,
     /// Old value
-    pub old_value: word::Word<Column<Advice>>,
+    pub old_value: WordLoHi<Column<Advice>>,
 }
 
 impl<F: Field> LookupTable<F> for MptTable {
@@ -103,12 +103,12 @@ impl MptTable {
     pub(crate) fn construct<F: Field>(meta: &mut ConstraintSystem<F>) -> Self {
         Self {
             address: meta.advice_column(),
-            storage_key: word::Word::new([meta.advice_column(), meta.advice_column()]),
+            storage_key: WordLoHi::new([meta.advice_column(), meta.advice_column()]),
             proof_type: meta.advice_column(),
-            new_root: word::Word::new([meta.advice_column(), meta.advice_column()]),
-            old_root: word::Word::new([meta.advice_column(), meta.advice_column()]),
-            new_value: word::Word::new([meta.advice_column(), meta.advice_column()]),
-            old_value: word::Word::new([meta.advice_column(), meta.advice_column()]),
+            new_root: WordLoHi::new([meta.advice_column(), meta.advice_column()]),
+            old_root: WordLoHi::new([meta.advice_column(), meta.advice_column()]),
+            new_value: WordLoHi::new([meta.advice_column(), meta.advice_column()]),
+            old_value: WordLoHi::new([meta.advice_column(), meta.advice_column()]),
         }
     }
 
@@ -119,11 +119,11 @@ impl MptTable {
         cb: &mut ConstraintBuilder<F, C>,
         address: Expression<F>,
         proof_type: Expression<F>,
-        storage_key: word::Word<Expression<F>>,
-        new_root: word::Word<Expression<F>>,
-        old_root: word::Word<Expression<F>>,
-        new_value: word::Word<Expression<F>>,
-        old_value: word::Word<Expression<F>>,
+        storage_key: WordLoHi<Expression<F>>,
+        new_root: WordLoHi<Expression<F>>,
+        old_root: WordLoHi<Expression<F>>,
+        new_value: WordLoHi<Expression<F>>,
+        old_value: WordLoHi<Expression<F>>,
     ) {
         circuit!([meta, cb], {
             require!(a!(self.address) => address);

--- a/zkevm-circuits/src/table/rw_table.rs
+++ b/zkevm-circuits/src/table/rw_table.rs
@@ -17,13 +17,13 @@ pub struct RwTable {
     /// Key3 (FieldTag)
     pub field_tag: Column<Advice>,
     /// Key3 (StorageKey)
-    pub storage_key: word::Word<Column<Advice>>,
+    pub storage_key: WordLoHi<Column<Advice>>,
     /// Value
-    pub value: word::Word<Column<Advice>>,
+    pub value: WordLoHi<Column<Advice>>,
     /// Value Previous
-    pub value_prev: word::Word<Column<Advice>>,
+    pub value_prev: WordLoHi<Column<Advice>>,
     /// InitVal (Committed Value)
-    pub init_val: word::Word<Column<Advice>>,
+    pub init_val: WordLoHi<Column<Advice>>,
 }
 
 impl<F: Field> LookupTable<F> for RwTable {
@@ -75,10 +75,10 @@ impl RwTable {
             id: meta.advice_column(),
             address: meta.advice_column(),
             field_tag: meta.advice_column(),
-            storage_key: word::Word::new([meta.advice_column(), meta.advice_column()]),
-            value: word::Word::new([meta.advice_column(), meta.advice_column()]),
-            value_prev: word::Word::new([meta.advice_column(), meta.advice_column()]),
-            init_val: word::Word::new([meta.advice_column(), meta.advice_column()]),
+            storage_key: WordLoHi::new([meta.advice_column(), meta.advice_column()]),
+            value: WordLoHi::new([meta.advice_column(), meta.advice_column()]),
+            value_prev: WordLoHi::new([meta.advice_column(), meta.advice_column()]),
+            init_val: WordLoHi::new([meta.advice_column(), meta.advice_column()]),
         }
     }
     fn assign<F: Field>(

--- a/zkevm-circuits/src/table/tx_table.rs
+++ b/zkevm-circuits/src/table/tx_table.rs
@@ -69,7 +69,7 @@ pub struct TxTable {
     /// Index for Tag = CallData
     pub index: Column<Advice>,
     /// Value
-    pub value: word::Word<Column<Advice>>,
+    pub value: WordLoHi<Column<Advice>>,
 }
 
 impl TxTable {
@@ -79,7 +79,7 @@ impl TxTable {
             tx_id: meta.advice_column(),
             tag: meta.fixed_column(),
             index: meta.advice_column(),
-            value: word::Word::new([meta.advice_column(), meta.advice_column()]),
+            value: WordLoHi::new([meta.advice_column(), meta.advice_column()]),
         }
     }
 
@@ -159,29 +159,23 @@ impl TxTable {
                 for tx in txs.iter().chain(padding_txs.iter()) {
                     let tx_id = Value::known(F::from(tx.id));
                     let tx_data = vec![
-                        (
-                            TxContextFieldTag::Nonce,
-                            word::Word::from(tx.nonce.as_u64()),
-                        ),
-                        (TxContextFieldTag::Gas, word::Word::from(tx.gas())),
-                        (TxContextFieldTag::GasPrice, word::Word::from(tx.gas_price)),
-                        (TxContextFieldTag::CallerAddress, word::Word::from(tx.from)),
+                        (TxContextFieldTag::Nonce, WordLoHi::from(tx.nonce.as_u64())),
+                        (TxContextFieldTag::Gas, WordLoHi::from(tx.gas())),
+                        (TxContextFieldTag::GasPrice, WordLoHi::from(tx.gas_price)),
+                        (TxContextFieldTag::CallerAddress, WordLoHi::from(tx.from)),
                         (
                             TxContextFieldTag::CalleeAddress,
-                            word::Word::from(tx.to_or_contract_addr()),
+                            WordLoHi::from(tx.to_or_contract_addr()),
                         ),
-                        (
-                            TxContextFieldTag::IsCreate,
-                            word::Word::from(tx.is_create()),
-                        ),
-                        (TxContextFieldTag::Value, word::Word::from(tx.value)),
+                        (TxContextFieldTag::IsCreate, WordLoHi::from(tx.is_create())),
+                        (TxContextFieldTag::Value, WordLoHi::from(tx.value)),
                         (
                             TxContextFieldTag::CallDataLength,
-                            word::Word::from(tx.call_data.len() as u64),
+                            WordLoHi::from(tx.call_data.len() as u64),
                         ),
                         (
                             TxContextFieldTag::CallDataGasCost,
-                            word::Word::from(tx.call_data_gas_cost()),
+                            WordLoHi::from(tx.call_data_gas_cost()),
                         ),
                     ]
                     .iter()

--- a/zkevm-circuits/src/table/wd_table.rs
+++ b/zkevm-circuits/src/table/wd_table.rs
@@ -10,7 +10,7 @@ pub struct WdTable {
     /// validator id
     pub validator_id: Column<Advice>,
     /// withdrawal address
-    pub address: Word<Column<Advice>>,
+    pub address: WordLoHi<Column<Advice>>,
     /// validator withdrawal amount in Gwei
     pub amount: Column<Advice>,
 }
@@ -21,7 +21,7 @@ impl WdTable {
         Self {
             id: meta.advice_column(),
             validator_id: meta.advice_column(),
-            address: Word::new([meta.advice_column(), meta.advice_column()]),
+            address: WordLoHi::new([meta.advice_column(), meta.advice_column()]),
             amount: meta.advice_column(),
         }
     }
@@ -78,7 +78,7 @@ impl WdTable {
                     .chain(padding_withdrawals.iter())
                     .enumerate()
                 {
-                    let address_word = Word::from(wd.address);
+                    let address_word = WordLoHi::from(wd.address);
                     let row = [
                         Value::known(F::from(wd.id)),
                         Value::known(F::from(wd.validator_id)),

--- a/zkevm-circuits/src/test_util.rs
+++ b/zkevm-circuits/src/test_util.rs
@@ -69,7 +69,7 @@ const NUM_BLINDING_ROWS: usize = 64;
 ///         txs[0]
 ///             .from(MOCK_ACCOUNTS[0])
 ///             .gas_price(gwei(2))
-///             .gas(WordLoHi::from(0x10000))
+///             .gas(Word::from(0x10000))
 ///             .value(eth(2))
 ///             .input(code.into());
 ///     },

--- a/zkevm-circuits/src/test_util.rs
+++ b/zkevm-circuits/src/test_util.rs
@@ -69,7 +69,7 @@ const NUM_BLINDING_ROWS: usize = 64;
 ///         txs[0]
 ///             .from(MOCK_ACCOUNTS[0])
 ///             .gas_price(gwei(2))
-///             .gas(Word::from(0x10000))
+///             .gas(WordLoHi::from(0x10000))
 ///             .value(eth(2))
 ///             .input(code.into());
 ///     },

--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -15,7 +15,7 @@ pub use dev::TxCircuit as TestTxCircuit;
 
 use crate::{
     table::{KeccakTable, TxFieldTag, TxTable},
-    util::{word::Word, Challenges, SubCircuit, SubCircuitConfig},
+    util::{word::WordLoHi, Challenges, SubCircuit, SubCircuitConfig},
     witness,
 };
 use eth_types::{geth_types::Transaction, sign_types::SignData, Field};
@@ -41,7 +41,7 @@ pub struct TxCircuitConfig<F: Field> {
     tx_id: Column<Advice>,
     tag: Column<Fixed>,
     index: Column<Advice>,
-    value: Word<Column<Advice>>,
+    value: WordLoHi<Column<Advice>>,
     sign_verify: SignVerifyConfig,
     _marker: PhantomData<F>,
 }
@@ -103,8 +103,8 @@ impl<F: Field> TxCircuitConfig<F> {
         tx_id: usize,
         tag: TxFieldTag,
         index: usize,
-        value: Word<Value<F>>,
-    ) -> Result<Word<AssignedCell<F, F>>, Error> {
+        value: WordLoHi<Value<F>>,
+    ) -> Result<WordLoHi<AssignedCell<F, F>>, Error> {
         region.assign_advice(
             || "tx_id",
             self.tx_id,
@@ -186,7 +186,7 @@ impl<F: Field> TxCircuit<F> {
                     0,
                     TxFieldTag::Null,
                     0,
-                    Word::default().into_value(),
+                    WordLoHi::default().into_value(),
                 )?;
                 offset += 1;
                 // Assign all Tx fields except for call data
@@ -201,27 +201,33 @@ impl<F: Field> TxCircuit<F> {
                     for (tag, value) in [
                         (
                             TxFieldTag::Nonce,
-                            Word::from(tx.nonce.as_u64()).into_value(),
+                            WordLoHi::from(tx.nonce.as_u64()).into_value(),
                         ),
-                        (TxFieldTag::Gas, Word::from(tx.gas()).into_value()),
-                        (TxFieldTag::GasPrice, Word::from(tx.gas_price).into_value()),
-                        (TxFieldTag::CallerAddress, Word::from(tx.from).into_value()),
+                        (TxFieldTag::Gas, WordLoHi::from(tx.gas()).into_value()),
+                        (
+                            TxFieldTag::GasPrice,
+                            WordLoHi::from(tx.gas_price).into_value(),
+                        ),
+                        (
+                            TxFieldTag::CallerAddress,
+                            WordLoHi::from(tx.from).into_value(),
+                        ),
                         (
                             TxFieldTag::CalleeAddress,
-                            Word::from(tx.to_or_zero()).into_value(),
+                            WordLoHi::from(tx.to_or_zero()).into_value(),
                         ),
                         (
                             TxFieldTag::IsCreate,
-                            Word::from(tx.is_create() as u64).into_value(),
+                            WordLoHi::from(tx.is_create() as u64).into_value(),
                         ),
-                        (TxFieldTag::Value, Word::from(tx.value).into_value()),
+                        (TxFieldTag::Value, WordLoHi::from(tx.value).into_value()),
                         (
                             TxFieldTag::CallDataLength,
-                            Word::from(tx.call_data.0.len() as u64).into_value(),
+                            WordLoHi::from(tx.call_data.0.len() as u64).into_value(),
                         ),
                         (
                             TxFieldTag::CallDataGasCost,
-                            Word::from(tx.call_data_gas_cost()).into_value(),
+                            WordLoHi::from(tx.call_data_gas_cost()).into_value(),
                         ),
                         (
                             TxFieldTag::TxSignHash,
@@ -271,7 +277,7 @@ impl<F: Field> TxCircuit<F> {
                             i + 1, // tx_id
                             TxFieldTag::CallData,
                             index,
-                            Word::from(*byte as u64).into_value(),
+                            WordLoHi::from(*byte as u64).into_value(),
                         )?;
                         offset += 1;
                         calldata_count += 1;
@@ -284,7 +290,7 @@ impl<F: Field> TxCircuit<F> {
                         0, // tx_id
                         TxFieldTag::CallData,
                         0,
-                        Word::default().into_value(),
+                        WordLoHi::default().into_value(),
                     )?;
                     offset += 1;
                 }

--- a/zkevm-circuits/src/tx_circuit/sign_verify.rs
+++ b/zkevm-circuits/src/tx_circuit/sign_verify.rs
@@ -10,7 +10,7 @@ use crate::{
         util::{from_bytes, not, rlc},
     },
     table::KeccakTable,
-    util::{word::Word, Challenges, Expr},
+    util::{word::WordLoHi, Challenges, Expr},
 };
 use ecc::{maingate, EccConfig, GeneralEccChip};
 use ecdsa::ecdsa::{AssignedEcdsaSig, AssignedPublicKey, EcdsaChip};
@@ -292,8 +292,8 @@ pub(crate) struct AssignedECDSA<F: Field> {
 
 #[derive(Debug)]
 pub(crate) struct AssignedSignatureVerify<F: Field> {
-    pub(crate) address: Word<AssignedValue<F>>,
-    pub(crate) msg_hash: Word<AssignedValue<F>>,
+    pub(crate) address: WordLoHi<AssignedValue<F>>,
+    pub(crate) msg_hash: WordLoHi<AssignedValue<F>>,
 }
 
 // Return an array of bytes that corresponds to the little endian representation
@@ -451,7 +451,7 @@ impl<F: Field> SignVerifyChip<F> {
         ctx: &mut RegionCtx<F>,
         is_address_zero: &AssignedCell<F, F>,
         pk_rlc: &AssignedCell<F, F>,
-        pk_hash: &Word<AssignedCell<F, F>>,
+        pk_hash: &WordLoHi<AssignedCell<F, F>>,
     ) -> Result<(), Error> {
         let copy = |ctx: &mut RegionCtx<F>, name, column, assigned: &AssignedCell<F, F>| {
             let copied = ctx.assign_advice(|| name, column, assigned.value().copied())?;
@@ -559,8 +559,8 @@ impl<F: Field> SignVerifyChip<F> {
             )?;
 
             (
-                Word::new([address_cell_lo, address_cell_hi]),
-                Word::new([pk_hash_cell_lo, pk_hash_cell_hi]),
+                WordLoHi::new([address_cell_lo, address_cell_hi]),
+                WordLoHi::new([pk_hash_cell_lo, pk_hash_cell_hi]),
             )
         };
 
@@ -594,7 +594,7 @@ impl<F: Field> SignVerifyChip<F> {
                 |_, _| Ok(()),
             )?;
 
-            Word::new([msg_hash_cell_lo, msg_hash_cell_hi])
+            WordLoHi::new([msg_hash_cell_lo, msg_hash_cell_hi])
         };
 
         let pk_rlc = {

--- a/zkevm-circuits/src/util/int_decomposition.rs
+++ b/zkevm-circuits/src/util/int_decomposition.rs
@@ -12,7 +12,7 @@ use crate::evm_circuit::{
     util::{rlc, CachedRegion, Cell},
 };
 
-use super::word::{Word, WordExpr};
+use super::word::{WordExpr, WordLoHi};
 
 #[derive(Clone, Debug)]
 /// IntDecomposition decompose integer into byte limbs
@@ -89,7 +89,7 @@ impl<F: Field, const N_LIMBS: usize> Expr<F> for IntDecomposition<F, N_LIMBS> {
 }
 
 impl<F: Field, const N_LIMBS: usize> WordExpr<F> for IntDecomposition<F, N_LIMBS> {
-    fn to_word(&self) -> Word<Expression<F>> {
+    fn to_word(&self) -> WordLoHi<Expression<F>> {
         let exprs = self
             .limbs
             .clone()
@@ -97,7 +97,7 @@ impl<F: Field, const N_LIMBS: usize> WordExpr<F> for IntDecomposition<F, N_LIMBS
             .chunks(N_BYTES_HALF_WORD)
             .map(|chunk| rlc::expr(chunk, 256.expr()))
             .collect::<Vec<Expression<F>>>();
-        Word::new(
+        WordLoHi::new(
             (0..2)
                 .map(|id| exprs.get(id).unwrap_or(&0.expr()).clone())
                 .collect_vec()

--- a/zkevm-circuits/src/util/word.rs
+++ b/zkevm-circuits/src/util/word.rs
@@ -35,7 +35,7 @@ pub(crate) type Word4<T> = WordLimbs<T, 4>;
 
 pub(crate) type Word32<T> = WordLimbs<T, 32>;
 
-pub(crate) type WordCell<F> = Word<Cell<F>>;
+pub(crate) type WordLoHiCell<F> = WordLoHi<Cell<F>>;
 
 pub(crate) type Word32Cell<F> = Word32<Cell<F>>;
 
@@ -79,7 +79,7 @@ impl<T: Default, const N: usize> Default for WordLimbs<T, N> {
 /// Get the word expression
 pub trait WordExpr<F> {
     /// Get the word expression
-    fn to_word(&self) -> Word<Expression<F>>;
+    fn to_word(&self) -> WordLoHi<Expression<F>>;
 }
 
 impl<F: Field, const N: usize> WordLimbs<Cell<F>, N> {
@@ -186,8 +186,8 @@ impl<F: Field, const N: usize> WordLimbs<Cell<F>, N> {
 }
 
 impl<F: Field, const N: usize> WordExpr<F> for WordLimbs<Cell<F>, N> {
-    fn to_word(&self) -> Word<Expression<F>> {
-        Word(self.word_expr().to_word_n())
+    fn to_word(&self) -> WordLoHi<Expression<F>> {
+        WordLoHi(self.word_expr().to_word_n())
     }
 }
 
@@ -200,9 +200,9 @@ impl<F: Field, const N: usize> WordLimbs<F, N> {
 
 /// `Word`, special alias for Word2.
 #[derive(Clone, Debug, Copy, Default)]
-pub struct Word<T>(Word2<T>);
+pub struct WordLoHi<T>(Word2<T>);
 
-impl<T: Clone> Word<T> {
+impl<T: Clone> WordLoHi<T> {
     /// Construct the word from 2 limbs
     pub fn new(limbs: [T; 2]) -> Self {
         Self(WordLimbs::<T, 2>::new(limbs))
@@ -230,19 +230,19 @@ impl<T: Clone> Word<T> {
         (lo, hi)
     }
 
-    /// Wrap `Word` into `Word<Value>`
-    pub fn into_value(self) -> Word<Value<T>> {
+    /// Wrap `Word` into `WordLoHi<Value>`
+    pub fn into_value(self) -> WordLoHi<Value<T>> {
         let [lo, hi] = self.0.limbs;
-        Word::new([Value::known(lo), Value::known(hi)])
+        WordLoHi::new([Value::known(lo), Value::known(hi)])
     }
 
     /// Map the word to other types
-    pub fn map<T2: Clone>(&self, mut func: impl FnMut(T) -> T2) -> Word<T2> {
-        Word(WordLimbs::<T2, 2>::new([func(self.lo()), func(self.hi())]))
+    pub fn map<T2: Clone>(&self, mut func: impl FnMut(T) -> T2) -> WordLoHi<T2> {
+        WordLoHi(WordLimbs::<T2, 2>::new([func(self.lo()), func(self.hi())]))
     }
 }
 
-impl<T> std::ops::Deref for Word<T> {
+impl<T> std::ops::Deref for WordLoHi<T> {
     type Target = WordLimbs<T, 2>;
 
     fn deref(&self) -> &Self::Target {
@@ -250,35 +250,35 @@ impl<T> std::ops::Deref for Word<T> {
     }
 }
 
-impl<T: Clone + PartialEq> PartialEq for Word<T> {
+impl<T: Clone + PartialEq> PartialEq for WordLoHi<T> {
     fn eq(&self, other: &Self) -> bool {
         self.lo() == other.lo() && self.hi() == other.hi()
     }
 }
 
-impl<F: Field> From<eth_types::Word> for Word<F> {
+impl<F: Field> From<eth_types::Word> for WordLoHi<F> {
     /// Construct the word from u256
     fn from(value: eth_types::Word) -> Self {
         let bytes = value.to_le_bytes();
-        Word::new([
+        WordLoHi::new([
             from_bytes::value(&bytes[..N_BYTES_HALF_WORD]),
             from_bytes::value(&bytes[N_BYTES_HALF_WORD..]),
         ])
     }
 }
 
-impl<T: Clone + OpsIdentity<Output = T>> OpsIdentity for Word<T> {
+impl<T: Clone + OpsIdentity<Output = T>> OpsIdentity for WordLoHi<T> {
     /// output type
-    type Output = Word<T>;
+    type Output = WordLoHi<T>;
     fn zero() -> Self::Output {
-        Word::new([T::zero(), T::zero()])
+        WordLoHi::new([T::zero(), T::zero()])
     }
     fn one() -> Self::Output {
-        Word::new([T::one(), T::zero()])
+        WordLoHi::new([T::one(), T::zero()])
     }
 }
 
-impl<F: Field> From<H256> for Word<F> {
+impl<F: Field> From<H256> for WordLoHi<F> {
     /// Construct the word from H256
     fn from(h: H256) -> Self {
         let le_bytes = {
@@ -286,55 +286,55 @@ impl<F: Field> From<H256> for Word<F> {
             b.reverse();
             b
         };
-        Word::new([
+        WordLoHi::new([
             from_bytes::value(&le_bytes[..N_BYTES_HALF_WORD]),
             from_bytes::value(&le_bytes[N_BYTES_HALF_WORD..]),
         ])
     }
 }
 
-impl<F: Field> From<u64> for Word<F> {
+impl<F: Field> From<u64> for WordLoHi<F> {
     /// Construct the word from u64
     fn from(value: u64) -> Self {
         let bytes = value.to_le_bytes();
-        Word::new([from_bytes::value(&bytes), F::from(0)])
+        WordLoHi::new([from_bytes::value(&bytes), F::from(0)])
     }
 }
 
-impl<F: Field> From<u8> for Word<F> {
+impl<F: Field> From<u8> for WordLoHi<F> {
     /// Construct the word from u8
     fn from(value: u8) -> Self {
-        Word::new([F::from(value as u64), F::from(0)])
+        WordLoHi::new([F::from(value as u64), F::from(0)])
     }
 }
 
-impl<F: Field> From<bool> for Word<F> {
+impl<F: Field> From<bool> for WordLoHi<F> {
     fn from(value: bool) -> Self {
-        Word::new([F::from(value as u64), F::from(0)])
+        WordLoHi::new([F::from(value as u64), F::from(0)])
     }
 }
 
-impl<F: Field> From<H160> for Word<F> {
+impl<F: Field> From<H160> for WordLoHi<F> {
     /// Construct the word from h160
     fn from(value: H160) -> Self {
         let mut bytes = *value.as_fixed_bytes();
         bytes.reverse();
-        Word::new([
+        WordLoHi::new([
             from_bytes::value(&bytes[..N_BYTES_HALF_WORD]),
             from_bytes::value(&bytes[N_BYTES_HALF_WORD..]),
         ])
     }
 }
 
-impl<F: Field> Word<Value<F>> {
+impl<F: Field> WordLoHi<Value<F>> {
     /// Assign advice
     pub fn assign_advice<A, AR>(
         &self,
         region: &mut Region<'_, F>,
         annotation: A,
-        column: Word<Column<Advice>>,
+        column: WordLoHi<Column<Advice>>,
         offset: usize,
-    ) -> Result<Word<AssignedCell<F, F>>, Error>
+    ) -> Result<WordLoHi<AssignedCell<F, F>>, Error>
     where
         A: Fn() -> AR,
         AR: Into<String>,
@@ -343,28 +343,28 @@ impl<F: Field> Word<Value<F>> {
         let lo = region.assign_advice(|| &annotation, column.lo(), offset, || self.lo())?;
         let hi = region.assign_advice(|| &annotation, column.hi(), offset, || self.hi())?;
 
-        Ok(Word::new([lo, hi]))
+        Ok(WordLoHi::new([lo, hi]))
     }
 }
 
-impl Word<Column<Advice>> {
+impl WordLoHi<Column<Advice>> {
     /// Query advice of Word of columns advice
     pub fn query_advice<F: Field>(
         &self,
         meta: &mut VirtualCells<F>,
         at: Rotation,
-    ) -> Word<Expression<F>> {
+    ) -> WordLoHi<Expression<F>> {
         self.0.query_advice(meta, at).to_word()
     }
 }
 
-impl<F: Field, T: Expr<F> + Clone> WordExpr<F> for Word<T> {
-    fn to_word(&self) -> Word<Expression<F>> {
+impl<F: Field, T: Expr<F> + Clone> WordExpr<F> for WordLoHi<T> {
+    fn to_word(&self) -> WordLoHi<Expression<F>> {
         self.map(|limb| limb.expr())
     }
 }
 
-impl<F: Field> Word<F> {
+impl<F: Field> WordLoHi<F> {
     /// Convert address (h160) to single field element.
     /// This method is Address specific
     pub fn compress_f(&self) -> F {
@@ -372,7 +372,7 @@ impl<F: Field> Word<F> {
     }
 }
 
-impl<F: Field> Word<Expression<F>> {
+impl<F: Field> WordLoHi<Expression<F>> {
     /// create word from lo limb with hi limb as 0. caller need to guaranteed to be 128 bits.
     pub fn from_lo_unchecked(lo: Expression<F>) -> Self {
         Self::new([lo, 0.expr()])
@@ -381,13 +381,13 @@ impl<F: Field> Word<Expression<F>> {
     /// select based on selector. Here assume selector is 1/0 therefore no overflow check
     pub fn select<T: Expr<F> + Clone>(
         selector: T,
-        when_true: Word<T>,
-        when_false: Word<T>,
-    ) -> Word<Expression<F>> {
+        when_true: WordLoHi<T>,
+        when_false: WordLoHi<T>,
+    ) -> WordLoHi<Expression<F>> {
         let (true_lo, true_hi) = when_true.to_lo_hi();
 
         let (false_lo, false_hi) = when_false.to_lo_hi();
-        Word::new([
+        WordLoHi::new([
             selector.expr() * true_lo.expr() + (1.expr() - selector.expr()) * false_lo.expr(),
             selector.expr() * true_hi.expr() + (1.expr() - selector.expr()) * false_hi.expr(),
         ])
@@ -395,22 +395,22 @@ impl<F: Field> Word<Expression<F>> {
 
     /// Assume selector is 1/0 therefore no overflow check
     pub fn mul_selector(&self, selector: Expression<F>) -> Self {
-        Word::new([self.lo() * selector.clone(), self.hi() * selector])
+        WordLoHi::new([self.lo() * selector.clone(), self.hi() * selector])
     }
 
     /// No overflow check on lo/hi limbs
     pub fn add_unchecked(self, rhs: Self) -> Self {
-        Word::new([self.lo() + rhs.lo(), self.hi() + rhs.hi()])
+        WordLoHi::new([self.lo() + rhs.lo(), self.hi() + rhs.hi()])
     }
 
     /// No underflow check on lo/hi limbs
     pub fn sub_unchecked(self, rhs: Self) -> Self {
-        Word::new([self.lo() - rhs.lo(), self.hi() - rhs.hi()])
+        WordLoHi::new([self.lo() - rhs.lo(), self.hi() - rhs.hi()])
     }
 
     /// No overflow check on lo/hi limbs
     pub fn mul_unchecked(self, rhs: Self) -> Self {
-        Word::new([self.lo() * rhs.lo(), self.hi() * rhs.hi()])
+        WordLoHi::new([self.lo() * rhs.lo(), self.hi() * rhs.hi()])
     }
 
     /// Convert address (h160) to single expression.
@@ -454,14 +454,14 @@ impl<F: Field, const N1: usize> WordLimbs<Expression<F>, N1> {
 }
 
 impl<F: Field, const N1: usize> WordExpr<F> for WordLimbs<Expression<F>, N1> {
-    fn to_word(&self) -> Word<Expression<F>> {
-        Word(self.to_word_n())
+    fn to_word(&self) -> WordLoHi<Expression<F>> {
+        WordLoHi(self.to_word_n())
     }
 }
 
-/// Return the hash of the empty code as a `Word<Value<F>>` in little-endian.
-pub fn empty_code_hash_word_value<F: Field>() -> Word<Value<F>> {
-    Word::from(CodeDB::empty_code_hash()).into_value()
+/// Return the hash of the empty code as a `WordLoHi<Value<F>>` in little-endian.
+pub fn empty_code_hash_word_value<F: Field>() -> WordLoHi<Value<F>> {
+    WordLoHi::from(CodeDB::empty_code_hash()).into_value()
 }
 
 // TODO unittest

--- a/zkevm-circuits/src/witness/block.rs
+++ b/zkevm-circuits/src/witness/block.rs
@@ -4,7 +4,7 @@ use crate::{
     exp_circuit::param::OFFSET_INCREMENT,
     instance::public_data_convert,
     table::BlockContextFieldTag,
-    util::{log2_ceil, word, SubCircuit},
+    util::{log2_ceil, word::WordLoHi, SubCircuit},
 };
 use bus_mapping::{
     circuit_input_builder::{self, CopyEvent, ExpEvent, FeatureConfig, FixedCParams, Withdrawal},
@@ -187,8 +187,8 @@ impl BlockContext {
                 [
                     Value::known(F::from(BlockContextFieldTag::Coinbase as u64)),
                     Value::known(F::ZERO),
-                    Value::known(word::Word::from(self.coinbase).lo()),
-                    Value::known(word::Word::from(self.coinbase).hi()),
+                    Value::known(WordLoHi::from(self.coinbase).lo()),
+                    Value::known(WordLoHi::from(self.coinbase).hi()),
                 ],
                 [
                     Value::known(F::from(BlockContextFieldTag::Timestamp as u64)),
@@ -205,8 +205,8 @@ impl BlockContext {
                 [
                     Value::known(F::from(BlockContextFieldTag::Difficulty as u64)),
                     Value::known(F::ZERO),
-                    Value::known(word::Word::from(self.difficulty).lo()),
-                    Value::known(word::Word::from(self.difficulty).hi()),
+                    Value::known(WordLoHi::from(self.difficulty).lo()),
+                    Value::known(WordLoHi::from(self.difficulty).hi()),
                 ],
                 [
                     Value::known(F::from(BlockContextFieldTag::GasLimit as u64)),
@@ -217,20 +217,20 @@ impl BlockContext {
                 [
                     Value::known(F::from(BlockContextFieldTag::BaseFee as u64)),
                     Value::known(F::ZERO),
-                    Value::known(word::Word::from(self.base_fee).lo()),
-                    Value::known(word::Word::from(self.base_fee).hi()),
+                    Value::known(WordLoHi::from(self.base_fee).lo()),
+                    Value::known(WordLoHi::from(self.base_fee).hi()),
                 ],
                 [
                     Value::known(F::from(BlockContextFieldTag::ChainId as u64)),
                     Value::known(F::ZERO),
-                    Value::known(word::Word::from(self.chain_id).lo()),
-                    Value::known(word::Word::from(self.chain_id).hi()),
+                    Value::known(WordLoHi::from(self.chain_id).lo()),
+                    Value::known(WordLoHi::from(self.chain_id).hi()),
                 ],
                 [
                     Value::known(F::from(BlockContextFieldTag::WithdrawalRoot as u64)),
                     Value::known(F::ZERO),
-                    Value::known(word::Word::from(self.withdrawals_root).lo()),
-                    Value::known(word::Word::from(self.withdrawals_root).hi()),
+                    Value::known(WordLoHi::from(self.withdrawals_root).lo()),
+                    Value::known(WordLoHi::from(self.withdrawals_root).hi()),
                 ],
             ],
             {
@@ -242,8 +242,8 @@ impl BlockContext {
                         [
                             Value::known(F::from(BlockContextFieldTag::BlockHash as u64)),
                             Value::known((self.number - len_history + idx).to_scalar().unwrap()),
-                            Value::known(word::Word::from(*hash).lo()),
-                            Value::known(word::Word::from(*hash).hi()),
+                            Value::known(WordLoHi::from(*hash).lo()),
+                            Value::known(WordLoHi::from(*hash).hi()),
                         ]
                     })
                     .collect()

--- a/zkevm-circuits/src/witness/mpt.rs
+++ b/zkevm-circuits/src/witness/mpt.rs
@@ -1,7 +1,7 @@
 use crate::{
     evm_circuit::witness::Rw,
     table::{AccountFieldTag, MPTProofType},
-    util::word,
+    util::word::WordLoHi,
 };
 use eth_types::{Address, Field, ToScalar, Word};
 use halo2_proofs::circuit::Value;
@@ -45,12 +45,12 @@ pub struct MptUpdates {
 #[derive(Default, Clone, Copy, Debug)]
 pub struct MptUpdateRow<F: Clone> {
     pub(crate) address: F,
-    pub(crate) storage_key: word::Word<F>,
+    pub(crate) storage_key: WordLoHi<F>,
     pub(crate) proof_type: F,
-    pub(crate) new_root: word::Word<F>,
-    pub(crate) old_root: word::Word<F>,
-    pub(crate) new_value: word::Word<F>,
-    pub(crate) old_value: word::Word<F>,
+    pub(crate) new_root: WordLoHi<F>,
+    pub(crate) old_root: WordLoHi<F>,
+    pub(crate) new_value: WordLoHi<F>,
+    pub(crate) old_value: WordLoHi<F>,
 }
 
 impl MptUpdates {
@@ -101,12 +101,12 @@ impl MptUpdates {
                 let (new_value, old_value) = update.value_assignments();
                 MptUpdateRow {
                     address: Value::known(update.key.address().to_scalar().unwrap()),
-                    storage_key: word::Word::<F>::from(update.key.storage_key()).into_value(),
+                    storage_key: WordLoHi::<F>::from(update.key.storage_key()).into_value(),
                     proof_type: Value::known(update.proof_type()),
-                    new_root: word::Word::<F>::from(new_root).into_value(),
-                    old_root: word::Word::<F>::from(old_root).into_value(),
-                    new_value: word::Word::<F>::from(new_value).into_value(),
-                    old_value: word::Word::<F>::from(old_value).into_value(),
+                    new_root: WordLoHi::<F>::from(new_root).into_value(),
+                    old_root: WordLoHi::<F>::from(old_root).into_value(),
+                    new_value: WordLoHi::<F>::from(new_value).into_value(),
+                    old_value: WordLoHi::<F>::from(old_value).into_value(),
                 }
             })
             .collect()

--- a/zkevm-circuits/src/witness/rw.rs
+++ b/zkevm-circuits/src/witness/rw.rs
@@ -11,7 +11,7 @@ use itertools::Itertools;
 
 use crate::{
     table::{AccountFieldTag, CallContextFieldTag, TxLogFieldTag, TxReceiptFieldTag},
-    util::{build_tx_log_address, word},
+    util::{build_tx_log_address, word::WordLoHi},
 };
 
 use super::MptUpdates;
@@ -267,10 +267,10 @@ pub struct RwRow<F> {
     pub(crate) id: F,
     pub(crate) address: F,
     pub(crate) field_tag: F,
-    pub(crate) storage_key: word::Word<F>,
-    pub(crate) value: word::Word<F>,
-    pub(crate) value_prev: word::Word<F>,
-    pub(crate) init_val: word::Word<F>,
+    pub(crate) storage_key: WordLoHi<F>,
+    pub(crate) value: WordLoHi<F>,
+    pub(crate) value_prev: WordLoHi<F>,
+    pub(crate) init_val: WordLoHi<F>,
 }
 
 impl<F: Field> RwRow<F> {
@@ -311,9 +311,9 @@ impl<F: Field> RwRow<Value<F>> {
             });
             inner.unwrap()
         };
-        let unwrap_w = |f: word::Word<Value<F>>| {
+        let unwrap_w = |f: WordLoHi<Value<F>>| {
             let (lo, hi) = f.into_lo_hi();
-            word::Word::new([unwrap_f(lo), unwrap_f(hi)])
+            WordLoHi::new([unwrap_f(lo), unwrap_f(hi)])
         };
 
         RwRow {
@@ -462,11 +462,11 @@ impl Rw {
             id: Value::known(F::from(self.id().unwrap_or_default() as u64)),
             address: Value::known(self.address().unwrap_or_default().to_scalar().unwrap()),
             field_tag: Value::known(F::from(self.field_tag().unwrap_or_default())),
-            storage_key: word::Word::from(self.storage_key().unwrap_or_default()).into_value(),
-            value: word::Word::from(self.value_assignment()).into_value(),
-            value_prev: word::Word::from(self.value_prev_assignment().unwrap_or_default())
+            storage_key: WordLoHi::from(self.storage_key().unwrap_or_default()).into_value(),
+            value: WordLoHi::from(self.value_assignment()).into_value(),
+            value_prev: WordLoHi::from(self.value_prev_assignment().unwrap_or_default())
                 .into_value(),
-            init_val: word::Word::from(self.committed_value_assignment().unwrap_or_default())
+            init_val: WordLoHi::from(self.committed_value_assignment().unwrap_or_default())
                 .into_value(),
         }
     }


### PR DESCRIPTION
### Description

Replacing Word with WordHiLo.

### Issue Link

#1736

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Refactor

### Contents

- Replace word::Word with WordLoHi
- Replace word::WordCell with WordLoHiCell

### Rationale

- WordLimbs and WordCell is used somewhere so couldn't go with that. 
- ZWord and CWord could be used, however, I saw that Word is actually an alias for Word2 ([source](https://github.com/privacy-scaling-explorations/zkevm-circuits/blob/7f356548dd6dd614289b9700a40fbc80c4949b47/zkevm-circuits/src/util/word.rs#L203)). Which is an alias of WordLimbs<2>. So Word2 could be better than ZWord or CWord, but I think WordHiLo is even better and makes the code more obvious, since we have hi-lo terminology in many places.

### How Has This Been Tested?

Built all packages locally.
