### PR TITLE
unify word interface for zero/one

### DIFF
--- a/gadgets/src/util.rs
+++ b/gadgets/src/util.rs
@@ -264,7 +264,6 @@ impl<F: Field> Expr<F> for &Expression<F> {
         (*self).clone()
     }
 }
-
 /// Given a bytes-representation of an expression, it computes and returns the
 /// single expression.
 pub fn expr_from_bytes<F: Field, E: Expr<F>>(bytes: &[E]) -> Expression<F> {

--- a/light-client-poc/src/circuit/state_update.rs
+++ b/light-client-poc/src/circuit/state_update.rs
@@ -1,5 +1,5 @@
 use super::equal_words::EqualWordsConfig;
-use eth_types::Field;
+use eth_types::{Field, OpsIdentity};
 use eyre::Result;
 use gadgets::{
     is_zero::{IsZeroChip, IsZeroConfig, IsZeroInstruction},
@@ -68,7 +68,7 @@ pub struct StateUpdateCircuitConfig<F: Field> {
 
 /// MPT Circuit for proving the storage modification is valid.
 #[derive(Default)]
-pub struct StateUpdateCircuit<F: Field> {
+pub struct StateUpdateCircuit<F: Field + OpsIdentity<Output = F>> {
     pub transforms: Transforms,
     #[cfg(not(feature = "disable-keccak"))]
     pub keccak_circuit: KeccakCircuit<F>,
@@ -78,7 +78,7 @@ pub struct StateUpdateCircuit<F: Field> {
     pub max_proof_count: usize,
 }
 
-impl<F: Field> Circuit<F> for StateUpdateCircuit<F> {
+impl<F: Field + OpsIdentity<Output = F>> Circuit<F> for StateUpdateCircuit<F> {
     type Config = (StateUpdateCircuitConfig<F>, Challenges);
     type FloorPlanner = SimpleFloorPlanner;
     type Params = MPTCircuitParams;

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -221,12 +221,12 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             cb.account_write(
                 call_callee_address.to_word(),
                 AccountFieldTag::Nonce,
-                Word::one(),
-                Word::zero(),
+                Word::one::<Expression<F>>(),
+                Word::zero::<Expression<F>>(),
                 Some(&mut reversion_info),
             );
             for (field_tag, value) in [
-                (CallContextFieldTag::Depth, Word::one()),
+                (CallContextFieldTag::Depth, Word::one::<Expression<F>>()),
                 (
                     CallContextFieldTag::CallerAddress,
                     tx.caller_address.to_word(),
@@ -235,24 +235,30 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                     CallContextFieldTag::CalleeAddress,
                     call_callee_address.to_word(),
                 ),
-                (CallContextFieldTag::CallDataOffset, Word::zero()),
+                (
+                    CallContextFieldTag::CallDataOffset,
+                    Word::zero::<Expression<F>>(),
+                ),
                 (
                     CallContextFieldTag::CallDataLength,
                     Word::from_lo_unchecked(tx.call_data_length.expr()),
                 ),
                 (CallContextFieldTag::Value, tx.value.to_word()),
-                (CallContextFieldTag::IsStatic, Word::zero()),
-                (CallContextFieldTag::LastCalleeId, Word::zero()),
+                (CallContextFieldTag::IsStatic, Word::zero::<Expression<F>>()),
+                (
+                    CallContextFieldTag::LastCalleeId,
+                    Word::zero::<Expression<F>>(),
+                ),
                 (
                     CallContextFieldTag::LastCalleeReturnDataOffset,
-                    Word::zero(),
+                    Word::zero::<Expression<F>>(),
                 ),
                 (
                     CallContextFieldTag::LastCalleeReturnDataLength,
-                    Word::zero(),
+                    Word::zero::<Expression<F>>(),
                 ),
-                (CallContextFieldTag::IsRoot, Word::one()),
-                (CallContextFieldTag::IsCreate, Word::one()),
+                (CallContextFieldTag::IsRoot, Word::one::<Expression<F>>()),
+                (CallContextFieldTag::IsCreate, Word::one::<Expression<F>>()),
                 (
                     CallContextFieldTag::CodeHash,
                     cb.curr.state.code_hash.to_word(),
@@ -349,7 +355,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             |cb| {
                 // Setup first call's context.
                 for (field_tag, value) in [
-                    (CallContextFieldTag::Depth, Word::one()),
+                    (CallContextFieldTag::Depth, Word::one::<Expression<F>>()),
                     (
                         CallContextFieldTag::CallerAddress,
                         tx.caller_address.to_word(),
@@ -358,23 +364,29 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
                         CallContextFieldTag::CalleeAddress,
                         tx.callee_address.to_word(),
                     ),
-                    (CallContextFieldTag::CallDataOffset, Word::zero()),
+                    (
+                        CallContextFieldTag::CallDataOffset,
+                        Word::zero::<Expression<F>>(),
+                    ),
                     (
                         CallContextFieldTag::CallDataLength,
                         Word::from_lo_unchecked(tx.call_data_length.expr()),
                     ),
                     (CallContextFieldTag::Value, tx.value.to_word()),
-                    (CallContextFieldTag::IsStatic, Word::zero()),
-                    (CallContextFieldTag::LastCalleeId, Word::zero()),
+                    (CallContextFieldTag::IsStatic, Word::zero::<Expression<F>>()),
+                    (
+                        CallContextFieldTag::LastCalleeId,
+                        Word::zero::<Expression<F>>(),
+                    ),
                     (
                         CallContextFieldTag::LastCalleeReturnDataOffset,
-                        Word::zero(),
+                        Word::zero::<Expression<F>>(),
                     ),
                     (
                         CallContextFieldTag::LastCalleeReturnDataLength,
-                        Word::zero(),
+                        Word::zero::<Expression<F>>(),
                     ),
-                    (CallContextFieldTag::IsRoot, Word::one()),
+                    (CallContextFieldTag::IsRoot, Word::one::<Expression<F>>()),
                     (
                         CallContextFieldTag::IsCreate,
                         Word::from_lo_unchecked(tx.is_create.expr()),

--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -32,7 +32,10 @@ use bus_mapping::{
     precompile::{is_precompiled, PrecompileCalls},
 };
 use eth_types::{evm_types::GAS_STIPEND_CALL_WITH_VALUE, Field, ToAddress, ToScalar, U256};
-use halo2_proofs::{circuit::Value, plonk::Error};
+use halo2_proofs::{
+    circuit::Value,
+    plonk::{Error, Expression},
+};
 use std::cmp::min;
 
 /// Gadget for call related opcodes. It supports `OpcodeId::CALL`,
@@ -540,7 +543,7 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
                     CallContextFieldTag::LastCalleeReturnDataOffset,
                     CallContextFieldTag::LastCalleeReturnDataLength,
                 ] {
-                    cb.call_context_lookup_write(None, field_tag, Word::zero());
+                    cb.call_context_lookup_write(None, field_tag, Word::zero::<Expression<F>>());
                 }
 
                 // For CALL opcode, it has an extra stack pop `value` (+1) and if the value is
@@ -588,7 +591,7 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
                 CallContextFieldTag::LastCalleeReturnDataOffset,
                 CallContextFieldTag::LastCalleeReturnDataLength,
             ] {
-                cb.call_context_lookup_write(None, field_tag, Word::zero());
+                cb.call_context_lookup_write(None, field_tag, Word::zero::<Expression<F>>());
             }
 
             cb.require_step_state_transition(StepStateTransition {
@@ -689,17 +692,20 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
                         CallContextFieldTag::IsStatic,
                         Word::from_lo_unchecked(or::expr([is_static.expr(), is_staticcall.expr()])),
                     ),
-                    (CallContextFieldTag::LastCalleeId, Word::zero()),
+                    (
+                        CallContextFieldTag::LastCalleeId,
+                        Word::zero::<Expression<F>>(),
+                    ),
                     (
                         CallContextFieldTag::LastCalleeReturnDataOffset,
-                        Word::zero(),
+                        Word::zero::<Expression<F>>(),
                     ),
                     (
                         CallContextFieldTag::LastCalleeReturnDataLength,
-                        Word::zero(),
+                        Word::zero::<Expression<F>>(),
                     ),
-                    (CallContextFieldTag::IsRoot, Word::zero()),
-                    (CallContextFieldTag::IsCreate, Word::zero()),
+                    (CallContextFieldTag::IsRoot, Word::zero::<Expression<F>>()),
+                    (CallContextFieldTag::IsCreate, Word::zero::<Expression<F>>()),
                     (
                         CallContextFieldTag::CodeHash,
                         call_gadget.callee_code_hash.to_word(),

--- a/zkevm-circuits/src/evm_circuit/execution/create.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/create.rs
@@ -296,7 +296,7 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                 CallContextFieldTag::LastCalleeReturnDataOffset,
                 CallContextFieldTag::LastCalleeReturnDataLength,
             ] {
-                cb.call_context_lookup_write(None, field_tag, Word::zero());
+                cb.call_context_lookup_write(None, field_tag, Word::zero::<Expression<F>>());
             }
 
             cb.require_step_state_transition(StepStateTransition {
@@ -342,8 +342,8 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                 cb.account_write(
                     contract_addr.to_word(),
                     AccountFieldTag::Nonce,
-                    Word::one(),
-                    Word::zero(),
+                    Word::one::<Expression<F>>(),
+                    Word::zero::<Expression<F>>(),
                     Some(&mut callee_reversion_info),
                 );
 
@@ -420,7 +420,11 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                         CallContextFieldTag::LastCalleeReturnDataOffset,
                         CallContextFieldTag::LastCalleeReturnDataLength,
                     ] {
-                        cb.call_context_lookup_write(None, field_tag, Word::zero());
+                        cb.call_context_lookup_write(
+                            None,
+                            field_tag,
+                            Word::zero::<Expression<F>>(),
+                        );
                     }
                     cb.require_step_state_transition(StepStateTransition {
                         rw_counter: Delta(cb.rw_counter_offset()),
@@ -463,7 +467,7 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                     CallContextFieldTag::LastCalleeReturnDataOffset,
                     CallContextFieldTag::LastCalleeReturnDataLength,
                 ] {
-                    cb.call_context_lookup_write(None, field_tag, Word::zero());
+                    cb.call_context_lookup_write(None, field_tag, Word::zero::<Expression<F>>());
                 }
 
                 cb.require_step_state_transition(StepStateTransition {

--- a/zkevm-circuits/src/evm_circuit/execution/end_block.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/end_block.rs
@@ -16,7 +16,10 @@ use crate::{
 };
 use eth_types::Field;
 use gadgets::util::select;
-use halo2_proofs::{circuit::Value, plonk::Error};
+use halo2_proofs::{
+    circuit::Value,
+    plonk::{Error, Expression},
+};
 
 #[derive(Clone, Debug)]
 pub(crate) struct EndBlockGadget<F> {
@@ -74,7 +77,7 @@ impl<F: Field> ExecutionGadget<F> for EndBlockGadget<F> {
                 total_txs.expr() + 1.expr(),
                 TxContextFieldTag::CallerAddress,
                 None,
-                Word::zero(),
+                Word::zero::<Expression<F>>(),
             );
             // Since every tx lookup done in the EVM circuit must succeed
             // and uses a unique tx_id, we know that at

--- a/zkevm-circuits/src/evm_circuit/execution/error_precompile_failed.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_precompile_failed.rs
@@ -18,7 +18,10 @@ use crate::{
 };
 use bus_mapping::evm::OpcodeId;
 use eth_types::{Field, U256};
-use halo2_proofs::{circuit::Value, plonk::Error};
+use halo2_proofs::{
+    circuit::Value,
+    plonk::{Error, Expression},
+};
 
 #[derive(Clone, Debug)]
 pub(crate) struct ErrorPrecompileFailedGadget<F> {
@@ -87,7 +90,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorPrecompileFailedGadget<F> {
         cb.stack_pop(cd_length.to_word());
         cb.stack_pop(rd_offset.to_word());
         cb.stack_pop(rd_length.to_word());
-        cb.stack_push(Word::zero());
+        cb.stack_push(Word::zero::<Expression<F>>());
 
         for (field_tag, value) in [
             (CallContextFieldTag::LastCalleeId, callee_call_id.expr()),

--- a/zkevm-circuits/src/evm_circuit/execution/error_write_protection.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_write_protection.rs
@@ -17,7 +17,10 @@ use crate::{
     },
 };
 use eth_types::{evm_types::OpcodeId, Field, ToAddress, U256};
-use halo2_proofs::{circuit::Value, plonk::Error};
+use halo2_proofs::{
+    circuit::Value,
+    plonk::{Error, Expression},
+};
 
 #[derive(Clone, Debug)]
 pub(crate) struct ErrorWriteProtectionGadget<F> {
@@ -73,7 +76,11 @@ impl<F: Field> ExecutionGadget<F> for ErrorWriteProtectionGadget<F> {
         });
 
         // current call context is readonly
-        cb.call_context_lookup_read(None, CallContextFieldTag::IsStatic, Word::one());
+        cb.call_context_lookup_read(
+            None,
+            CallContextFieldTag::IsStatic,
+            Word::one::<Expression<F>>(),
+        );
 
         // constrain not root call as at least one previous staticcall preset.
         cb.require_zero(

--- a/zkevm-circuits/src/evm_circuit/execution/stop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/stop.rs
@@ -22,7 +22,10 @@ use crate::{
 };
 use bus_mapping::evm::OpcodeId;
 use eth_types::Field;
-use halo2_proofs::{circuit::Value, plonk::Error};
+use halo2_proofs::{
+    circuit::Value,
+    plonk::{Error, Expression},
+};
 
 #[derive(Clone, Debug)]
 pub(crate) struct StopGadget<F> {
@@ -63,7 +66,11 @@ impl<F: Field> ExecutionGadget<F> for StopGadget<F> {
         );
 
         // Call ends with STOP must be successful
-        cb.call_context_lookup_read(None, CallContextFieldTag::IsSuccess, Word::one());
+        cb.call_context_lookup_read(
+            None,
+            CallContextFieldTag::IsSuccess,
+            Word::one::<Expression<F>>(),
+        );
 
         let is_to_end_tx = cb.next.execution_state_selector([ExecutionState::EndTx]);
         cb.require_equal(

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -429,7 +429,7 @@ impl<F: Field> TransferToGadget<F> {
                     receiver_address.clone(),
                     AccountFieldTag::CodeHash,
                     cb.empty_code_hash(),
-                    Word::zero(),
+                    Word::zero::<Expression<F>>(),
                     reversion_info,
                 );
             },
@@ -767,7 +767,7 @@ impl<F: Field, MemAddrGadget: CommonMemoryAddressGadget<F>, const IS_SUCCESS_CAL
         cb.stack_push(if IS_SUCCESS_CALL {
             Word::from_lo_unchecked(is_success.expr()) // is_success is bool
         } else {
-            Word::zero()
+            Word::zero::<Expression<F>>()
         });
 
         // Recomposition of random linear combination to integer
@@ -1097,7 +1097,11 @@ impl<F: Field> CommonErrorGadget<F> {
         let rw_counter_end_of_reversion = cb.query_word_unchecked(); // rw_counter_end_of_reversion just used for read lookup, therefore skip range check
 
         // current call must be failed.
-        cb.call_context_lookup_read(None, CallContextFieldTag::IsSuccess, Word::zero());
+        cb.call_context_lookup_read(
+            None,
+            CallContextFieldTag::IsSuccess,
+            Word::zero::<Expression<F>>(),
+        );
 
         cb.call_context_lookup_read(
             None,

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -165,7 +165,7 @@ pub(crate) trait ConstrainBuilderCommon<F: Field> {
     }
 
     fn require_zero_word(&mut self, name: &'static str, word: Word<Expression<F>>) {
-        self.require_equal_word(name, word, Word::zero());
+        self.require_equal_word(name, word, Word::zero::<Expression<F>>());
     }
 
     fn require_equal_word(
@@ -865,10 +865,10 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 tx_id,
                 account_address.compress(),
                 0.expr(),
-                Word::zero(),
+                Word::zero::<Expression<F>>(),
                 Word::from_lo_unchecked(value),
                 Word::from_lo_unchecked(value_prev),
-                Word::zero(),
+                Word::zero::<Expression<F>>(),
             ),
             reversion_info,
         );
@@ -888,10 +888,10 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 tx_id,
                 account_address.compress(),
                 0.expr(),
-                Word::zero(),
+                Word::zero::<Expression<F>>(),
                 Word::from_lo_unchecked(value.clone()),
                 Word::from_lo_unchecked(value),
-                Word::zero(),
+                Word::zero::<Expression<F>>(),
             ),
         );
     }
@@ -914,7 +914,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 storage_key,
                 value,
                 value_prev,
-                Word::zero(),
+                Word::zero::<Expression<F>>(),
             ),
             reversion_info,
         );
@@ -938,7 +938,7 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 storage_key,
                 value.clone(),
                 value,
-                Word::zero(),
+                Word::zero::<Expression<F>>(),
             ),
         );
     }
@@ -954,10 +954,10 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 tx_id,
                 0.expr(),
                 0.expr(),
-                Word::zero(),
+                Word::zero::<Expression<F>>(),
                 value.clone(),
                 value,
-                Word::zero(),
+                Word::zero::<Expression<F>>(),
             ),
         );
     }
@@ -976,10 +976,10 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 tx_id,
                 0.expr(),
                 0.expr(),
-                Word::zero(),
+                Word::zero::<Expression<F>>(),
                 value,
                 value_prev,
-                Word::zero(),
+                Word::zero::<Expression<F>>(),
             ),
             reversion_info,
         );
@@ -1000,10 +1000,10 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 0.expr(),
                 account_address.compress(),
                 field_tag.expr(),
-                Word::zero(),
+                Word::zero::<Expression<F>>(),
                 value.clone(),
                 value,
-                Word::zero(),
+                Word::zero::<Expression<F>>(),
             ),
         );
     }
@@ -1023,10 +1023,10 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 0.expr(),
                 account_address.compress(),
                 field_tag.expr(),
-                Word::zero(),
+                Word::zero::<Expression<F>>(),
                 value,
                 value_prev,
-                Word::zero(),
+                Word::zero::<Expression<F>>(),
             ),
             reversion_info,
         );
@@ -1127,10 +1127,10 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 call_id.unwrap_or_else(|| self.curr.state.call_id.expr()),
                 0.expr(),
                 field_tag.expr(),
-                Word::zero(),
+                Word::zero::<Expression<F>>(),
                 value,
-                Word::zero(),
-                Word::zero(),
+                Word::zero::<Expression<F>>(),
+                Word::zero::<Expression<F>>(),
             ),
         );
     }
