### PR TITLE
Rename Word::zero to Word::zero_expr

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -221,12 +221,12 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             cb.account_write(
                 call_callee_address.to_word(),
                 AccountFieldTag::Nonce,
-                Word::one(),
+                Word::one_expr(),
                 Word::zero_expr(),
                 Some(&mut reversion_info),
             );
             for (field_tag, value) in [
-                (CallContextFieldTag::Depth, Word::one()),
+                (CallContextFieldTag::Depth, Word::one_expr()),
                 (
                     CallContextFieldTag::CallerAddress,
                     tx.caller_address.to_word(),
@@ -251,8 +251,8 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                     CallContextFieldTag::LastCalleeReturnDataLength,
                     Word::zero_expr(),
                 ),
-                (CallContextFieldTag::IsRoot, Word::one()),
-                (CallContextFieldTag::IsCreate, Word::one()),
+                (CallContextFieldTag::IsRoot, Word::one_expr()),
+                (CallContextFieldTag::IsCreate, Word::one_expr()),
                 (
                     CallContextFieldTag::CodeHash,
                     cb.curr.state.code_hash.to_word(),
@@ -349,7 +349,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             |cb| {
                 // Setup first call's context.
                 for (field_tag, value) in [
-                    (CallContextFieldTag::Depth, Word::one()),
+                    (CallContextFieldTag::Depth, Word::one_expr()),
                     (
                         CallContextFieldTag::CallerAddress,
                         tx.caller_address.to_word(),
@@ -374,7 +374,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                         CallContextFieldTag::LastCalleeReturnDataLength,
                         Word::zero_expr(),
                     ),
-                    (CallContextFieldTag::IsRoot, Word::one()),
+                    (CallContextFieldTag::IsRoot, Word::one_expr()),
                     (
                         CallContextFieldTag::IsCreate,
                         Word::from_lo_unchecked(tx.is_create.expr()),

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -222,7 +222,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                 call_callee_address.to_word(),
                 AccountFieldTag::Nonce,
                 Word::one(),
-                Word::zero(),
+                Word::zero_expr(),
                 Some(&mut reversion_info),
             );
             for (field_tag, value) in [
@@ -235,21 +235,21 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                     CallContextFieldTag::CalleeAddress,
                     call_callee_address.to_word(),
                 ),
-                (CallContextFieldTag::CallDataOffset, Word::zero()),
+                (CallContextFieldTag::CallDataOffset, Word::zero_expr()),
                 (
                     CallContextFieldTag::CallDataLength,
                     Word::from_lo_unchecked(tx.call_data_length.expr()),
                 ),
                 (CallContextFieldTag::Value, tx.value.to_word()),
-                (CallContextFieldTag::IsStatic, Word::zero()),
-                (CallContextFieldTag::LastCalleeId, Word::zero()),
+                (CallContextFieldTag::IsStatic, Word::zero_expr()),
+                (CallContextFieldTag::LastCalleeId, Word::zero_expr()),
                 (
                     CallContextFieldTag::LastCalleeReturnDataOffset,
-                    Word::zero(),
+                    Word::zero_expr(),
                 ),
                 (
                     CallContextFieldTag::LastCalleeReturnDataLength,
-                    Word::zero(),
+                    Word::zero_expr(),
                 ),
                 (CallContextFieldTag::IsRoot, Word::one()),
                 (CallContextFieldTag::IsCreate, Word::one()),
@@ -358,21 +358,21 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                         CallContextFieldTag::CalleeAddress,
                         tx.callee_address.to_word(),
                     ),
-                    (CallContextFieldTag::CallDataOffset, Word::zero()),
+                    (CallContextFieldTag::CallDataOffset, Word::zero_expr()),
                     (
                         CallContextFieldTag::CallDataLength,
                         Word::from_lo_unchecked(tx.call_data_length.expr()),
                     ),
                     (CallContextFieldTag::Value, tx.value.to_word()),
-                    (CallContextFieldTag::IsStatic, Word::zero()),
-                    (CallContextFieldTag::LastCalleeId, Word::zero()),
+                    (CallContextFieldTag::IsStatic, Word::zero_expr()),
+                    (CallContextFieldTag::LastCalleeId, Word::zero_expr()),
                     (
                         CallContextFieldTag::LastCalleeReturnDataOffset,
-                        Word::zero(),
+                        Word::zero_expr(),
                     ),
                     (
                         CallContextFieldTag::LastCalleeReturnDataLength,
-                        Word::zero(),
+                        Word::zero_expr(),
                     ),
                     (CallContextFieldTag::IsRoot, Word::one()),
                     (

--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -540,7 +540,7 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
                     CallContextFieldTag::LastCalleeReturnDataOffset,
                     CallContextFieldTag::LastCalleeReturnDataLength,
                 ] {
-                    cb.call_context_lookup_write(None, field_tag, Word::zero());
+                    cb.call_context_lookup_write(None, field_tag, Word::zero_expr());
                 }
 
                 // For CALL opcode, it has an extra stack pop `value` (+1) and if the value is
@@ -588,7 +588,7 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
                 CallContextFieldTag::LastCalleeReturnDataOffset,
                 CallContextFieldTag::LastCalleeReturnDataLength,
             ] {
-                cb.call_context_lookup_write(None, field_tag, Word::zero());
+                cb.call_context_lookup_write(None, field_tag, Word::zero_expr());
             }
 
             cb.require_step_state_transition(StepStateTransition {
@@ -689,17 +689,17 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
                         CallContextFieldTag::IsStatic,
                         Word::from_lo_unchecked(or::expr([is_static.expr(), is_staticcall.expr()])),
                     ),
-                    (CallContextFieldTag::LastCalleeId, Word::zero()),
+                    (CallContextFieldTag::LastCalleeId, Word::zero_expr()),
                     (
                         CallContextFieldTag::LastCalleeReturnDataOffset,
-                        Word::zero(),
+                        Word::zero_expr(),
                     ),
                     (
                         CallContextFieldTag::LastCalleeReturnDataLength,
-                        Word::zero(),
+                        Word::zero_expr(),
                     ),
-                    (CallContextFieldTag::IsRoot, Word::zero()),
-                    (CallContextFieldTag::IsCreate, Word::zero()),
+                    (CallContextFieldTag::IsRoot, Word::zero_expr()),
+                    (CallContextFieldTag::IsCreate, Word::zero_expr()),
                     (
                         CallContextFieldTag::CodeHash,
                         call_gadget.callee_code_hash.to_word(),

--- a/zkevm-circuits/src/evm_circuit/execution/create.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/create.rs
@@ -342,7 +342,7 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                 cb.account_write(
                     contract_addr.to_word(),
                     AccountFieldTag::Nonce,
-                    Word::one(),
+                    Word::one_expr(),
                     Word::zero_expr(),
                     Some(&mut callee_reversion_info),
                 );

--- a/zkevm-circuits/src/evm_circuit/execution/create.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/create.rs
@@ -296,7 +296,7 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                 CallContextFieldTag::LastCalleeReturnDataOffset,
                 CallContextFieldTag::LastCalleeReturnDataLength,
             ] {
-                cb.call_context_lookup_write(None, field_tag, Word::zero());
+                cb.call_context_lookup_write(None, field_tag, Word::zero_expr());
             }
 
             cb.require_step_state_transition(StepStateTransition {
@@ -343,7 +343,7 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                     contract_addr.to_word(),
                     AccountFieldTag::Nonce,
                     Word::one(),
-                    Word::zero(),
+                    Word::zero_expr(),
                     Some(&mut callee_reversion_info),
                 );
 
@@ -420,7 +420,7 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                         CallContextFieldTag::LastCalleeReturnDataOffset,
                         CallContextFieldTag::LastCalleeReturnDataLength,
                     ] {
-                        cb.call_context_lookup_write(None, field_tag, Word::zero());
+                        cb.call_context_lookup_write(None, field_tag, Word::zero_expr());
                     }
                     cb.require_step_state_transition(StepStateTransition {
                         rw_counter: Delta(cb.rw_counter_offset()),
@@ -463,7 +463,7 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                     CallContextFieldTag::LastCalleeReturnDataOffset,
                     CallContextFieldTag::LastCalleeReturnDataLength,
                 ] {
-                    cb.call_context_lookup_write(None, field_tag, Word::zero());
+                    cb.call_context_lookup_write(None, field_tag, Word::zero_expr());
                 }
 
                 cb.require_step_state_transition(StepStateTransition {

--- a/zkevm-circuits/src/evm_circuit/execution/end_block.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/end_block.rs
@@ -74,7 +74,7 @@ impl<F: Field> ExecutionGadget<F> for EndBlockGadget<F> {
                 total_txs.expr() + 1.expr(),
                 TxContextFieldTag::CallerAddress,
                 None,
-                Word::zero(),
+                Word::zero_expr(),
             );
             // Since every tx lookup done in the EVM circuit must succeed
             // and uses a unique tx_id, we know that at

--- a/zkevm-circuits/src/evm_circuit/execution/error_precompile_failed.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_precompile_failed.rs
@@ -87,7 +87,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorPrecompileFailedGadget<F> {
         cb.stack_pop(cd_length.to_word());
         cb.stack_pop(rd_offset.to_word());
         cb.stack_pop(rd_length.to_word());
-        cb.stack_push(Word::zero());
+        cb.stack_push(Word::zero_expr());
 
         for (field_tag, value) in [
             (CallContextFieldTag::LastCalleeId, callee_call_id.expr()),

--- a/zkevm-circuits/src/evm_circuit/execution/error_write_protection.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_write_protection.rs
@@ -73,7 +73,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorWriteProtectionGadget<F> {
         });
 
         // current call context is readonly
-        cb.call_context_lookup_read(None, CallContextFieldTag::IsStatic, Word::one());
+        cb.call_context_lookup_read(None, CallContextFieldTag::IsStatic, Word::one_expr());
 
         // constrain not root call as at least one previous staticcall preset.
         cb.require_zero(

--- a/zkevm-circuits/src/evm_circuit/execution/stop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/stop.rs
@@ -63,7 +63,7 @@ impl<F: Field> ExecutionGadget<F> for StopGadget<F> {
         );
 
         // Call ends with STOP must be successful
-        cb.call_context_lookup_read(None, CallContextFieldTag::IsSuccess, Word::one());
+        cb.call_context_lookup_read(None, CallContextFieldTag::IsSuccess, Word::one_expr());
 
         let is_to_end_tx = cb.next.execution_state_selector([ExecutionState::EndTx]);
         cb.require_equal(

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -429,7 +429,7 @@ impl<F: Field> TransferToGadget<F> {
                     receiver_address.clone(),
                     AccountFieldTag::CodeHash,
                     cb.empty_code_hash(),
-                    Word::zero(),
+                    Word::zero_expr(),
                     reversion_info,
                 );
             },
@@ -767,7 +767,7 @@ impl<F: Field, MemAddrGadget: CommonMemoryAddressGadget<F>, const IS_SUCCESS_CAL
         cb.stack_push(if IS_SUCCESS_CALL {
             Word::from_lo_unchecked(is_success.expr()) // is_success is bool
         } else {
-            Word::zero()
+            Word::zero_expr()
         });
 
         // Recomposition of random linear combination to integer
@@ -1097,7 +1097,7 @@ impl<F: Field> CommonErrorGadget<F> {
         let rw_counter_end_of_reversion = cb.query_word_unchecked(); // rw_counter_end_of_reversion just used for read lookup, therefore skip range check
 
         // current call must be failed.
-        cb.call_context_lookup_read(None, CallContextFieldTag::IsSuccess, Word::zero());
+        cb.call_context_lookup_read(None, CallContextFieldTag::IsSuccess, Word::zero_expr());
 
         cb.call_context_lookup_read(
             None,

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -165,7 +165,7 @@ pub(crate) trait ConstrainBuilderCommon<F: Field> {
     }
 
     fn require_zero_word(&mut self, name: &'static str, word: Word<Expression<F>>) {
-        self.require_equal_word(name, word, Word::zero());
+        self.require_equal_word(name, word, Word::zero_expr());
     }
 
     fn require_equal_word(
@@ -865,10 +865,10 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 tx_id,
                 account_address.compress(),
                 0.expr(),
-                Word::zero(),
+                Word::zero_expr(),
                 Word::from_lo_unchecked(value),
                 Word::from_lo_unchecked(value_prev),
-                Word::zero(),
+                Word::zero_expr(),
             ),
             reversion_info,
         );
@@ -888,10 +888,10 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 tx_id,
                 account_address.compress(),
                 0.expr(),
-                Word::zero(),
+                Word::zero_expr(),
                 Word::from_lo_unchecked(value.clone()),
                 Word::from_lo_unchecked(value),
-                Word::zero(),
+                Word::zero_expr(),
             ),
         );
     }
@@ -914,7 +914,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 storage_key,
                 value,
                 value_prev,
-                Word::zero(),
+                Word::zero_expr(),
             ),
             reversion_info,
         );
@@ -938,7 +938,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 storage_key,
                 value.clone(),
                 value,
-                Word::zero(),
+                Word::zero_expr(),
             ),
         );
     }
@@ -954,10 +954,10 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 tx_id,
                 0.expr(),
                 0.expr(),
-                Word::zero(),
+                Word::zero_expr(),
                 value.clone(),
                 value,
-                Word::zero(),
+                Word::zero_expr(),
             ),
         );
     }
