### PR TITLE
upgrade halo2 ecosystem dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,7 +962,7 @@ checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 [[package]]
 name = "ecc"
 version = "0.1.0"
-source = "git+https://github.com/privacy-scaling-explorations/halo2wrong?tag=v2023_04_20#f72db265aa3cebe297c9b9816e940d0e1d400886"
+source = "git+https://github.com/privacy-scaling-explorations/halo2wrong?tag=v2024_01_31#1fe10a798edde7a0686248c29cae96ca79b710ae"
 dependencies = [
  "integer",
  "num-bigint",
@@ -975,7 +975,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.1.0"
-source = "git+https://github.com/privacy-scaling-explorations/halo2wrong?tag=v2023_04_20#f72db265aa3cebe297c9b9816e940d0e1d400886"
+source = "git+https://github.com/privacy-scaling-explorations/halo2wrong?tag=v2024_01_31#1fe10a798edde7a0686248c29cae96ca79b710ae"
 dependencies = [
  "ecc",
  "num-bigint",
@@ -1803,8 +1803,8 @@ dependencies = [
 
 [[package]]
 name = "halo2_proofs"
-version = "0.2.0"
-source = "git+https://github.com/privacy-scaling-explorations/halo2.git?tag=v2023_04_20#be955686f86eb618f55d2320c0e042485b313d22"
+version = "0.3.0"
+source = "git+https://github.com/privacy-scaling-explorations/halo2.git?tag=v0.3.0#73408a140737d8336490452193b21f5a7a94e7de"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -1819,18 +1819,22 @@ dependencies = [
 
 [[package]]
 name = "halo2curves"
-version = "0.3.2"
-source = "git+https://github.com/privacy-scaling-explorations/halo2curves?tag=0.3.2#9f5c50810bbefe779ee5cf1d852b2fe85dc35d5e"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3675880dc0cc7cd468943266297198a28f88210ba60ca5e0e04d121edf86b46"
 dependencies = [
+ "blake2b_simd",
  "ff",
  "group",
  "lazy_static",
  "num-bigint",
  "num-traits",
+ "pairing",
  "pasta_curves",
  "paste",
  "rand",
  "rand_core",
+ "rayon",
  "static_assertions",
  "subtle",
 ]
@@ -1838,7 +1842,7 @@ dependencies = [
 [[package]]
 name = "halo2wrong"
 version = "0.1.0"
-source = "git+https://github.com/privacy-scaling-explorations/halo2wrong?tag=v2023_04_20#f72db265aa3cebe297c9b9816e940d0e1d400886"
+source = "git+https://github.com/privacy-scaling-explorations/halo2wrong?tag=v2024_01_31#1fe10a798edde7a0686248c29cae96ca79b710ae"
 dependencies = [
  "halo2_proofs",
  "num-bigint",
@@ -1865,15 +1869,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -2161,7 +2156,7 @@ dependencies = [
 [[package]]
 name = "integer"
 version = "0.1.0"
-source = "git+https://github.com/privacy-scaling-explorations/halo2wrong?tag=v2023_04_20#f72db265aa3cebe297c9b9816e940d0e1d400886"
+source = "git+https://github.com/privacy-scaling-explorations/halo2wrong?tag=v2024_01_31#1fe10a798edde7a0686248c29cae96ca79b710ae"
 dependencies = [
  "maingate",
  "num-bigint",
@@ -2458,7 +2453,7 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 [[package]]
 name = "maingate"
 version = "0.1.0"
-source = "git+https://github.com/privacy-scaling-explorations/halo2wrong?tag=v2023_04_20#f72db265aa3cebe297c9b9816e940d0e1d400886"
+source = "git+https://github.com/privacy-scaling-explorations/halo2wrong?tag=v2024_01_31#1fe10a798edde7a0686248c29cae96ca79b710ae"
 dependencies = [
  "halo2wrong",
  "num-bigint",
@@ -2817,6 +2812,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
+name = "pairing"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
+dependencies = [
+ "group",
+]
+
+[[package]]
 name = "parity-scale-codec"
 version = "3.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3107,7 +3111,7 @@ checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
 [[package]]
 name = "poseidon"
 version = "0.2.0"
-source = "git+https://github.com/privacy-scaling-explorations/poseidon.git?tag=v2023_04_20#807f8f555313f726ca03bdf941f798098f488ba4"
+source = "git+https://github.com/privacy-scaling-explorations/poseidon?tag=v2024_01_31#d29f35d9744e0c58b63679a15730ff2fab470ef2"
 dependencies = [
  "halo2curves",
  "subtle",
@@ -3430,19 +3434,22 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "2.3.1"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73d84c8f9836efb0f5f5f8de4700a953c4e1f3119e5cfcb0aad8e5be73daf991"
+checksum = "68f4ca8ae0345104523b4af1a8a7ea97cfa1865cdb7a7c25d23c1a18d9b48598"
 dependencies = [
- "arrayref",
  "auto_impl",
- "bytes",
- "hashbrown 0.13.2",
- "num_enum 0.5.11",
- "primitive-types",
- "revm_precompiles",
- "rlp",
- "sha3 0.10.8",
+ "revm-interpreter",
+ "revm-precompile",
+]
+
+[[package]]
+name = "revm-interpreter"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f959cafdf64a7f89b014fa73dc2325001cf654b3d9400260b212d19a2ebe3da0"
+dependencies = [
+ "revm-primitives",
 ]
 
 [[package]]
@@ -3474,24 +3481,6 @@ dependencies = [
  "enumn",
  "hashbrown 0.14.3",
  "hex",
-]
-
-[[package]]
-name = "revm_precompiles"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0353d456ef3e989dc9190f42c6020f09bc2025930c37895826029304413204b5"
-dependencies = [
- "bytes",
- "hashbrown 0.13.2",
- "num",
- "once_cell",
- "primitive-types",
- "ripemd",
- "secp256k1",
- "sha2 0.10.8",
- "sha3 0.10.8",
- "substrate-bn",
 ]
 
 [[package]]
@@ -3756,24 +3745,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "secp256k1"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1629c9c557ef9b293568b338dddfc8208c98a18c59d722a9d53f859d9c9b62"
-dependencies = [
- "secp256k1-sys",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83080e2c2fc1006e625be82e5d1eb6a43b7fd9578b617fcc55814daf286bba4b"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "security-framework"
 version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4005,10 +3976,9 @@ checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "snark-verifier"
-version = "0.1.0"
-source = "git+https://github.com/privacy-scaling-explorations/snark-verifier?tag=v2023_04_20#e5d5e4a6ccff2bba71baf77ab7a12b124d6364a1"
+version = "0.1.1"
+source = "git+https://github.com/privacy-scaling-explorations/snark-verifier?tag=v2024_01_31#946536fc01901db93a3e7cdb8a7359a7ef675b55"
 dependencies = [
- "bytes",
  "ecc",
  "halo2_proofs",
  "halo2curves",
@@ -4019,10 +3989,8 @@ dependencies = [
  "num-integer",
  "num-traits",
  "poseidon",
- "primitive-types",
  "rand",
  "revm",
- "rlp",
  "sha3 0.10.8",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [patch.crates-io]
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_04_20" }
+halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v0.3.0" }
 
 # Definition of benchmarks profile to use.
 [profile.bench]

--- a/bus-mapping/Cargo.toml
+++ b/bus-mapping/Cargo.toml
@@ -12,7 +12,7 @@ mock = { path = "../mock", optional = true }
 
 ethers-core = "=2.0.10"
 ethers-providers = "=2.0.10"
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_04_20" }
+halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v0.3.0" }
 itertools = "0.10"
 lazy_static = "1.4"
 log = "0.4.14"
@@ -21,7 +21,7 @@ serde_json = "1.0.66"
 strum = "0.24"
 strum_macros = "0.24"
 revm-precompile = { version = "=2.2.0", default-features = false, optional = true }
- 
+
 [dev-dependencies]
 hex = "0.4.3"
 pretty_assertions = "1.0.0"

--- a/circuit-benchmarks/Cargo.toml
+++ b/circuit-benchmarks/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_04_20" }
+halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v0.3.0" }
 ark-std = { version = "0.3", features = ["print-trace"] }
 zkevm-circuits = { path = "../zkevm-circuits", features = ["test-circuits"] }
 bus-mapping = { path = "../bus-mapping",  features = ["test"] }

--- a/eth-types/Cargo.toml
+++ b/eth-types/Cargo.toml
@@ -10,7 +10,7 @@ ethers-core = "=2.0.10"
 ethers-signers = "=2.0.10"
 hex = "0.4"
 lazy_static = "1.4"
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_04_20" }
+halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v0.3.0" }
 regex = "1.5.4"
 serde = {version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.66"

--- a/gadgets/Cargo.toml
+++ b/gadgets/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["The appliedzkp team"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_04_20" }
+halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v0.3.0" }
 sha3 = "0.7.2"
 eth-types = { path = "../eth-types" }
 digest = "0.7.6"

--- a/gadgets/src/batched_is_zero.rs
+++ b/gadgets/src/batched_is_zero.rs
@@ -242,7 +242,7 @@ mod test {
         };
         let k = 4;
         let prover = MockProver::<Fr>::run(k, &circuit, vec![]).unwrap();
-        prover.assert_satisfied_par()
+        prover.assert_satisfied()
     }
 
     #[test]

--- a/gadgets/src/is_zero.rs
+++ b/gadgets/src/is_zero.rs
@@ -171,7 +171,7 @@ mod test {
                 _marker: PhantomData,
             };
             let prover = MockProver::<Fp>::run(k, &circuit, vec![]).unwrap();
-            prover.assert_satisfied_par()
+            prover.assert_satisfied()
         }};
     }
 
@@ -188,7 +188,7 @@ mod test {
                 _marker: PhantomData,
             };
             let prover = MockProver::<Fp>::run(k, &circuit, vec![]).unwrap();
-            assert!(prover.verify_par().is_err());
+            assert!(prover.verify().is_err());
         }};
     }
 

--- a/gadgets/src/mul_add.rs
+++ b/gadgets/src/mul_add.rs
@@ -401,7 +401,7 @@ mod test {
                 _marker: PhantomData,
             };
             let prover = MockProver::<Fp>::run(k, &circuit, vec![]).unwrap();
-            prover.assert_satisfied_par()
+            prover.assert_satisfied()
         }};
     }
 

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -19,7 +19,7 @@ url = "2.2.2"
 pretty_assertions = "1.0.0"
 log = "0.4.14"
 env_logger = "0.9"
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_04_20" }
+halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v0.3.0" }
 rand_chacha = "0.3"
 paste = "1.0"
 rand_xorshift = "0.3.0"

--- a/integration-tests/src/integration_test_circuits.rs
+++ b/integration-tests/src/integration_test_circuits.rs
@@ -340,7 +340,7 @@ impl<C: SubCircuit<Fr> + Circuit<Fr>> IntegrationTest<C> {
         self.test_variadic(&mock_prover);
 
         mock_prover
-            .verify_par()
+            .verify()
             .expect("mock prover verification failed");
     }
 
@@ -465,7 +465,7 @@ impl<C: SubCircuit<Fr> + Circuit<Fr>> IntegrationTest<C> {
                         .unwrap();
                 self.test_root_variadic(&mock_prover);
                 mock_prover
-                    .verify_par()
+                    .verify()
                     .expect("mock prover verification failed");
             }
         } else {

--- a/light-client-poc/Cargo.toml
+++ b/light-client-poc/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }
 zkevm-circuits = { path = "../zkevm-circuits", features=["test-circuits"]}
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_04_20" }
+halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v0.3.0" }
 eyre = { version  = "0.6.8" }
 hex = "0.4.3"
 num_enum = "0.6.1"

--- a/light-client-poc/src/circuit/prover.rs
+++ b/light-client-poc/src/circuit/prover.rs
@@ -99,7 +99,7 @@ impl StateUpdateCircuit<Fr> {
 
         let prover =
             MockProver::<Fr>::run(self.degree as u32, self, vec![public_inputs.0]).unwrap();
-        prover.assert_satisfied_at_rows_par(0..num_rows, 0..num_rows);
+        prover.assert_satisfied_at_rows(0..num_rows, 0..num_rows);
     }
 
     pub fn prove(self, keys: &StateUpdateCircuitKeys) -> Result<Vec<u8>> {

--- a/testool/Cargo.toml
+++ b/testool/Cargo.toml
@@ -32,7 +32,7 @@ yaml-rust = "0.4.5"
 zkevm-circuits = { path="../zkevm-circuits", features=["test-util", "test-circuits"] }
 rand_chacha = "0.3"
 rand = "0.8"
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_04_20" }
+halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v0.3.0" }
 urlencoding = "2.1.2"
 
 

--- a/testool/src/statetest/executor.rs
+++ b/testool/src/statetest/executor.rs
@@ -382,7 +382,7 @@ pub fn run_test(
 
         let prover = MockProver::run(k, &circuit, instance).unwrap();
         prover
-            .verify_par()
+            .verify()
             .map_err(|err| StateTestError::CircuitUnsatisfied {
                 num_failure: err.len(),
                 first_failure: err[0].to_string(),

--- a/zkevm-circuits/Cargo.toml
+++ b/zkevm-circuits/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", features = ["circuit-params"], tag = "v2023_04_20" }
+halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", features = ["circuit-params"], tag = "v0.3.0" }
 num = "0.4"
 sha3 = "0.10"
 array-init = "2.0.0"
@@ -26,14 +26,14 @@ itertools = "0.10.3"
 lazy_static = "1.4"
 log = "0.4"
 env_logger = "0.9"
-ecdsa = { git = "https://github.com/privacy-scaling-explorations/halo2wrong", tag = "v2023_04_20" }
-ecc =       { git = "https://github.com/privacy-scaling-explorations/halo2wrong", tag = "v2023_04_20" }
-maingate =  { git = "https://github.com/privacy-scaling-explorations/halo2wrong", tag = "v2023_04_20" }
-integer =   { git = "https://github.com/privacy-scaling-explorations/halo2wrong", tag = "v2023_04_20" }
+ecdsa = { git = "https://github.com/privacy-scaling-explorations/halo2wrong", tag = "v2024_01_31" }
+ecc =       { git = "https://github.com/privacy-scaling-explorations/halo2wrong", tag = "v2024_01_31" }
+maingate =  { git = "https://github.com/privacy-scaling-explorations/halo2wrong", tag = "v2024_01_31" }
+integer =   { git = "https://github.com/privacy-scaling-explorations/halo2wrong", tag = "v2024_01_31" }
 libsecp256k1 = "0.7"
 num-bigint = { version = "0.4" }
 rand_chacha = "0.3"
-snark-verifier = { git = "https://github.com/privacy-scaling-explorations/snark-verifier", tag = "v2023_04_20", default-features = false, features = ["loader_halo2", "system_halo2", "loader_evm"], optional = true }
+snark-verifier = { git = "https://github.com/privacy-scaling-explorations/snark-verifier", tag = "v2024_01_31", default-features = false, features = ["loader_halo2", "system_halo2", "loader_evm"], optional = true }
 cli-table = { version = "0.4", optional = true }
 num_enum = "0.5.7"
 serde = { version = "1.0.130", features = ["derive"] }

--- a/zkevm-circuits/src/bytecode_circuit/test.rs
+++ b/zkevm-circuits/src/bytecode_circuit/test.rs
@@ -25,7 +25,7 @@ impl<F: Field> BytecodeCircuit<F> {
 
     fn verify(&self, success: bool) {
         let prover = MockProver::<F>::run(log2_ceil(self.max_rows), self, Vec::new()).unwrap();
-        let result = prover.verify_par();
+        let result = prover.verify();
         if success {
             if let Err(failures) = &result {
                 for failure in failures.iter() {

--- a/zkevm-circuits/src/copy_circuit/test.rs
+++ b/zkevm-circuits/src/copy_circuit/test.rs
@@ -36,7 +36,7 @@ pub fn test_copy_circuit<F: Field>(
         CopyCircuit::<F>::new_with_external_data(copy_events, max_copy_rows, external_data);
 
     let prover = MockProver::<F>::run(k, &circuit, vec![]).unwrap();
-    prover.verify_par()
+    prover.verify()
 }
 
 /// Test copy circuit with the provided block witness
@@ -330,6 +330,8 @@ fn assert_error_matches(result: Result<(), Vec<VerifyFailure>>, names: Vec<&str>
             VerifyFailure::CellNotAssigned { .. } => panic!(),
             VerifyFailure::ConstraintPoisoned { .. } => panic!(),
             VerifyFailure::Permutation { .. } => panic!(),
+            VerifyFailure::InstanceCellNotAssigned { .. } => panic!(),
+            VerifyFailure::Shuffle { .. } => panic!(),
         }
     }
 }

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_precompile.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_precompile.rs
@@ -218,7 +218,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGPrecompileGadget<F> {
 #[cfg(test)]
 mod test {
     use crate::test_util::CircuitTestBuilder;
-    use bus_mapping::{evm::PrecompileCallArgs, precompile::PrecompileCalls};
+    use bus_mapping::precompile::{PrecompileCallArgs, PrecompileCalls};
     use eth_types::{
         bytecode,
         evm_types::{GasCost, OpcodeId},

--- a/zkevm-circuits/src/evm_circuit/execution/precompiles/identity.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/precompiles/identity.rs
@@ -159,8 +159,8 @@ impl<F: Field> ExecutionGadget<F> for IdentityGadget<F> {
 #[cfg(test)]
 mod test {
     use bus_mapping::{
-        evm::{OpcodeId, PrecompileCallArgs},
-        precompile::PrecompileCalls,
+        evm::OpcodeId,
+        precompile::{PrecompileCallArgs, PrecompileCalls},
     };
     use eth_types::{bytecode, word, ToWord};
     use itertools::Itertools;

--- a/zkevm-circuits/src/exp_circuit/test.rs
+++ b/zkevm-circuits/src/exp_circuit/test.rs
@@ -26,7 +26,7 @@ pub fn test_exp_circuit<F: Field>(k: u32, block: Block<F>) {
         block.circuits_params.max_exp_steps,
     );
     let prover = MockProver::<F>::run(k, &circuit, vec![]).unwrap();
-    prover.assert_satisfied_par()
+    prover.assert_satisfied()
 }
 
 fn gen_code_single(base: Word, exponent: Word) -> Bytecode {

--- a/zkevm-circuits/src/mpt_circuit.rs
+++ b/zkevm-circuits/src/mpt_circuit.rs
@@ -807,7 +807,7 @@ mod tests {
                 println!("{} {:?}", idx, path);
                 let prover = MockProver::<Fr>::run(degree as u32, &circuit, vec![]).unwrap();
                 assert_eq!(prover.verify_at_rows(0..num_rows, 0..num_rows,), Ok(()));
-                // assert_eq!(prover.verify_par(), Ok(()));
+                // assert_eq!(prover.verify(), Ok(()));
                 // prover.assert_satisfied();
             });
     }

--- a/zkevm-circuits/src/root_circuit/dev.rs
+++ b/zkevm-circuits/src/root_circuit/dev.rs
@@ -2,7 +2,7 @@ use super::{aggregate, AggregationConfig, Halo2Loader, KzgSvk, Snark, SnarkWitne
 use eth_types::Field;
 use halo2_proofs::{
     circuit::{Layouter, SimpleFloorPlanner},
-    halo2curves::{ff::Field as Halo2Field, serde::SerdeObject},
+    halo2curves::{ff::Field as Halo2Field, serde::SerdeObject, CurveAffine, CurveExt},
     plonk::{Circuit, ConstraintSystem, Error},
     poly::{commitment::ParamsProver, kzg::commitment::ParamsKZG},
 };
@@ -20,18 +20,23 @@ use std::{iter, marker::PhantomData, rc::Rc};
 
 /// Aggregation circuit for testing purpose.
 #[derive(Clone)]
-pub struct TestAggregationCircuit<'a, M: MultiMillerLoop, As> {
+pub struct TestAggregationCircuit<'a, M: MultiMillerLoop, As>
+where
+    M::G1Affine: CurveAffine,
+{
     svk: KzgSvk<M>,
     snarks: Vec<SnarkWitness<'a, M::G1Affine>>,
-    instances: Vec<M::Scalar>,
+    instances: Vec<M::Fr>,
     _marker: PhantomData<As>,
 }
 
-impl<'a, M: MultiMillerLoop, As> TestAggregationCircuit<'a, M, As>
+impl<'a, M, As> TestAggregationCircuit<'a, M, As>
 where
-    M::G1Affine: SerdeObject,
-    M::G2Affine: SerdeObject,
-    M::Scalar: Field,
+    M: MultiMillerLoop,
+    M::Fr: Field,
+    M::G1: CurveExt<AffineExt = M::G1Affine, ScalarExt = M::Fr>,
+    M::G1Affine: SerdeObject + CurveAffine<ScalarExt = M::Fr, CurveExt = M::G1>,
+    M::G2Affine: SerdeObject + CurveAffine,
     for<'b> As: PolynomialCommitmentScheme<
             M::G1Affine,
             NativeLoader,
@@ -87,14 +92,15 @@ where
     }
 
     /// Returns instances
-    pub fn instances(&self) -> Vec<Vec<M::Scalar>> {
+    pub fn instances(&self) -> Vec<Vec<M::Fr>> {
         vec![self.instances.clone()]
     }
 }
 
-impl<'a, M: MultiMillerLoop, As> Circuit<M::Scalar> for TestAggregationCircuit<'a, M, As>
+impl<'a, M: MultiMillerLoop, As> Circuit<M::Fr> for TestAggregationCircuit<'a, M, As>
 where
-    M::Scalar: Field,
+    M::Fr: Field,
+    M::G1Affine: CurveAffine<ScalarExt = M::Fr>,
     for<'b> As: PolynomialCommitmentScheme<
             M::G1Affine,
             Rc<Halo2Loader<'b, M::G1Affine>>,
@@ -119,19 +125,19 @@ where
                 .iter()
                 .map(SnarkWitness::without_witnesses)
                 .collect(),
-            instances: vec![M::Scalar::ZERO; self.instances.len()],
+            instances: vec![M::Fr::ZERO; self.instances.len()],
             _marker: PhantomData,
         }
     }
 
-    fn configure(meta: &mut ConstraintSystem<M::Scalar>) -> Self::Config {
+    fn configure(meta: &mut ConstraintSystem<M::Fr>) -> Self::Config {
         AggregationConfig::configure::<M::G1Affine>(meta)
     }
 
     fn synthesize(
         &self,
         config: Self::Config,
-        mut layouter: impl Layouter<M::Scalar>,
+        mut layouter: impl Layouter<M::Fr>,
     ) -> Result<(), Error> {
         config.load_table(&mut layouter)?;
         let (instances, accumulator_limbs) =

--- a/zkevm-circuits/src/root_circuit/test.rs
+++ b/zkevm-circuits/src/root_circuit/test.rs
@@ -73,7 +73,7 @@ fn test_root_circuit() {
     assert_eq!(
         MockProver::run(26, &root_circuit, root_circuit.instance())
             .unwrap()
-            .verify_par(),
+            .verify(),
         Ok(())
     );
 }

--- a/zkevm-circuits/src/state_circuit/test.rs
+++ b/zkevm-circuits/src/state_circuit/test.rs
@@ -1044,5 +1044,7 @@ fn assert_error_matches(result: Result<(), Vec<VerifyFailure>>, name: &str) {
         VerifyFailure::CellNotAssigned { .. } => panic!(),
         VerifyFailure::ConstraintPoisoned { .. } => panic!(),
         VerifyFailure::Permutation { .. } => panic!(),
+        VerifyFailure::InstanceCellNotAssigned { .. } => panic!(),
+        VerifyFailure::Shuffle { .. } => panic!(),
     }
 }

--- a/zkevm-circuits/src/super_circuit/test.rs
+++ b/zkevm-circuits/src/super_circuit/test.rs
@@ -29,7 +29,7 @@ fn test_super_circuit(block: GethData, circuits_params: FixedCParams, mock_rando
     let (k, circuit, instance, _) =
         SuperCircuit::<Fr>::build(block, circuits_params, mock_randomness).unwrap();
     let prover = MockProver::run(k, &circuit, instance).unwrap();
-    let res = prover.verify_par();
+    let res = prover.verify();
     if let Err(err) = res {
         error!("Verification failures: {:#?}", err);
         panic!("Failed verification");

--- a/zkevm-circuits/src/test_util.rs
+++ b/zkevm-circuits/src/test_util.rs
@@ -204,7 +204,7 @@ impl<const NACC: usize, const NTX: usize> CircuitTestBuilder<NACC, NTX> {
         })?;
 
         prover
-            .verify_at_rows_par(
+            .verify_at_rows(
                 active_gate_rows.iter().cloned(),
                 active_lookup_rows.iter().cloned(),
             )
@@ -234,12 +234,12 @@ impl<const NACC: usize, const NTX: usize> CircuitTestBuilder<NACC, NTX> {
             .filter(|rw| !matches!(rw, Rw::Start { .. }))
             .count();
         let rows = max_rws - non_start_rows_len..max_rws;
-        prover
-            .verify_at_rows_par(rows.clone(), rows)
-            .map_err(|err| CircuitTestError::VerificationFailed {
+        prover.verify_at_rows(rows.clone(), rows).map_err(|err| {
+            CircuitTestError::VerificationFailed {
                 circuit: Circuit::EVM,
                 reasons: err,
-            })
+            }
+        })
     }
     /// Triggers the `CircuitTestBuilder` to convert the [`TestContext`] if any,
     /// into a [`Block`] and apply the default or provided block_modifiers or

--- a/zkevm-circuits/src/tx_circuit/sign_verify.rs
+++ b/zkevm-circuits/src/tx_circuit/sign_verify.rs
@@ -817,7 +817,7 @@ mod sign_verify_tests {
             Ok(prover) => prover,
             Err(e) => panic!("{:#?}", e),
         };
-        prover.assert_satisfied_par();
+        prover.assert_satisfied();
     }
 
     // Generate a test key pair

--- a/zkevm-circuits/tests/prover_error.rs
+++ b/zkevm-circuits/tests/prover_error.rs
@@ -99,7 +99,7 @@ fn prover_error() {
     let circuit = SuperCircuit::new_from_block(&block_witness);
     let res = MockProver::run(k, &circuit, circuit.instance())
         .expect("MockProver::run")
-        .verify_par();
+        .verify();
     println!("MockProver: {res:#?}");
-    res.expect("verify_par");
+    res.expect("verify");
 }


### PR DESCRIPTION
### Description

- halo2 (v2023_04_20 -> v0.3.0)
- halo2wrong (v2023_04_20 -> v2024_01_31)
- snark-verifier (v2023_04_20 -> v2024_01_31)
- remove halo2curves patching and fetch from `crate-io`, which got latest release `0.6.0`

### Issue Link

https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/1691

### Type of change
- [x] New feature (non-breaking change which adds functionality)