@@ -1153,10 +1153,10 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 call_id.unwrap_or_else(|| self.curr.state.call_id.expr()),
                 0.expr(),
                 field_tag.expr(),
-                Word::zero(),
+                Word::zero::<Expression<F>>(),
                 value,
-                Word::zero(),
-                Word::zero(),
+                Word::zero::<Expression<F>>(),
+                Word::zero::<Expression<F>>(),
             ),
         );
     }
@@ -1175,10 +1175,10 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 call_id.unwrap_or_else(|| self.curr.state.call_id.expr()),
                 0.expr(),
                 field_tag.expr(),
-                Word::zero(),
+                Word::zero::<Expression<F>>(),
                 value,
-                Word::zero(),
-                Word::zero(),
+                Word::zero::<Expression<F>>(),
+                Word::zero::<Expression<F>>(),
             ),
         );
     }
@@ -1261,10 +1261,10 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 self.curr.state.call_id.expr(),
                 self.curr.state.stack_pointer.expr() + stack_pointer_offset,
                 0.expr(),
-                Word::zero(),
+                Word::zero::<Expression<F>>(),
                 value,
-                Word::zero(),
-                Word::zero(),
+                Word::zero::<Expression<F>>(),
+                Word::zero::<Expression<F>>(),
             ),
         );
     }