@@ -976,10 +976,10 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 tx_id,
                 0.expr(),
                 0.expr(),
-                Word::zero(),
+                Word::zero_expr(),
                 value,
                 value_prev,
-                Word::zero(),
+                Word::zero_expr(),
             ),
             reversion_info,
         );
@@ -1000,10 +1000,10 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 0.expr(),
                 account_address.compress(),
                 field_tag.expr(),
-                Word::zero(),
+                Word::zero_expr(),
                 value.clone(),
                 value,
-                Word::zero(),
+                Word::zero_expr(),
             ),
         );
     }
@@ -1023,10 +1023,10 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 0.expr(),
                 account_address.compress(),
                 field_tag.expr(),
-                Word::zero(),
+                Word::zero_expr(),
                 value,
                 value_prev,
-                Word::zero(),
+                Word::zero_expr(),
             ),
             reversion_info,
         );
@@ -1127,10 +1127,10 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 call_id.unwrap_or_else(|| self.curr.state.call_id.expr()),
                 0.expr(),
                 field_tag.expr(),
-                Word::zero(),
+                Word::zero_expr(),
                 value,
-                Word::zero(),
-                Word::zero(),
+                Word::zero_expr(),
+                Word::zero_expr(),
             ),
         );
     }
@@ -1153,10 +1153,10 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 call_id.unwrap_or_else(|| self.curr.state.call_id.expr()),
                 0.expr(),
                 field_tag.expr(),
-                Word::zero(),
+                Word::zero_expr(),
                 value,
-                Word::zero(),
-                Word::zero(),
+                Word::zero_expr(),
+                Word::zero_expr(),
             ),
         );
     }
@@ -1175,10 +1175,10 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 call_id.unwrap_or_else(|| self.curr.state.call_id.expr()),
                 0.expr(),
                 field_tag.expr(),
-                Word::zero(),
+                Word::zero_expr(),
                 value,
-                Word::zero(),
-                Word::zero(),
+                Word::zero_expr(),
+                Word::zero_expr(),
             ),
         );
     }
@@ -1261,10 +1261,10 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 self.curr.state.call_id.expr(),
                 self.curr.state.stack_pointer.expr() + stack_pointer_offset,
                 0.expr(),
-                Word::zero(),
+                Word::zero_expr(),
                 value,
-                Word::zero(),
-                Word::zero(),
+                Word::zero_expr(),
+                Word::zero_expr(),
             ),
         );
     }
@@ -1286,11 +1286,11 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 call_id.unwrap_or_else(|| self.curr.state.call_id.expr()),
                 memory_address,
                 0.expr(),
-                Word::zero(),
+                Word::zero_expr(),
                 // TODO assure range check since write=true also possible
                 Word::from_lo_unchecked(byte),