@@ -1286,11 +1286,11 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 call_id.unwrap_or_else(|| self.curr.state.call_id.expr()),
                 memory_address,
                 0.expr(),
-                Word::zero(),
+                Word::zero::<Expression<F>>(),
                 // TODO assure range check since write=true also possible
                 Word::from_lo_unchecked(byte),
-                Word::zero(),
-                Word::zero(),
+                Word::zero::<Expression<F>>(),
+                Word::zero::<Expression<F>>(),
             ),
         );
     }
@@ -1311,10 +1311,10 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 tx_id,
                 build_tx_log_expression(index, field_tag.expr(), log_id),
                 0.expr(),
-                Word::zero(),
+                Word::zero::<Expression<F>>(),
                 value,
-                Word::zero(),
-                Word::zero(),
+                Word::zero::<Expression<F>>(),
+                Word::zero::<Expression<F>>(),
             ),
         );
     }
@@ -1335,11 +1335,11 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 tx_id,
                 0.expr(),
                 tag.expr(),
-                Word::zero(),
+                Word::zero::<Expression<F>>(),
                 // TODO assure range check since write=true also possible
                 Word::from_lo_unchecked(value),
-                Word::zero(),
-                Word::zero(),
+                Word::zero::<Expression<F>>(),
+                Word::zero::<Expression<F>>(),
             ),
         );
     }