-                Word::zero(),
-                Word::zero(),
+                Word::zero_expr(),
+                Word::zero_expr(),
             ),
         );
     }
@@ -1311,10 +1311,10 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 tx_id,
                 build_tx_log_expression(index, field_tag.expr(), log_id),
                 0.expr(),
-                Word::zero(),
+                Word::zero_expr(),
                 value,
-                Word::zero(),
-                Word::zero(),
+                Word::zero_expr(),
+                Word::zero_expr(),
             ),
         );
     }
@@ -1335,11 +1335,11 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 tx_id,
                 0.expr(),
                 tag.expr(),
-                Word::zero(),
+                Word::zero_expr(),
                 // TODO assure range check since write=true also possible
                 Word::from_lo_unchecked(value),
-                Word::zero(),
-                Word::zero(),
+                Word::zero_expr(),
+                Word::zero_expr(),
             ),
         );
     }
@@ -1356,10 +1356,10 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 0.expr(),
                 0.expr(),
                 0.expr(),
-                Word::zero(),
-                Word::zero(),
-                Word::zero(),
-                Word::zero(),
+                Word::zero_expr(),
+                Word::zero_expr(),
+                Word::zero_expr(),
+                Word::zero_expr(),
             ),
         );
     }

--- a/zkevm-circuits/src/mpt_circuit/account_leaf.rs
+++ b/zkevm-circuits/src/mpt_circuit/account_leaf.rs
@@ -498,10 +498,10 @@ impl<F: Field> AccountLeafConfig<F> {
 
         // Key
         let mut key_rlc = vec![0.scalar(); 2];
-        let mut nonce = vec![Word::zero_f(); 2];
-        let mut balance = vec![Word::zero_f(); 2];
-        let mut storage = vec![Word::zero_f(); 2];
-        let mut codehash = vec![Word::zero_f(); 2];
+        let mut nonce = vec![Word::zero(); 2];
+        let mut balance = vec![Word::zero(); 2];
+        let mut storage = vec![Word::zero(); 2];
+        let mut codehash = vec![Word::zero(); 2];
         let mut key_data = vec![KeyDataWitness::default(); 2];
         let mut parent_data = vec![ParentDataWitness::default(); 2];
         for is_s in [true, false] {
@@ -671,11 +671,11 @@ impl<F: Field> AccountLeafConfig<F> {
         } else if is_codehash_mod {
             (MPTProofType::CodeHashChanged, codehash)
         } else if is_account_delete_mod {
-            (MPTProofType::AccountDestructed, vec![Word::zero_f(); 2])
+            (MPTProofType::AccountDestructed, vec![Word::zero(); 2])
         } else if is_non_existing_proof {
-            (MPTProofType::AccountDoesNotExist, vec![Word::zero_f(); 2])
+            (MPTProofType::AccountDoesNotExist, vec![Word::zero(); 2])
         } else {
-            (MPTProofType::Disabled, vec![Word::zero_f(); 2])
+            (MPTProofType::Disabled, vec![Word::zero(); 2])
         };
 
         if account.is_mod_extension[0] || account.is_mod_extension[1] {
@@ -689,7 +689,7 @@ impl<F: Field> AccountLeafConfig<F> {
 
         let mut new_value = value[false.idx()];
         if parent_data[false.idx()].is_placeholder {
-            new_value = word::Word::zero_f();
+            new_value = word::Word::zero();
         }
         mpt_config.mpt_table.assign_cached(
             region,
@@ -698,7 +698,7 @@ impl<F: Field> AccountLeafConfig<F> {
                 address: Value::known(from_bytes::value(
                     &account.address.iter().cloned().rev().collect::<Vec<_>>(),
                 )),
-                storage_key: word::Word::zero_f().into_value(),
+                storage_key: word::Word::zero().into_value(),
                 proof_type: Value::known(proof_type.scalar()),
                 new_root: main_data.new_root.into_value(),
                 old_root: main_data.old_root.into_value(),

--- a/zkevm-circuits/src/mpt_circuit/account_leaf.rs
+++ b/zkevm-circuits/src/mpt_circuit/account_leaf.rs
@@ -148,10 +148,10 @@ impl<F: Field> AccountLeafConfig<F> {
             require!(config.main_data.is_below_account => false);
 
             let mut key_rlc = vec![0.expr(); 2];
-            let mut nonce = vec![Word::zero(); 2];
-            let mut balance = vec![Word::zero(); 2];
-            let mut storage = vec![Word::zero(); 2];
-            let mut codehash = vec![Word::zero(); 2];
+            let mut nonce = vec![Word::zero_expr(); 2];
+            let mut balance = vec![Word::zero_expr(); 2];
+            let mut storage = vec![Word::zero_expr(); 2];
+            let mut codehash = vec![Word::zero_expr(); 2];
             let mut leaf_no_key_rlc = vec![0.expr(); 2];
             let mut leaf_no_key_rlc_mult = vec![0.expr(); 2];
             let mut value_list_num_bytes = vec![0.expr(); 2];
@@ -431,7 +431,7 @@ impl<F: Field> AccountLeafConfig<F> {
                     &mut cb.base,
                     address.clone(),
                     proof_type.clone(),
-                    Word::zero(),
+                    Word::zero_expr(),
                     config.main_data.new_root.expr(),
                     config.main_data.old_root.expr(),
                     Word::<Expression<F>>::new([new_value_lo, new_value_hi]),
@@ -443,10 +443,10 @@ impl<F: Field> AccountLeafConfig<F> {
                     &mut cb.base,
                     address,
                     proof_type,
-                    Word::zero(),
+                    Word::zero_expr(),
                     config.main_data.new_root.expr(),
                     config.main_data.old_root.expr(),
-                    Word::zero(),
+                    Word::zero_expr(),
                     Word::<Expression<F>>::new([old_value_lo, old_value_hi]),
                 );
             }};

--- a/zkevm-circuits/src/mpt_circuit/branch.rs
+++ b/zkevm-circuits/src/mpt_circuit/branch.rs
@@ -351,7 +351,7 @@ impl<F: Field> BranchGadget<F> {
         let key_mult_post_branch = *key_mult * mult;
 
         // Set the branch we'll take
-        let mut mod_node_hash_word = [word::Word::zero_f(); 2];
+        let mut mod_node_hash_word = [word::Word::zero(); 2];
         let mut mod_node_hash_rlc = [0.scalar(); 2];
         for is_s in [true, false] {
             (

--- a/zkevm-circuits/src/mpt_circuit/extension.rs
+++ b/zkevm-circuits/src/mpt_circuit/extension.rs
@@ -100,7 +100,7 @@ impl<F: Field> ExtensionGadget<F> {
             require!((FixedTableTag::ExtOddKey.expr(), first_byte, config.is_key_part_odd.expr()) =>> @FIXED);
 
             let mut branch_rlp_rlc = vec![0.expr(); 2];
-            let mut branch_rlp_word = vec![Word::zero(); 2];
+            let mut branch_rlp_word = vec![Word::zero_expr(); 2];
             for is_s in [true, false] {
                 // In C we have the key nibbles, we check below only for S.
                 if is_s {

--- a/zkevm-circuits/src/mpt_circuit/extension_branch.rs
+++ b/zkevm-circuits/src/mpt_circuit/extension_branch.rs
@@ -158,7 +158,7 @@ impl<F: Field> ExtensionBranchConfig<F> {
                         branch.mod_rlc[is_s.idx()].expr(),
                         false.expr(),
                         false.expr(),
-                        Word::zero(),
+                        Word::zero_expr(),
                     );
                  } elsex {
                     KeyData::store(

--- a/zkevm-circuits/src/mpt_circuit/extension_branch.rs
+++ b/zkevm-circuits/src/mpt_circuit/extension_branch.rs
@@ -287,7 +287,7 @@ impl<F: Field> ExtensionBranchConfig<F> {
                     mod_node_hash_rlc[is_s.idx()],
                     false,
                     false,
-                    Word::zero_f(),
+                    Word::zero(),
                 )?;
             } else {
                 KeyData::witness_store(

--- a/zkevm-circuits/src/mpt_circuit/helpers.rs
+++ b/zkevm-circuits/src/mpt_circuit/helpers.rs
@@ -1082,7 +1082,7 @@ impl<F: Field> IsPlaceholderLeafGadget<F> {
                 ]),
             );
             let is_nil_in_branch_at_mod_index =
-                IsEqualWordGadget::construct(&mut cb.base, &parent_word, &Word::zero());
+                IsEqualWordGadget::construct(&mut cb.base, &parent_word, &Word::zero_expr());
 
             Self {
                 is_empty_trie,

--- a/zkevm-circuits/src/mpt_circuit/start.rs
+++ b/zkevm-circuits/src/mpt_circuit/start.rs
@@ -40,7 +40,7 @@ impl<F: Field> StartConfig<F> {
 
             config.proof_type = cb.query_cell();
 
-            let mut root = vec![Word::zero(); 2];
+            let mut root = vec![Word::zero_expr(); 2];
             for is_s in [true, false] {
                 root[is_s.idx()] = root_items[is_s.idx()].word();
             }

--- a/zkevm-circuits/src/mpt_circuit/start.rs
+++ b/zkevm-circuits/src/mpt_circuit/start.rs
@@ -96,7 +96,7 @@ impl<F: Field> StartConfig<F> {
         self.proof_type
             .assign(region, offset, start.proof_type.scalar())?;
 
-        let mut root = vec![Word::zero_f(); 2];
+        let mut root = vec![Word::zero(); 2];
         for is_s in [true, false] {
             root[is_s.idx()] = rlp_values[is_s.idx()].word();
         }

--- a/zkevm-circuits/src/mpt_circuit/storage_leaf.rs
+++ b/zkevm-circuits/src/mpt_circuit/storage_leaf.rs
@@ -104,7 +104,7 @@ impl<F: Field> StorageLeafConfig<F> {
             require!(config.main_data.is_below_account => true);
 
             let mut key_rlc = vec![0.expr(); 2];
-            let mut value_word = vec![Word::zero(); 2];
+            let mut value_word = vec![Word::zero_expr(); 2];
             let mut value_rlp_rlc = vec![0.expr(); 2];
             let mut value_rlp_rlc_mult = vec![0.expr(); 2];
 
@@ -179,7 +179,7 @@ impl<F: Field> StorageLeafConfig<F> {
 
                     // Placeholder leaves default to value `0`.
                     ifx! {is_placeholder_leaf => {
-                        require!(value_word[is_s.idx()] => Word::zero());
+                        require!(value_word[is_s.idx()] => Word::zero_expr());
                     }}
 
                     // Make sure the RLP encoding is correct.
@@ -207,11 +207,11 @@ impl<F: Field> StorageLeafConfig<F> {
                 ParentData::store(
                     cb,
                     &mut ctx.memory[parent_memory(is_s)],
-                    word::Word::zero(),
+                    word::Word::zero_expr(),
                     0.expr(),
                     true.expr(),
                     false.expr(),
-                    word::Word::zero(),
+                    word::Word::zero_expr(),
                 );
             }
 
@@ -332,7 +332,7 @@ impl<F: Field> StorageLeafConfig<F> {
                     address_item.word(),
                     config.main_data.new_root.expr(),
                     config.main_data.old_root.expr(),
-                    Word::zero(),
+                    Word::zero_expr(),
                     value_word[true.idx()].clone(),
                 );
             }};

--- a/zkevm-circuits/src/mpt_circuit/storage_leaf.rs
+++ b/zkevm-circuits/src/mpt_circuit/storage_leaf.rs
@@ -373,7 +373,7 @@ impl<F: Field> StorageLeafConfig<F> {
         let mut key_data = vec![KeyDataWitness::default(); 2];
         let mut parent_data = vec![ParentDataWitness::default(); 2];
         let mut key_rlc = vec![0.scalar(); 2];
-        let mut value_word = vec![Word::zero_f(); 2];
+        let mut value_word = vec![Word::zero(); 2];
         for is_s in [true, false] {
             self.is_mod_extension[is_s.idx()].assign(
                 region,
@@ -532,7 +532,7 @@ impl<F: Field> StorageLeafConfig<F> {
 
         let mut new_value = value_word[false.idx()];
         if parent_data[false.idx()].is_placeholder {
-            new_value = word::Word::zero_f();
+            new_value = word::Word::zero();
         }
         mpt_config.mpt_table.assign_cached(
             region,

--- a/zkevm-circuits/src/util/word.rs
+++ b/zkevm-circuits/src/util/word.rs
@@ -360,7 +360,7 @@ impl<F: Field> Word<F> {
     }
 
     /// one word
-    pub fn one_f() -> Self {
+    pub fn one() -> Self {
         Self::new([F::ONE, F::ZERO])
     }
 

--- a/zkevm-circuits/src/util/word.rs
+++ b/zkevm-circuits/src/util/word.rs
@@ -355,7 +355,7 @@ impl<F: Field, T: Expr<F> + Clone> WordExpr<F> for Word<T> {
 
 impl<F: Field> Word<F> {
     /// zero word
-    pub fn zero_f() -> Self {
+    pub fn zero() -> Self {
         Self::new([F::ZERO, F::ZERO])
     }
 

--- a/zkevm-circuits/src/util/word.rs
+++ b/zkevm-circuits/src/util/word.rs
@@ -377,7 +377,7 @@ impl<F: Field> Word<Expression<F>> {
         Self::new([lo, 0.expr()])
     }
     /// zero word
-    pub fn zero() -> Self {
+    pub fn zero_expr() -> Self {
         Self::new([0.expr(), 0.expr()])
     }
 

--- a/zkevm-circuits/src/util/word.rs
+++ b/zkevm-circuits/src/util/word.rs
@@ -382,7 +382,7 @@ impl<F: Field> Word<Expression<F>> {
     }
 
     /// one word
-    pub fn one() -> Self {
+    pub fn one_expr() -> Self {
         Self::new([1.expr(), 0.expr()])
     }
 


### PR DESCRIPTION
### Description

Address https://github.com/privacy-scaling-explorations/zkevm-circuits/pull/1746#issuecomment-1918615874, we rename the constructors for zero word and one word.



### Type of change

- Refactor

### Contents

- Rename Word<Expression<F>>::zero to zero_expr
- Rename Word<Expression<F>>::one to one_expr
- Rename Word<F>::zero_f to one
- Rename Word<F>::one_f to one