@@ -1356,10 +1356,10 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
                 0.expr(),
                 0.expr(),
                 0.expr(),
-                Word::zero(),
-                Word::zero(),
-                Word::zero(),
-                Word::zero(),
+                Word::zero::<Expression<F>>(),
+                Word::zero::<Expression<F>>(),
+                Word::zero::<Expression<F>>(),
+                Word::zero::<Expression<F>>(),
             ),
         );
     }

--- a/zkevm-circuits/src/mpt_circuit.rs
+++ b/zkevm-circuits/src/mpt_circuit.rs
@@ -1,5 +1,5 @@
 //! The MPT circuit implementation.
-use eth_types::Field;
+use eth_types::{Field, OpsIdentity};
 use gadgets::{impl_expr, util::Scalar};
 use halo2_proofs::{
     circuit::{Layouter, SimpleFloorPlanner, Value},
@@ -208,7 +208,7 @@ pub enum FixedTableTag {
 }
 impl_expr!(FixedTableTag);
 
-impl<F: Field> MPTConfig<F> {
+impl<F: Field + OpsIdentity<Output = F>> MPTConfig<F> {
     /// Configure MPT Circuit
     pub fn new(
         meta: &mut ConstraintSystem<F>,
@@ -646,7 +646,7 @@ impl<F: Field> MPTConfig<F> {
 
 /// MPT Circuit for proving the storage modification is valid.
 #[derive(Default)]
-pub struct MPTCircuit<F: Field> {
+pub struct MPTCircuit<F: Field + OpsIdentity<Output = F>> {
     /// MPT nodes
     pub nodes: Vec<Node>,
     /// MPT keccak_data
@@ -685,7 +685,7 @@ impl MPTCircuitParams {
     }
 }
 
-impl<F: Field> Circuit<F> for MPTCircuit<F> {
+impl<F: Field + OpsIdentity<Output = F>> Circuit<F> for MPTCircuit<F> {
     type Config = (MPTConfig<F>, Challenges);
     type FloorPlanner = SimpleFloorPlanner;
     type Params = MPTCircuitParams;

--- a/zkevm-circuits/src/mpt_circuit/account_leaf.rs
+++ b/zkevm-circuits/src/mpt_circuit/account_leaf.rs
@@ -1,4 +1,4 @@
-use eth_types::{Field, U256};
+use eth_types::{Field, OpsIdentity, U256};
 use gadgets::util::{pow, Scalar};
 use halo2_proofs::{
     circuit::Value,
@@ -55,7 +55,7 @@ pub(crate) struct AccountLeafConfig<F> {
     mod_extension: ModExtensionGadget<F>,
 }
 
-impl<F: Field> AccountLeafConfig<F> {
+impl<F: Field + OpsIdentity<Output = F>> AccountLeafConfig<F> {
     pub fn configure(
         meta: &mut VirtualCells<'_, F>,
         cb: &mut MPTConstraintBuilder<F>,
@@ -149,10 +149,10 @@ impl<F: Field> AccountLeafConfig<F> {
             require!(config.main_data.is_below_account => false);
 
             let mut key_rlc = vec![0.expr(); 2];
-            let mut nonce = vec![Word::zero(); 2];
-            let mut balance = vec![Word::zero(); 2];
-            let mut storage = vec![Word::zero(); 2];
-            let mut codehash = vec![Word::zero(); 2];
+            let mut nonce = vec![Word::zero::<Expression<F>>(); 2];
+            let mut balance = vec![Word::zero::<Expression<F>>(); 2];
+            let mut storage = vec![Word::zero::<Expression<F>>(); 2];
+            let mut codehash = vec![Word::zero::<Expression<F>>(); 2];
             let mut leaf_no_key_rlc = vec![0.expr(); 2];
             let mut leaf_no_key_rlc_mult = vec![0.expr(); 2];
             let mut value_list_num_bytes = vec![0.expr(); 2];
@@ -467,7 +467,7 @@ impl<F: Field> AccountLeafConfig<F> {
                         &mut cb.base,
                         address.clone(),
                         proof_type.clone(),
-                        Word::zero(),
+                        Word::zero::<Expression<F>>(),
                         config.main_data.new_root.expr(),
                         config.main_data.old_root.expr(),
                         Word::<Expression<F>>::new([new_value_lo, new_value_hi]),
@@ -481,11 +481,11 @@ impl<F: Field> AccountLeafConfig<F> {
                         &mut cb.base,
                         address.clone(),
                         proof_type.clone(),
-                        Word::zero(),
+                        Word::zero::<Expression<F>>(),
                         config.main_data.new_root.expr(),
                         config.main_data.old_root.expr(),
-                        Word::zero(),
-                        Word::zero(),
+                        Word::zero::<Expression<F>>(),
+                        Word::zero::<Expression<F>>(),
                     );
                 }};
             } elsex {
@@ -499,10 +499,10 @@ impl<F: Field> AccountLeafConfig<F> {
                     &mut cb.base,
                     address,
                     proof_type,
-                    Word::zero(),
+                    Word::zero::<Expression<F>>(),
                     config.main_data.new_root.expr(),
                     config.main_data.old_root.expr(),
-                    Word::zero(),
+                    Word::zero::<Expression<F>>(),
                     Word::<Expression<F>>::new([old_value_lo, old_value_hi]),
                 );
             }};
@@ -554,10 +554,10 @@ impl<F: Field> AccountLeafConfig<F> {
 
         // Key
         let mut key_rlc = vec![0.scalar(); 2];
-        let mut nonce = vec![Word::zero_f(); 2];
-        let mut balance = vec![Word::zero_f(); 2];
-        let mut storage = vec![Word::zero_f(); 2];
-        let mut codehash = vec![Word::zero_f(); 2];
+        let mut nonce = vec![Word::zero::<F>(); 2];
+        let mut balance = vec![Word::zero::<F>(); 2];
+        let mut storage = vec![Word::zero::<F>(); 2];
+        let mut codehash = vec![Word::zero::<F>(); 2];
         let mut key_data = vec![KeyDataWitness::default(); 2];
         let mut parent_data = vec![ParentDataWitness::default(); 2];
         for is_s in [true, false] {
@@ -727,11 +727,14 @@ impl<F: Field> AccountLeafConfig<F> {
         } else if is_codehash_mod {
             (MPTProofType::CodeHashChanged, codehash)
         } else if is_account_delete_mod {
-            (MPTProofType::AccountDestructed, vec![Word::zero_f(); 2])
+            (MPTProofType::AccountDestructed, vec![Word::zero::<F>(); 2])
         } else if is_non_existing_proof {
-            (MPTProofType::AccountDoesNotExist, vec![Word::zero_f(); 2])
+            (
+                MPTProofType::AccountDoesNotExist,
+                vec![Word::zero::<F>(); 2],
+            )
         } else {
-            (MPTProofType::Disabled, vec![Word::zero_f(); 2])
+            (MPTProofType::Disabled, vec![Word::zero::<F>(); 2])
         };
 
         if account.is_mod_extension[0] || account.is_mod_extension[1] {
@@ -746,10 +749,10 @@ impl<F: Field> AccountLeafConfig<F> {
         let mut new_value = value[false.idx()];
         let mut old_value = value[true.idx()];
         if parent_data[false.idx()].is_placeholder {
-            new_value = word::Word::zero_f();
+            new_value = word::Word::zero::<F>();
         } else if is_non_existing_proof {
-            new_value = word::Word::zero_f();
-            old_value = word::Word::zero_f();
+            new_value = word::Word::zero::<F>();
+            old_value = word::Word::zero::<F>();
         }
         mpt_config.mpt_table.assign_cached(
             region,
@@ -758,7 +761,7 @@ impl<F: Field> AccountLeafConfig<F> {
                 address: Value::known(from_bytes::value(
                     &account.address.iter().cloned().rev().collect::<Vec<_>>(),
                 )),
-                storage_key: word::Word::zero_f().into_value(),
+                storage_key: word::Word::zero::<F>().into_value(),
                 proof_type: Value::known(proof_type.scalar()),
                 new_root: main_data.new_root.into_value(),
                 old_root: main_data.old_root.into_value(),

--- a/zkevm-circuits/src/mpt_circuit/branch.rs
+++ b/zkevm-circuits/src/mpt_circuit/branch.rs
@@ -1,4 +1,4 @@
-use eth_types::Field;
+use eth_types::{Field, OpsIdentity};
 use gadgets::util::Scalar;
 use halo2_proofs::plonk::{Error, Expression, VirtualCells};
 
@@ -50,7 +50,7 @@ pub(crate) struct BranchGadget<F> {
     post_state: Option<BranchState<F>>,
 }
 
-impl<F: Field> BranchGadget<F> {
+impl<F: Field + OpsIdentity<Output = F>> BranchGadget<F> {
     #[allow(clippy::too_many_arguments)]
     pub fn configure(
         meta: &mut VirtualCells<'_, F>,
@@ -299,7 +299,10 @@ impl<F: Field> BranchGadget<F> {
         is_key_odd: &mut bool,
         node: &Node,
         rlp_values: &[RLPItemWitness],
-    ) -> Result<(F, F, F, [word::Word<F>; 2], [F; 2]), Error> {
+    ) -> Result<(F, F, F, [word::Word<F>; 2], [F; 2]), Error>
+    where
+        <F as OpsIdentity>::Output: Field,
+    {
         let branch = &node.extension_branch.clone().unwrap().branch;
 
         for is_s in [true, false] {
@@ -351,7 +354,7 @@ impl<F: Field> BranchGadget<F> {
         let key_mult_post_branch = *key_mult * mult;
 
         // Set the branch we'll take
-        let mut mod_node_hash_word = [word::Word::zero_f(); 2];
+        let mut mod_node_hash_word = [word::Word::zero::<F>(); 2];
         let mut mod_node_hash_rlc = [0.scalar(); 2];
         for is_s in [true, false] {
             (

--- a/zkevm-circuits/src/mpt_circuit/extension.rs
+++ b/zkevm-circuits/src/mpt_circuit/extension.rs
@@ -100,7 +100,7 @@ impl<F: Field> ExtensionGadget<F> {
             require!((FixedTableTag::ExtOddKey.expr(), first_byte, config.is_key_part_odd.expr()) =>> @FIXED);
 
             let mut branch_rlp_rlc = vec![0.expr(); 2];
-            let mut branch_rlp_word = vec![Word::zero(); 2];
+            let mut branch_rlp_word = vec![Word::zero::<Expression<F>>(); 2];
             for is_s in [true, false] {
                 // In C we have the key nibbles, we check below only for S.
                 if is_s {

--- a/zkevm-circuits/src/mpt_circuit/extension_branch.rs
+++ b/zkevm-circuits/src/mpt_circuit/extension_branch.rs
@@ -1,4 +1,4 @@
-use eth_types::Field;
+use eth_types::{Field, OpsIdentity};
 use gadgets::util::Scalar;
 use halo2_proofs::plonk::{Error, Expression, VirtualCells};
 
@@ -30,7 +30,7 @@ pub(crate) struct ExtensionBranchConfig<F> {
     branch: BranchGadget<F>,
 }
 
-impl<F: Field> ExtensionBranchConfig<F> {
+impl<F: Field + OpsIdentity<Output = F>> ExtensionBranchConfig<F> {
     pub fn configure(
         meta: &mut VirtualCells<'_, F>,
         cb: &mut MPTConstraintBuilder<F>,
@@ -158,7 +158,7 @@ impl<F: Field> ExtensionBranchConfig<F> {
                         branch.mod_rlc[is_s.idx()].expr(),
                         false.expr(),
                         false.expr(),
-                        Word::zero(),
+                        Word::zero::<Expression<F>>(),
                     );
                  } elsex {
                     // For the placeholder branch / extension node the values did not change, we reuse
@@ -291,7 +291,7 @@ impl<F: Field> ExtensionBranchConfig<F> {
                     mod_node_hash_rlc[is_s.idx()],
                     false,
                     false,
-                    Word::zero_f(),
+                    Word::zero::<F>(),
                 )?;
             } else {
                 KeyData::witness_store(

--- a/zkevm-circuits/src/mpt_circuit/helpers.rs
+++ b/zkevm-circuits/src/mpt_circuit/helpers.rs
@@ -1081,8 +1081,11 @@ impl<F: Field> IsPlaceholderLeafGadget<F> {
                     Expression::Constant(empty_hash.hi()),
                 ]),
             );
-            let is_nil_in_branch_at_mod_index =
-                IsEqualWordGadget::construct(&mut cb.base, &parent_word, &Word::zero());
+            let is_nil_in_branch_at_mod_index = IsEqualWordGadget::construct(
+                &mut cb.base,
+                &parent_word,
+                &Word::zero::<Expression<F>>(),
+            );
 
             Self {
                 is_empty_trie,

--- a/zkevm-circuits/src/mpt_circuit/start.rs
+++ b/zkevm-circuits/src/mpt_circuit/start.rs
@@ -15,16 +15,19 @@ use crate::{
     },
     util::word::Word,
 };
-use eth_types::Field;
+use eth_types::{Field, OpsIdentity};
 use gadgets::util::Scalar;
-use halo2_proofs::plonk::{Error, VirtualCells};
+use halo2_proofs::plonk::{Error, Expression, VirtualCells};
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct StartConfig<F> {
     proof_type: Cell<F>,
 }
 
-impl<F: Field> StartConfig<F> {
+impl<F: Field + OpsIdentity<Output = F>> StartConfig<F>
+where
+    <F as OpsIdentity>::Output: eth_types::Field,
+{
     pub fn configure(
         meta: &mut VirtualCells<'_, F>,
         cb: &mut MPTConstraintBuilder<F>,
@@ -40,7 +43,7 @@ impl<F: Field> StartConfig<F> {
 
             config.proof_type = cb.query_cell();
 
-            let mut root = vec![Word::zero(); 2];
+            let mut root = vec![Word::zero::<Expression<F>>(); 2];
             for is_s in [true, false] {
                 root[is_s.idx()] = root_items[is_s.idx()].word();
             }
@@ -96,7 +99,7 @@ impl<F: Field> StartConfig<F> {
         self.proof_type
             .assign(region, offset, start.proof_type.scalar())?;
 
-        let mut root = vec![Word::zero_f(); 2];
+        let mut root = vec![Word::zero::<F>(); 2];
         for is_s in [true, false] {
             root[is_s.idx()] = rlp_values[is_s.idx()].word();
         }


### PR DESCRIPTION
### Description

to address discussion in PR https://github.com/privacy-scaling-explorations/zkevm-circuits/pull/1748

### Rationale

- introduce new trait `OpsIdentity` and implement it for `Field`, `Expression<F>` type, therefore we can move zero(), one() method to base `word` type

