### PR TITLE
Streamline the math gadget API

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution/addmod.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/addmod.rs
@@ -69,7 +69,7 @@ impl<F: Field> ExecutionGadget<F> for AddModGadget<F> {
         let a_reduced = cb.query_word32();
         let d = cb.query_word32();
 
-        let n_is_zero = IsZeroWordGadget::construct(cb, &n);
+        let n_is_zero = cb.is_zero_word(&n);
 
         // 1. check k * N + a_reduced == a without overflow
         let muladd_k_n_areduced =

--- a/zkevm-circuits/src/evm_circuit/execution/balance.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/balance.rs
@@ -60,7 +60,7 @@ impl<F: Field> ExecutionGadget<F> for BalanceGadget<F> {
             AccountFieldTag::CodeHash,
             code_hash.to_word(),
         );
-        let not_exists = IsZeroWordGadget::construct(cb, &code_hash);
+        let not_exists = cb.is_zero_word(&code_hash);
         let exists = not::expr(not_exists.expr());
         let balance = cb.query_word32();
         cb.condition(exists.expr(), |cb| {

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -81,7 +81,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
         let gas_left = tx.gas.expr() - tx.intrinsic_gas();
         let sufficient_gas_left = RangeCheckGadget::construct(cb, gas_left.clone());
 
-        let tx_caller_address_is_zero = IsZeroWordGadget::construct(cb, &tx.caller_address);
+        let tx_caller_address_is_zero = cb.is_zero_word(&tx.caller_address);
         cb.require_equal(
             "CallerAddress != 0 (not a padding tx)",
             tx_caller_address_is_zero.expr(),
@@ -157,7 +157,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
         let code_hash = cb.query_word_unchecked();
         let is_empty_code_hash =
             IsEqualWordGadget::construct(cb, &code_hash.to_word(), &cb.empty_code_hash());
-        let callee_not_exists = IsZeroWordGadget::construct(cb, &code_hash);
+        let callee_not_exists = cb.is_zero_word(&code_hash);
         // no_callee_code is true when the account exists and has empty
         // code hash, or when the account doesn't exist (which we encode with
         // code_hash = 0).

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -155,8 +155,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
 
         // Read code_hash of callee
         let code_hash = cb.query_word_unchecked();
-        let is_empty_code_hash =
-            cb.is_eq_word( &code_hash.to_word(), &cb.empty_code_hash());
+        let is_empty_code_hash = cb.is_eq_word(&code_hash.to_word(), &cb.empty_code_hash());
         let callee_not_exists = cb.is_zero_word(&code_hash);
         // no_callee_code is true when the account exists and has empty
         // code hash, or when the account doesn't exist (which we encode with

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -156,7 +156,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
         // Read code_hash of callee
         let code_hash = cb.query_word_unchecked();
         let is_empty_code_hash =
-            IsEqualWordGadget::construct(cb, &code_hash.to_word(), &cb.empty_code_hash());
+            cb.is_eq_word( &code_hash.to_word(), &cb.empty_code_hash());
         let callee_not_exists = cb.is_zero_word(&code_hash);
         // no_callee_code is true when the account exists and has empty
         // code hash, or when the account doesn't exist (which we encode with

--- a/zkevm-circuits/src/evm_circuit/execution/byte.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/byte.rs
@@ -53,7 +53,7 @@ impl<F: Field> ExecutionGadget<F> for ByteGadget<F> {
         let is_byte_selected = array_init(|idx| {
             // Check if this byte is selected looking only at the LSB of the
             // index word
-            IsEqualGadget::construct(cb, index.limbs[0].expr(), (31 - idx).expr())
+            cb.is_eq(index.limbs[0].expr(), (31 - idx).expr())
         });
 
         // Sum all possible selected bytes

--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -271,7 +271,7 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
         let gas_cost = call_gadget.gas_cost_expr(is_warm_prev.expr(), is_call.expr());
         // Apply EIP 150
         let gas_available = cb.curr.state.gas_left.expr() - gas_cost.clone();
-        let one_64th_gas = ConstantDivisionGadget::construct(cb, gas_available.clone(), 64);
+        let one_64th_gas = cb.div_by_const(gas_available.clone(), 64);
         let all_but_one_64th_gas = gas_available - one_64th_gas.quotient();
         let capped_callee_gas_left =
             cb.min_max(call_gadget.gas_expr(), all_but_one_64th_gas.clone());
@@ -476,8 +476,8 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
                 let callee_gas_left = callee_gas_left.expr()
                     + call_gadget.has_value.clone() * GAS_STIPEND_CALL_WITH_VALUE.expr();
 
-                let precompile_output_word_size_div: ConstantDivisionGadget<F, N_BYTES_U64> =
-                    ConstantDivisionGadget::construct(cb, precompile_output_rws.expr(), 32);
+                let precompile_output_word_size_div =
+                    cb.div_by_const(precompile_output_rws.expr(), 32);
                 let precompile_output_word_size_div_remainder_zero =
                     cb.is_zero(precompile_output_word_size_div.remainder());
                 let precompile_output_word_size = precompile_output_word_size_div.quotient()

--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -197,7 +197,7 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
         let is_insufficient_balance =
             LtWordGadget::construct(cb, &caller_balance.to_word(), &call_gadget.value.to_word());
         // depth < 1025
-        let is_depth_ok = LtGadget::construct(cb, depth.expr(), 1025.expr());
+        let is_depth_ok = cb.is_lt(depth.expr(), 1025.expr());
 
         let is_precheck_ok = and::expr([
             is_depth_ok.expr(),

--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -195,7 +195,7 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
         // rwc_delta = 8 + is_delegatecall * 2 + call_gadget.rw_delta() +
         // callee_reversion_info.rw_delta()
         let is_insufficient_balance =
-            LtWordGadget::construct(cb, &caller_balance.to_word(), &call_gadget.value.to_word());
+            cb.is_lt_word(&caller_balance.to_word(), &call_gadget.value.to_word());
         // depth < 1025
         let is_depth_ok = cb.is_lt(depth.expr(), 1025.expr());
 

--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -274,7 +274,7 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
         let one_64th_gas = ConstantDivisionGadget::construct(cb, gas_available.clone(), 64);
         let all_but_one_64th_gas = gas_available - one_64th_gas.quotient();
         let capped_callee_gas_left =
-            MinMaxGadget::construct(cb, call_gadget.gas_expr(), all_but_one_64th_gas.clone());
+            cb.min_max(call_gadget.gas_expr(), all_but_one_64th_gas.clone());
         let callee_gas_left = select::expr(
             call_gadget.gas_is_u64.expr(),
             capped_callee_gas_left.min(),

--- a/zkevm-circuits/src/evm_circuit/execution/comparator.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/comparator.rs
@@ -41,10 +41,10 @@ impl<F: Field> ExecutionGadget<F> for ComparatorGadget<F> {
         let b = cb.query_word_unchecked();
 
         // Check if opcode is EQ
-        let is_eq = IsEqualGadget::construct(cb, opcode.expr(), OpcodeId::EQ.expr());
+        let is_eq = cb.is_eq(opcode.expr(), OpcodeId::EQ.expr());
         // Check if opcode is GT. For GT we swap the stack inputs so that we
         // actually do greater than instead of smaller than.
-        let is_gt = IsEqualGadget::construct(cb, opcode.expr(), OpcodeId::GT.expr());
+        let is_gt = cb.is_eq(opcode.expr(), OpcodeId::GT.expr());
 
         let word_comparison = CmpWordsGadget::construct(cb, a.clone(), b.clone());
 

--- a/zkevm-circuits/src/evm_circuit/execution/create.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/create.rs
@@ -168,7 +168,7 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
             );
         let gas_cost = GasCost::CREATE.expr() + memory_expansion.gas_cost() + keccak_gas_cost;
         let gas_remaining = cb.curr.state.gas_left.expr() - gas_cost.clone();
-        let gas_left = ConstantDivisionGadget::construct(cb, gas_remaining.clone(), 64);
+        let gas_left = cb.div_by_const(gas_remaining.clone(), 64);
         let callee_gas_left = gas_remaining - gas_left.quotient();
 
         let was_warm = cb.query_bool();

--- a/zkevm-circuits/src/evm_circuit/execution/create.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/create.rs
@@ -144,8 +144,7 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
 
         // Pre-check: call depth, user's nonce and user's balance
         let is_depth_in_range = cb.is_lt(depth.expr(), 1025.expr());
-        let is_insufficient_balance =
-            LtWordGadget::construct(cb, &caller_balance.to_word(), &value.to_word());
+        let is_insufficient_balance = cb.is_lt_word(&caller_balance.to_word(), &value.to_word());
         let is_nonce_in_range = cb.is_lt(caller_nonce.expr(), u64::MAX.expr());
         let is_precheck_ok = and::expr([
             is_depth_in_range.expr(),

--- a/zkevm-circuits/src/evm_circuit/execution/create.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/create.rs
@@ -143,10 +143,10 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
         );
 
         // Pre-check: call depth, user's nonce and user's balance
-        let is_depth_in_range = LtGadget::construct(cb, depth.expr(), 1025.expr());
+        let is_depth_in_range = cb.is_lt(depth.expr(), 1025.expr());
         let is_insufficient_balance =
             LtWordGadget::construct(cb, &caller_balance.to_word(), &value.to_word());
-        let is_nonce_in_range = LtGadget::construct(cb, caller_nonce.expr(), u64::MAX.expr());
+        let is_nonce_in_range = cb.is_lt(caller_nonce.expr(), u64::MAX.expr());
         let is_precheck_ok = and::expr([
             is_depth_in_range.expr(),
             not::expr(is_insufficient_balance.expr()),

--- a/zkevm-circuits/src/evm_circuit/execution/create.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/create.rs
@@ -209,7 +209,7 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                 // empty_code_hash_word))` to represent `(callee_nonce == 0 && (prev_code_hash_word
                 // == 0 or prev_code_hash_word == empty_code_hash_word))`
                 let prev_code_hash_word = prev_code_hash.to_word();
-                let prev_code_hash_is_zero = IsZeroWordGadget::construct(cb, &prev_code_hash_word);
+                let prev_code_hash_is_zero = cb.is_zero_word(&prev_code_hash_word);
                 cb.condition(not::expr(prev_code_hash_is_zero.expr()), |cb| {
                     cb.account_read(
                         contract_addr.to_word(),

--- a/zkevm-circuits/src/evm_circuit/execution/end_block.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/end_block.rs
@@ -36,7 +36,7 @@ impl<F: Field> ExecutionGadget<F> for EndBlockGadget<F> {
         let max_txs = cb.query_copy_cell();
         let max_rws = cb.query_copy_cell();
         let total_txs = cb.query_cell();
-        let total_txs_is_max_txs = IsEqualGadget::construct(cb, total_txs.expr(), max_txs.expr());
+        let total_txs_is_max_txs = cb.is_eq(total_txs.expr(), max_txs.expr());
         // Note that rw_counter starts at 1
         let is_empty_block = cb.is_eq(cb.curr.state.rw_counter.clone().expr(), 1.expr());
 

--- a/zkevm-circuits/src/evm_circuit/execution/end_block.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/end_block.rs
@@ -6,7 +6,7 @@ use crate::{
             constraint_builder::{
                 ConstrainBuilderCommon, EVMConstraintBuilder, StepStateTransition, Transition::Same,
             },
-            math_gadget::{IsEqualGadget, IsZeroGadget},
+            math_gadget::IsEqualGadget,
             not, CachedRegion, Cell,
         },
         witness::{Block, Call, ExecStep, Transaction},
@@ -22,7 +22,7 @@ use halo2_proofs::{circuit::Value, plonk::Error};
 pub(crate) struct EndBlockGadget<F> {
     total_txs: Cell<F>,
     total_txs_is_max_txs: IsEqualGadget<F>,
-    is_empty_block: IsZeroGadget<F>,
+    is_empty_block: IsEqualGadget<F>,
     max_rws: Cell<F>,
     max_txs: Cell<F>,
 }
@@ -38,8 +38,7 @@ impl<F: Field> ExecutionGadget<F> for EndBlockGadget<F> {
         let total_txs = cb.query_cell();
         let total_txs_is_max_txs = IsEqualGadget::construct(cb, total_txs.expr(), max_txs.expr());
         // Note that rw_counter starts at 1
-        let is_empty_block =
-            IsZeroGadget::construct(cb, cb.curr.state.rw_counter.clone().expr() - 1.expr());
+        let is_empty_block = cb.is_eq(cb.curr.state.rw_counter.clone().expr(), 1.expr());
 
         let total_rws_before_padding = cb.curr.state.rw_counter.clone().expr() - 1.expr()
             + select::expr(
@@ -126,7 +125,7 @@ impl<F: Field> ExecutionGadget<F> for EndBlockGadget<F> {
         step: &ExecStep,
     ) -> Result<(), Error> {
         self.is_empty_block
-            .assign(region, offset, F::from(u64::from(step.rwc) - 1))?;
+            .assign(region, offset, F::from(u64::from(step.rwc)), F::ONE)?;
         let max_rws = F::from(block.circuits_params.max_rws as u64);
         let max_rws_assigned = self.max_rws.assign(region, offset, Value::known(max_rws))?;
 

--- a/zkevm-circuits/src/evm_circuit/execution/end_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/end_tx.rs
@@ -67,7 +67,7 @@ impl<F: Field> ExecutionGadget<F> for EndTxGadget<F> {
         );
         let refund = cb.query_cell();
         cb.tx_refund_read(tx_id.expr(), WordLoHi::from_lo_unchecked(refund.expr()));
-        let effective_refund = MinMaxGadget::construct(cb, max_refund.quotient(), refund.expr());
+        let effective_refund = cb.min_max(max_refund.quotient(), refund.expr());
 
         // Add effective_refund * tx_gas_price back to caller's balance
         let mul_gas_price_by_refund = MulWordByU64Gadget::construct(

--- a/zkevm-circuits/src/evm_circuit/execution/end_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/end_tx.rs
@@ -85,7 +85,7 @@ impl<F: Field> ExecutionGadget<F> for EndTxGadget<F> {
         // Add gas_used * effective_tip to coinbase's balance
         let coinbase = cb.query_word_unchecked();
         let coinbase_code_hash = cb.query_word_unchecked();
-        let coinbase_code_hash_is_zero = IsZeroWordGadget::construct(cb, &coinbase_code_hash);
+        let coinbase_code_hash_is_zero = cb.is_zero_word(&coinbase_code_hash);
         cb.account_read(
             coinbase.to_word(),
             AccountFieldTag::CodeHash,

--- a/zkevm-circuits/src/evm_circuit/execution/error_code_store.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_code_store.rs
@@ -72,8 +72,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorCodeStoreGadget<F> {
         );
 
         // constrain code size > MAXCODESIZE
-        let max_code_size_exceed =
-            LtGadget::construct(cb, MAXCODESIZE.expr(), memory_address.length());
+        let max_code_size_exceed = cb.is_lt(MAXCODESIZE.expr(), memory_address.length());
 
         // check must be one of CodeStoreOutOfGas or MaxCodeSizeExceeded
         cb.require_in_set(

--- a/zkevm-circuits/src/evm_circuit/execution/error_invalid_creation_code.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_invalid_creation_code.rs
@@ -46,7 +46,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorInvalidCreationCodeGadget<F> {
         cb.memory_lookup(0.expr(), memory_address.offset(), first_byte.expr(), None);
 
         let is_first_byte_invalid =
-            IsEqualGadget::construct(cb, first_byte.expr(), INVALID_INIT_CODE_FIRST_BYTE.expr());
+            cb.is_eq(first_byte.expr(), INVALID_INIT_CODE_FIRST_BYTE.expr());
         cb.require_true(
             "is_first_byte_invalid is true",
             is_first_byte_invalid.expr(),

--- a/zkevm-circuits/src/evm_circuit/execution/error_invalid_jump.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_invalid_jump.rs
@@ -54,10 +54,10 @@ impl<F: Field> ExecutionGadget<F> for ErrorInvalidJumpGadget<F> {
             vec![OpcodeId::JUMP.expr(), OpcodeId::JUMPI.expr()],
         );
 
-        let is_jumpi = IsEqualGadget::construct(cb, opcode.expr(), OpcodeId::JUMPI.expr());
+        let is_jumpi = cb.is_eq(opcode.expr(), OpcodeId::JUMPI.expr());
 
         // initialize is_jump_dest
-        let is_jump_dest = IsEqualGadget::construct(cb, value.expr(), OpcodeId::JUMPDEST.expr());
+        let is_jump_dest = cb.is_eq(value.expr(), OpcodeId::JUMPDEST.expr());
 
         // first default this condition, if use will re-construct with real condition
         // value

--- a/zkevm-circuits/src/evm_circuit/execution/error_invalid_jump.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_invalid_jump.rs
@@ -61,7 +61,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorInvalidJumpGadget<F> {
 
         // first default this condition, if use will re-construct with real condition
         // value
-        let is_condition_zero = IsZeroWordGadget::construct(cb, &condition);
+        let is_condition_zero = cb.is_zero_word(&condition);
 
         // Pop the value from the stack
         cb.stack_pop(dest.original_word().to_word());

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_account_access.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_account_access.rs
@@ -62,8 +62,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGAccountAccessGadget<F> {
             GasCost::COLD_ACCOUNT_ACCESS.expr(),
         );
 
-        let insufficient_gas_cost =
-            LtGadget::construct(cb, cb.curr.state.gas_left.expr(), gas_cost);
+        let insufficient_gas_cost = cb.is_lt(cb.curr.state.gas_left.expr(), gas_cost);
 
         cb.require_equal(
             "Gas left is less than gas cost",

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_call.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_call.rs
@@ -79,7 +79,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGCallGadget<F> {
         let gas_cost = call_gadget.gas_cost_expr(is_warm.expr(), is_call.expr());
 
         // Check if the amount of gas available is less than the amount of gas required
-        let insufficient_gas = LtGadget::construct(cb, cb.curr.state.gas_left.expr(), gas_cost);
+        let insufficient_gas = cb.is_lt(cb.curr.state.gas_left.expr(), gas_cost);
 
         cb.require_equal(
             "Either Memory address is overflow or gas left is less than cost",

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_constant.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_constant.rs
@@ -38,8 +38,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGConstantGadget<F> {
         cb.constant_gas_lookup(opcode.expr(), gas_required.expr());
         // Check if the amount of gas available is less than the amount of gas
         // required
-        let insufficient_gas =
-            LtGadget::construct(cb, cb.curr.state.gas_left.expr(), gas_required.expr());
+        let insufficient_gas = cb.is_lt(cb.curr.state.gas_left.expr(), gas_required.expr());
         cb.require_equal(
             "constant gas left is less than gas required ",
             insufficient_gas.expr(),

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_create.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_create.rs
@@ -68,8 +68,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGCreateGadget<F> {
         cb.stack_pop(memory_address.length_word());
         cb.condition(is_create2.expr().0, |cb| cb.stack_pop(salt.to_word()));
 
-        let init_code_size_overflow =
-            LtGadget::construct(cb, MAX_INIT_CODE_SIZE.expr(), memory_address.length());
+        let init_code_size_overflow = cb.is_lt(MAX_INIT_CODE_SIZE.expr(), memory_address.length());
 
         let minimum_word_size = MemoryWordSizeGadget::construct(cb, memory_address.length());
         let memory_expansion = MemoryExpansionGadget::construct(cb, [memory_address.address()]);
@@ -81,7 +80,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGCreateGadget<F> {
                 CREATE_GAS_PER_CODE_WORD.expr(),
             );
         let gas_cost = GasCost::CREATE.expr() + memory_expansion.gas_cost() + code_store_gas_cost;
-        let insufficient_gas = LtGadget::construct(cb, cb.curr.state.gas_left.expr(), gas_cost);
+        let insufficient_gas = cb.is_lt(cb.curr.state.gas_left.expr(), gas_cost);
 
         cb.require_equal(
             "Memory address is overflow, init code size is overflow, or gas left is less than cost",

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_log.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_log.rs
@@ -55,7 +55,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGLogGadget<F> {
         cb.require_zero("is_static_call is false in LOGN", is_static_call.expr());
 
         let topic_count = opcode.expr() - OpcodeId::LOG0.as_u8().expr();
-        let is_opcode_logn = LtGadget::construct(cb, topic_count.clone(), 5.expr());
+        let is_opcode_logn = cb.is_lt(topic_count.clone(), 5.expr());
         cb.require_equal(
             "topic count in [0..5) which means opcode is Log0...Log4 ",
             is_opcode_logn.expr(),
@@ -73,7 +73,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGLogGadget<F> {
 
         // Check if the amount of gas available is less than the amount of gas
         // required
-        let insufficient_gas = LtGadget::construct(cb, cb.curr.state.gas_left.expr(), gas_cost);
+        let insufficient_gas = cb.is_lt(cb.curr.state.gas_left.expr(), gas_cost);
         cb.require_equal(
             "Memory address is overflow or gas left is less than cost",
             or::expr([memory_address.overflow(), insufficient_gas.expr()]),

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_precompile.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_precompile.rs
@@ -114,8 +114,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGPrecompileGadget<F> {
         );
 
         // gas_left < required_gas
-        let insufficient_gas =
-            LtGadget::construct(cb, cb.curr.state.gas_left.expr(), required_gas.expr());
+        let insufficient_gas = cb.is_lt(cb.curr.state.gas_left.expr(), required_gas.expr());
         cb.require_equal("gas_left < required_gas", insufficient_gas.expr(), 1.expr());
 
         let restore_context = RestoreContextGadget::construct2(

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_static_memory.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_static_memory.rs
@@ -55,7 +55,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGStaticMemoryGadget<F> {
         );
 
         // Check if this is an MSTORE8
-        let is_mstore8 = IsEqualGadget::construct(cb, opcode.expr(), OpcodeId::MSTORE8.expr());
+        let is_mstore8 = cb.is_eq(opcode.expr(), OpcodeId::MSTORE8.expr());
 
         // pop memory_offset from stack
         let memory_address = MemoryExpandedAddressGadget::construct_self(cb);

--- a/zkevm-circuits/src/evm_circuit/execution/error_return_data_oo_bound.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_return_data_oo_bound.rs
@@ -69,18 +69,17 @@ impl<F: Field> ExecutionGadget<F> for ErrorReturnDataOutOfBoundGadget<F> {
 
         // Check if `data_offset` is Uint64 overflow.
         let data_offset_larger_u64 = sum::expr(&data_offset.limbs[N_BYTES_U64..]);
-        let is_data_offset_within_u64 = IsZeroGadget::construct(cb, data_offset_larger_u64);
+        let is_data_offset_within_u64 = cb.is_zero(data_offset_larger_u64);
 
         // Check if `remainder_end` is Uint64 overflow.
         let sum = AddWordsGadget::construct(cb, [data_offset, size], remainder_end.clone());
         let is_end_u256_overflow = sum.carry().as_ref().unwrap();
 
         let remainder_end_larger_u64 = sum::expr(&remainder_end.limbs[N_BYTES_U64..]);
-        let is_remainder_end_within_u64 = IsZeroGadget::construct(cb, remainder_end_larger_u64);
+        let is_remainder_end_within_u64 = cb.is_zero(remainder_end_larger_u64);
 
         // check if `remainder_end` exceeds return data length.
-        let is_remainder_end_exceed_len = LtGadget::construct(
-            cb,
+        let is_remainder_end_exceed_len = cb.is_lt(
             return_data_length.expr(),
             from_bytes::expr(&remainder_end.limbs[..N_BYTES_U64]),
         );

--- a/zkevm-circuits/src/evm_circuit/execution/error_write_protection.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_write_protection.rs
@@ -41,7 +41,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorWriteProtectionGadget<F> {
         let gas_word = cb.query_word_unchecked();
         let code_address = cb.query_account_address();
         let value = cb.query_word_unchecked();
-        let is_value_zero = IsZeroWordGadget::construct(cb, &value);
+        let is_value_zero = cb.is_zero_word(&value);
 
         // require_in_set method will spilit into more low degree expressions if exceed
         // max_degree. otherwise need to do fixed lookup for these opcodes

--- a/zkevm-circuits/src/evm_circuit/execution/exp.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/exp.rs
@@ -78,11 +78,11 @@ impl<F: Field> ExecutionGadget<F> for ExponentiationGadget<F> {
 
         // We simplify constraints depending on whether or not the exponent is 0 or 1.
         // In order to do this, we build some utility expressions.
-        let exponent_lo_is_zero = IsZeroGadget::construct(cb, exponent_lo.clone());
-        let exponent_hi_is_zero = IsZeroGadget::construct(cb, exponent_hi.clone());
+        let exponent_lo_is_zero = cb.is_zero(exponent_lo.clone());
+        let exponent_hi_is_zero = cb.is_zero(exponent_hi.clone());
         let exponent_is_zero_expr =
             and::expr([exponent_lo_is_zero.expr(), exponent_hi_is_zero.expr()]);
-        let exponent_lo_is_one = IsEqualGadget::construct(cb, exponent_lo.clone(), 1.expr());
+        let exponent_lo_is_one = cb.is_eq(exponent_lo.clone(), 1.expr());
         let exponent_is_one_expr =
             and::expr([exponent_lo_is_one.expr(), exponent_hi_is_zero.expr()]);
 

--- a/zkevm-circuits/src/evm_circuit/execution/extcodecopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodecopy.rs
@@ -91,7 +91,7 @@ impl<F: Field> ExecutionGadget<F> for ExtcodecopyGadget<F> {
             AccountFieldTag::CodeHash,
             code_hash.to_word(),
         );
-        let not_exists = IsZeroWordGadget::construct(cb, &code_hash.to_word());
+        let not_exists = cb.is_zero_word(&code_hash.to_word());
         let exists = not::expr(not_exists.expr());
         cb.condition(exists.expr(), |cb| {
             cb.bytecode_length(code_hash.to_word(), code_size.expr());

--- a/zkevm-circuits/src/evm_circuit/execution/extcodesize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodesize.rs
@@ -69,7 +69,7 @@ impl<F: Field> ExecutionGadget<F> for ExtcodesizeGadget<F> {
             AccountFieldTag::CodeHash,
             code_hash.to_word(),
         );
-        let not_exists = IsZeroWordGadget::construct(cb, &code_hash);
+        let not_exists = cb.is_zero_word(&code_hash);
         let exists = not::expr(not_exists.expr());
 
         let code_size = cb.query_u64();

--- a/zkevm-circuits/src/evm_circuit/execution/invalid_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/invalid_tx.rs
@@ -47,7 +47,7 @@ impl<F: Field> ExecutionGadget<F> for InvalidTxGadget<F> {
             AccountFieldTag::Nonce,
             WordLoHi::from_lo_unchecked(account_nonce.expr()),
         );
-        let is_nonce_match = IsEqualGadget::construct(cb, account_nonce.expr(), tx.nonce.expr());
+        let is_nonce_match = cb.is_eq(account_nonce.expr(), tx.nonce.expr());
 
         // Check if the gas limit is larger or equal to the intrinsic gas cost
         let insufficient_gas_limit =

--- a/zkevm-circuits/src/evm_circuit/execution/invalid_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/invalid_tx.rs
@@ -60,8 +60,7 @@ impl<F: Field> ExecutionGadget<F> for InvalidTxGadget<F> {
             AccountFieldTag::Balance,
             balance.to_word(),
         );
-        let insufficient_balance =
-            LtWordGadget::construct(cb, &balance.to_word(), &tx.total_cost().to_word());
+        let insufficient_balance = cb.is_lt_word(&balance.to_word(), &tx.total_cost().to_word());
 
         // At least one of the invalid conditions needs to be true
         let invalid_tx = or::expr([

--- a/zkevm-circuits/src/evm_circuit/execution/is_zero.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/is_zero.rs
@@ -34,7 +34,7 @@ impl<F: Field> ExecutionGadget<F> for IsZeroGadget<F> {
         let opcode = cb.query_cell();
 
         let value = cb.query_word_unchecked();
-        let is_zero_word = math_gadget::IsZeroWordGadget::construct(cb, &value);
+        let is_zero_word = cb.is_zero_word(&value);
 
         cb.stack_pop(value.to_word());
         cb.stack_push(WordLoHi::from_lo_unchecked(is_zero_word.expr()));

--- a/zkevm-circuits/src/evm_circuit/execution/jumpi.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/jumpi.rs
@@ -44,7 +44,7 @@ impl<F: Field> ExecutionGadget<F> for JumpiGadget<F> {
         cb.stack_pop(condition.to_word());
 
         // Determine if the jump condition is met
-        let is_condition_zero = IsZeroWordGadget::construct(cb, &condition);
+        let is_condition_zero = cb.is_zero_word(&condition);
         let should_jump = 1.expr() - is_condition_zero.expr();
 
         // Lookup opcode at destination when should_jump

--- a/zkevm-circuits/src/evm_circuit/execution/memory.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/memory.rs
@@ -46,9 +46,9 @@ impl<F: Field> ExecutionGadget<F> for MemoryGadget<F> {
         let value = cb.query_word32();
 
         // Check if this is an MLOAD
-        let is_mload = IsEqualGadget::construct(cb, opcode.expr(), OpcodeId::MLOAD.expr());
+        let is_mload = cb.is_eq(opcode.expr(), OpcodeId::MLOAD.expr());
         // Check if this is an MSTORE8
-        let is_mstore8 = IsEqualGadget::construct(cb, opcode.expr(), OpcodeId::MSTORE8.expr());
+        let is_mstore8 = cb.is_eq(opcode.expr(), OpcodeId::MSTORE8.expr());
         // This is an MSTORE/MSTORE8
         let is_store = not::expr(is_mload.expr());
         // This is an MSTORE/MLOAD

--- a/zkevm-circuits/src/evm_circuit/execution/mul_div_mod.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/mul_div_mod.rs
@@ -64,7 +64,7 @@ impl<F: Field> ExecutionGadget<F> for MulDivModGadget<F> {
 
         let mul_add_words = MulAddWordsGadget::construct(cb, [&a, &b, &c, &d]);
         let divisor_is_zero = cb.is_zero_word(&b);
-        let lt_word = LtWordGadget::construct(cb, &c.to_word(), &b.to_word());
+        let lt_word = cb.is_lt_word(&c.to_word(), &b.to_word());
 
         // Pop a and b from the stack, push result on the stack
         // The first pop is multiplier for MUL and dividend for DIV/MOD

--- a/zkevm-circuits/src/evm_circuit/execution/mul_div_mod.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/mul_div_mod.rs
@@ -63,7 +63,7 @@ impl<F: Field> ExecutionGadget<F> for MulDivModGadget<F> {
         let d = cb.query_word32();
 
         let mul_add_words = MulAddWordsGadget::construct(cb, [&a, &b, &c, &d]);
-        let divisor_is_zero = IsZeroWordGadget::construct(cb, &b);
+        let divisor_is_zero = cb.is_zero_word(&b);
         let lt_word = LtWordGadget::construct(cb, &c.to_word(), &b.to_word());
 
         // Pop a and b from the stack, push result on the stack

--- a/zkevm-circuits/src/evm_circuit/execution/mulmod.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/mulmod.rs
@@ -71,7 +71,7 @@ impl<F: Field> ExecutionGadget<F> for MulModGadget<F> {
 
         // (r < n ) or n == 0
         let n_is_zero = cb.is_zero_word(&n);
-        let lt = LtWordGadget::construct(cb, &r.to_word(), &n.to_word());
+        let lt = cb.is_lt_word(&r.to_word(), &n.to_word());
         cb.add_constraint(
             " (1 - (r < n) - (n==0)) ",
             1.expr() - lt.expr() - n_is_zero.expr(),

--- a/zkevm-circuits/src/evm_circuit/execution/mulmod.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/mulmod.rs
@@ -70,7 +70,7 @@ impl<F: Field> ExecutionGadget<F> for MulModGadget<F> {
         let mul512_right = MulAddWords512Gadget::construct(cb, [&k, &n, &d, &e], Some(&r));
 
         // (r < n ) or n == 0
-        let n_is_zero = IsZeroWordGadget::construct(cb, &n);
+        let n_is_zero = cb.is_zero_word(&n);
         let lt = LtWordGadget::construct(cb, &r.to_word(), &n.to_word());
         cb.add_constraint(
             " (1 - (r < n) - (n==0)) ",

--- a/zkevm-circuits/src/evm_circuit/execution/push.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/push.rs
@@ -56,8 +56,7 @@ impl<F: Field> ExecutionGadget<F> for PushGadget<F> {
         cb.bytecode_length(cb.curr.state.code_hash.to_word(), code_length.expr());
 
         let num_bytes_needed = opcode.expr() - OpcodeId::PUSH0.expr();
-        let is_out_of_bound =
-            LtGadget::construct(cb, code_length_left.expr(), num_bytes_needed.expr());
+        let is_out_of_bound = cb.is_lt(code_length_left.expr(), num_bytes_needed.expr());
         let num_bytes_padding = select::expr(
             is_out_of_bound.expr(),
             num_bytes_needed.expr() - code_length_left.expr(),

--- a/zkevm-circuits/src/evm_circuit/execution/return_revert.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/return_revert.rs
@@ -92,7 +92,7 @@ impl<F: Field> ExecutionGadget<F> for ReturnRevertGadget<F> {
 
         // These are globally defined because they are used across multiple cases.
         let copy_rw_increase = cb.query_cell();
-        let copy_rw_increase_is_zero = IsZeroGadget::construct(cb, copy_rw_increase.expr());
+        let copy_rw_increase_is_zero = cb.is_zero(copy_rw_increase.expr());
 
         let memory_expansion = MemoryExpansionGadget::construct(cb, [range.address()]);
 

--- a/zkevm-circuits/src/evm_circuit/execution/return_revert.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/return_revert.rs
@@ -218,8 +218,7 @@ impl<F: Field> ExecutionGadget<F> for ReturnRevertGadget<F> {
                     CallContextFieldTag::ReturnDataLength,
                 ]
                 .map(|field_tag| cb.call_context(None, field_tag));
-                let copy_length =
-                    MinMaxGadget::construct(cb, return_data_length.expr(), range.length());
+                let copy_length = cb.min_max(return_data_length.expr(), range.length());
                 cb.require_equal(
                     "increase rw counter twice for each memory to memory byte copied",
                     copy_length.min() + copy_length.min(),

--- a/zkevm-circuits/src/evm_circuit/execution/sar.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sar.rs
@@ -99,8 +99,8 @@ impl<F: Field> ExecutionGadget<F> for SarGadget<F> {
         let p_lo = cb.query_cell();
         let p_hi = cb.query_cell();
         let p_top = cb.query_cell();
-        let is_neg = LtGadget::construct(cb, 127.expr(), a.limbs[31].expr());
-        let shf_lt256 = IsZeroGadget::construct(cb, sum::expr(&shift.limbs[1..32]));
+        let is_neg = cb.is_lt(127.expr(), a.limbs[31].expr());
+        let shf_lt256 = cb.is_zero(sum::expr(&shift.limbs[1..32]));
 
         for idx in 0..4 {
             cb.require_equal(
@@ -112,23 +112,23 @@ impl<F: Field> ExecutionGadget<F> for SarGadget<F> {
 
         // Constrain `a64s_lo[idx] < p_lo`.
         let a64s_lo_lt_p_lo = array_init(|idx| {
-            let lt = LtGadget::construct(cb, a64s_lo[idx].expr(), p_lo.expr());
+            let lt = cb.is_lt(a64s_lo[idx].expr(), p_lo.expr());
             cb.require_zero("a64s_lo[idx] < p_lo", 1.expr() - lt.expr());
             lt
         });
 
         // Constrain `a64s_hi[idx] < p_hi`.
         let a64s_hi_lt_p_hi = array_init(|idx| {
-            let lt = LtGadget::construct(cb, a64s_hi[idx].expr(), p_hi.expr());
+            let lt = cb.is_lt(a64s_hi[idx].expr(), p_hi.expr());
             cb.require_zero("a64s_hi[idx] < p_hi", 1.expr() - lt.expr());
             lt
         });
 
         // Merge contraints
-        let shf_lo_div64_eq0 = IsZeroGadget::construct(cb, shf_div64.expr());
-        let shf_lo_div64_eq1 = IsEqualGadget::construct(cb, shf_div64.expr(), 1.expr());
-        let shf_lo_div64_eq2 = IsEqualGadget::construct(cb, shf_div64.expr(), 2.expr());
-        let shf_lo_div64_eq3 = IsEqualGadget::construct(cb, shf_div64.expr(), 3.expr());
+        let shf_lo_div64_eq0 = cb.is_zero(shf_div64.expr());
+        let shf_lo_div64_eq1 = cb.is_eq(shf_div64.expr(), 1.expr());
+        let shf_lo_div64_eq2 = cb.is_eq(shf_div64.expr(), 2.expr());
+        let shf_lo_div64_eq3 = cb.is_eq(shf_div64.expr(), 3.expr());
         let shf_div64_eq0 = shf_lt256.expr() * shf_lo_div64_eq0.expr();
         let shf_div64_eq1 = shf_lt256.expr() * shf_lo_div64_eq1.expr();
         let shf_div64_eq2 = shf_lt256.expr() * shf_lo_div64_eq2.expr();
@@ -179,9 +179,9 @@ impl<F: Field> ExecutionGadget<F> for SarGadget<F> {
         );
 
         // Shift constraint
-        let shf_div64_lt_4 = LtGadget::construct(cb, shf_div64.expr(), 4.expr());
+        let shf_div64_lt_4 = cb.is_lt(shf_div64.expr(), 4.expr());
         cb.require_equal("shf_div64 < 4", shf_div64_lt_4.expr(), 1.expr());
-        let shf_mod64_lt_64 = LtGadget::construct(cb, shf_mod64.expr(), 64.expr());
+        let shf_mod64_lt_64 = cb.is_lt(shf_mod64.expr(), 64.expr());
         cb.require_equal("shf_mod64 < 64", shf_mod64_lt_64.expr(), 1.expr());
         cb.require_equal(
             "shift[0] == shf_mod64 + shf_div64 * 64",

--- a/zkevm-circuits/src/evm_circuit/execution/sdiv_smod.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sdiv_smod.rs
@@ -109,7 +109,7 @@ impl<F: Field> ExecutionGadget<F> for SignedDivModGadget<F> {
         // `sign(dividend) == sign(divisor) ^ sign(quotient)` cannot be applied
         // for this case.
         let dividend_is_signed_overflow =
-            LtGadget::construct(cb, 127.expr(), dividend_abs.x_abs().limbs[31].expr());
+            cb.is_lt(127.expr(), dividend_abs.x_abs().limbs[31].expr());
 
         // Constrain sign(dividend) == sign(divisor) ^ sign(quotient) when both
         // quotient and divisor are non-zero and dividend is not signed overflow.

--- a/zkevm-circuits/src/evm_circuit/execution/sdiv_smod.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sdiv_smod.rs
@@ -52,9 +52,9 @@ impl<F: Field> ExecutionGadget<F> for SignedDivModGadget<F> {
         let divisor_abs = AbsWordGadget::construct(cb);
         let remainder_abs = AbsWordGadget::construct(cb);
         let dividend_abs = AbsWordGadget::construct(cb);
-        let quotient_is_zero = IsZeroWordGadget::construct(cb, quotient_abs.x());
-        let divisor_is_zero = IsZeroWordGadget::construct(cb, divisor_abs.x());
-        let remainder_is_zero = IsZeroWordGadget::construct(cb, remainder_abs.x());
+        let quotient_is_zero = cb.is_zero_word(quotient_abs.x());
+        let divisor_is_zero = cb.is_zero_word(divisor_abs.x());
+        let remainder_is_zero = cb.is_zero_word(remainder_abs.x());
 
         cb.stack_pop(dividend_abs.x().to_word());
         cb.stack_pop(divisor_abs.x().to_word());

--- a/zkevm-circuits/src/evm_circuit/execution/shl_shr.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/shl_shr.rs
@@ -70,8 +70,8 @@ impl<F: Field> ExecutionGadget<F> for ShlShrGadget<F> {
         let mul_add_words =
             MulAddWordsGadget::construct(cb, [&quotient, &divisor, &remainder, &dividend]);
         let shf_lt256 = cb.is_zero(sum::expr(&shift.limbs[1..32]));
-        let divisor_is_zero = IsZeroWordGadget::construct(cb, &divisor);
-        let remainder_is_zero = IsZeroWordGadget::construct(cb, &remainder);
+        let divisor_is_zero = cb.is_zero_word(&divisor);
+        let remainder_is_zero = cb.is_zero_word(&remainder);
         let remainder_lt_divisor =
             LtWordGadget::construct(cb, &remainder.to_word(), &divisor.to_word());
 

--- a/zkevm-circuits/src/evm_circuit/execution/shl_shr.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/shl_shr.rs
@@ -69,7 +69,7 @@ impl<F: Field> ExecutionGadget<F> for ShlShrGadget<F> {
 
         let mul_add_words =
             MulAddWordsGadget::construct(cb, [&quotient, &divisor, &remainder, &dividend]);
-        let shf_lt256 = IsZeroGadget::construct(cb, sum::expr(&shift.limbs[1..32]));
+        let shf_lt256 = cb.is_zero(sum::expr(&shift.limbs[1..32]));
         let divisor_is_zero = IsZeroWordGadget::construct(cb, &divisor);
         let remainder_is_zero = IsZeroWordGadget::construct(cb, &remainder);
         let remainder_lt_divisor =

--- a/zkevm-circuits/src/evm_circuit/execution/shl_shr.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/shl_shr.rs
@@ -72,8 +72,7 @@ impl<F: Field> ExecutionGadget<F> for ShlShrGadget<F> {
         let shf_lt256 = cb.is_zero(sum::expr(&shift.limbs[1..32]));
         let divisor_is_zero = cb.is_zero_word(&divisor);
         let remainder_is_zero = cb.is_zero_word(&remainder);
-        let remainder_lt_divisor =
-            LtWordGadget::construct(cb, &remainder.to_word(), &divisor.to_word());
+        let remainder_lt_divisor = cb.is_lt_word(&remainder.to_word(), &divisor.to_word());
 
         // Constrain stack pops and pushes as:
         // - for SHL, two pops are shift and quotient, and push is dividend.

--- a/zkevm-circuits/src/evm_circuit/execution/signed_comparator.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/signed_comparator.rs
@@ -59,8 +59,8 @@ impl<F: Field> ExecutionGadget<F> for SignedComparatorGadget<F> {
         // number is negative if the most significant cell >= 128
         // (0b10000000). a and b being in the little-endian notation, the
         // most-significant byte is the last byte.
-        let sign_check_a = LtGadget::construct(cb, a.limbs[31].expr(), 128.expr());
-        let sign_check_b = LtGadget::construct(cb, b.limbs[31].expr(), 128.expr());
+        let sign_check_a = cb.is_lt(a.limbs[31].expr(), 128.expr());
+        let sign_check_b = cb.is_lt(b.limbs[31].expr(), 128.expr());
 
         // sign_check_a_lt expression implies a is positive since its MSB < 2**7
         // sign_check_b_lt expression implies b is positive since its MSB < 2**7
@@ -77,7 +77,7 @@ impl<F: Field> ExecutionGadget<F> for SignedComparatorGadget<F> {
         // b_hi) && (a_lo < b_lo)))
         let (a_lo, a_hi) = a.to_word().to_lo_hi();
         let (b_lo, b_hi) = b.to_word().to_lo_hi();
-        let lt_lo = LtGadget::construct(cb, a_lo, b_lo);
+        let lt_lo = cb.is_lt(a_lo, b_lo);
         let comparison_hi = ComparisonGadget::construct(cb, a_hi, b_hi);
         let a_lt_b_lo = lt_lo.expr();
         let (a_lt_b_hi, a_eq_b_hi) = comparison_hi.expr();

--- a/zkevm-circuits/src/evm_circuit/execution/signed_comparator.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/signed_comparator.rs
@@ -51,7 +51,7 @@ impl<F: Field> ExecutionGadget<F> for SignedComparatorGadget<F> {
         // The Signed Comparator gadget is used for both opcodes SLT and SGT.
         // Depending on whether the opcode is SLT or SGT, we
         // swap the order in which the inputs are placed on the stack.
-        let is_sgt = IsEqualGadget::construct(cb, opcode.expr(), OpcodeId::SGT.expr());
+        let is_sgt = cb.is_eq(opcode.expr(), OpcodeId::SGT.expr());
 
         // Both a and b are to be treated as two's complement signed 256-bit
         // (32 cells) integers. This means, the first bit denotes the sign

--- a/zkevm-circuits/src/evm_circuit/execution/signextend.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/signextend.rs
@@ -52,12 +52,11 @@ impl<F: Field> ExecutionGadget<F> for SignextendGadget<F> {
         // need to do any changes. So just sum all the non-LSB byte
         // values here and then check if it's non-zero so we can use
         // that as an additional condition to enable the selector.
-        let is_msb_sum_zero = IsZeroGadget::construct(cb, sum::expr(&index.limbs[1..32]));
+        let is_msb_sum_zero = cb.is_zero(sum::expr(&index.limbs[1..32]));
 
         // Check if this byte is selected looking only at the LSB of the index
         // word
-        let is_byte_selected =
-            array_init(|idx| IsEqualGadget::construct(cb, index.limbs[0].expr(), idx.expr()));
+        let is_byte_selected = array_init(|idx| cb.is_eq(index.limbs[0].expr(), idx.expr()));
 
         // We need to find the byte we have to get the sign from so we can
         // extend correctly. We go byte by byte and check if `idx ==

--- a/zkevm-circuits/src/evm_circuit/execution/sstore.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sstore.rs
@@ -248,9 +248,9 @@ impl<F: Field> SstoreTxRefundGadget<F> {
         value_prev: T,
         original_value: T,
     ) -> Self {
-        let value_prev_is_zero_gadget = IsZeroWordGadget::construct(cb, &value_prev.to_word());
-        let value_is_zero_gadget = IsZeroWordGadget::construct(cb, &value.to_word());
-        let original_is_zero_gadget = IsZeroWordGadget::construct(cb, &original_value.to_word());
+        let value_prev_is_zero_gadget = cb.is_zero_word(&value_prev.to_word());
+        let value_is_zero_gadget = cb.is_zero_word(&value.to_word());
+        let original_is_zero_gadget = cb.is_zero_word(&original_value.to_word());
 
         let original_eq_value_gadget =
             IsEqualWordGadget::construct(cb, &original_value.to_word(), &value.to_word());

--- a/zkevm-circuits/src/evm_circuit/execution/sstore.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sstore.rs
@@ -253,11 +253,11 @@ impl<F: Field> SstoreTxRefundGadget<F> {
         let original_is_zero_gadget = cb.is_zero_word(&original_value.to_word());
 
         let original_eq_value_gadget =
-            IsEqualWordGadget::construct(cb, &original_value.to_word(), &value.to_word());
+            cb.is_eq_word( &original_value.to_word(), &value.to_word());
         let prev_eq_value_gadget =
-            IsEqualWordGadget::construct(cb, &value_prev.to_word(), &value.to_word());
+            cb.is_eq_word( &value_prev.to_word(), &value.to_word());
         let original_eq_prev_gadget =
-            IsEqualWordGadget::construct(cb, &original_value.to_word(), &value_prev.to_word());
+            cb.is_eq_word( &original_value.to_word(), &value_prev.to_word());
 
         let value_prev_is_zero = value_prev_is_zero_gadget.expr();
         let value_is_zero = value_is_zero_gadget.expr();

--- a/zkevm-circuits/src/evm_circuit/execution/sstore.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sstore.rs
@@ -252,12 +252,10 @@ impl<F: Field> SstoreTxRefundGadget<F> {
         let value_is_zero_gadget = cb.is_zero_word(&value.to_word());
         let original_is_zero_gadget = cb.is_zero_word(&original_value.to_word());
 
-        let original_eq_value_gadget =
-            cb.is_eq_word( &original_value.to_word(), &value.to_word());
-        let prev_eq_value_gadget =
-            cb.is_eq_word( &value_prev.to_word(), &value.to_word());
+        let original_eq_value_gadget = cb.is_eq_word(&original_value.to_word(), &value.to_word());
+        let prev_eq_value_gadget = cb.is_eq_word(&value_prev.to_word(), &value.to_word());
         let original_eq_prev_gadget =
-            cb.is_eq_word( &original_value.to_word(), &value_prev.to_word());
+            cb.is_eq_word(&original_value.to_word(), &value_prev.to_word());
 
         let value_prev_is_zero = value_prev_is_zero_gadget.expr();
         let value_is_zero = value_is_zero_gadget.expr();

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -792,7 +792,7 @@ impl<F: Field, MemAddrGadget: CommonMemoryAddressGadget<F>, const IS_SUCCESS_CAL
             callee_code_hash.to_word(),
         );
         let is_empty_code_hash =
-            IsEqualWordGadget::construct(cb, &callee_code_hash, &cb.empty_code_hash());
+            cb.is_eq_word( &callee_code_hash, &cb.empty_code_hash());
         let callee_not_exists = cb.is_zero_word(&callee_code_hash);
 
         Self {
@@ -973,8 +973,8 @@ impl<F: Field, T: WordExpr<F> + Clone> SstoreGasGadget<F, T> {
         value_prev: T,
         original_value: T,
     ) -> Self {
-        let value_eq_prev = IsEqualWordGadget::construct(cb, &value, &value_prev);
-        let original_eq_prev = IsEqualWordGadget::construct(cb, &original_value, &value_prev);
+        let value_eq_prev = cb.is_eq_word( &value, &value_prev);
+        let original_eq_prev = cb.is_eq_word( &original_value, &value_prev);
         let original_is_zero = cb.is_zero_word(&original_value);
         let warm_case_gas = select::expr(
             value_eq_prev.expr(),

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -773,12 +773,12 @@ impl<F: Field, MemAddrGadget: CommonMemoryAddressGadget<F>, const IS_SUCCESS_CAL
         });
 
         // Recomposition of random linear combination to integer
-        let gas_is_u64 = IsZeroGadget::construct(cb, sum::expr(&gas_word.limbs[N_BYTES_GAS..]));
+        let gas_is_u64 = cb.is_zero(sum::expr(&gas_word.limbs[N_BYTES_GAS..]));
         let memory_expansion =
             MemoryExpansionGadget::construct(cb, [cd_address.address(), rd_address.address()]);
 
         // construct common gadget
-        let value_is_zero = IsZeroWordGadget::construct(cb, &value);
+        let value_is_zero = cb.is_zero_word(&value);
         let has_value = select::expr(
             is_delegatecall.expr() + is_staticcall.expr(),
             0.expr(),
@@ -1255,7 +1255,7 @@ impl<F: Field, const VALID_BYTES: usize> WordByteRangeGadget<F, VALID_BYTES> {
         debug_assert!(VALID_BYTES < 32);
 
         let original = cb.query_word32();
-        let not_overflow = IsZeroGadget::construct(cb, sum::expr(&original.limbs[VALID_BYTES..]));
+        let not_overflow = cb.is_zero(sum::expr(&original.limbs[VALID_BYTES..]));
 
         Self {
             original,

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -791,8 +791,7 @@ impl<F: Field, MemAddrGadget: CommonMemoryAddressGadget<F>, const IS_SUCCESS_CAL
             AccountFieldTag::CodeHash,
             callee_code_hash.to_word(),
         );
-        let is_empty_code_hash =
-            cb.is_eq_word( &callee_code_hash, &cb.empty_code_hash());
+        let is_empty_code_hash = cb.is_eq_word(&callee_code_hash, &cb.empty_code_hash());
         let callee_not_exists = cb.is_zero_word(&callee_code_hash);
 
         Self {
@@ -973,8 +972,8 @@ impl<F: Field, T: WordExpr<F> + Clone> SstoreGasGadget<F, T> {
         value_prev: T,
         original_value: T,
     ) -> Self {
-        let value_eq_prev = cb.is_eq_word( &value, &value_prev);
-        let original_eq_prev = cb.is_eq_word( &original_value, &value_prev);
+        let value_eq_prev = cb.is_eq_word(&value, &value_prev);
+        let original_eq_prev = cb.is_eq_word(&original_value, &value_prev);
         let original_is_zero = cb.is_zero_word(&original_value);
         let warm_case_gas = select::expr(
             value_eq_prev.expr(),
@@ -1193,7 +1192,7 @@ impl<F: Field, const VALID_BYTES: usize> WordByteCapGadget<F, VALID_BYTES> {
     pub(crate) fn construct(cb: &mut EVMConstraintBuilder<F>, cap: Expression<F>) -> Self {
         let word = WordByteRangeGadget::construct(cb);
         let value = select::expr(word.overflow(), cap.expr(), word.valid_value());
-        let lt_cap = LtGadget::construct(cb, value, cap);
+        let lt_cap = cb.is_lt(value, cap);
 
         Self { word, lt_cap }
     }

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -385,7 +385,7 @@ impl<F: Field> TransferToGadget<F> {
         mut reversion_info: Option<&mut ReversionInfo<F>>,
         account_write: bool,
     ) -> Self {
-        let value_is_zero = IsZeroWordGadget::construct(cb, &value);
+        let value_is_zero = cb.is_zero_word(&value);
         if account_write {
             Self::create_account(
                 cb,
@@ -497,7 +497,7 @@ impl<F: Field> TransferWithGasFeeGadget<F> {
     ) -> Self {
         let sender_sub_fee =
             UpdateBalanceGadget::construct(cb, sender_address.to_word(), vec![gas_fee], None);
-        let value_is_zero = IsZeroWordGadget::construct(cb, &value);
+        let value_is_zero = cb.is_zero_word(&value);
         // If receiver doesn't exist, create it
         TransferToGadget::create_account(
             cb,
@@ -618,7 +618,7 @@ impl<F: Field> TransferGadget<F> {
         value: Word32Cell<F>,
         reversion_info: &mut ReversionInfo<F>,
     ) -> Self {
-        let value_is_zero = IsZeroWordGadget::construct(cb, &value);
+        let value_is_zero = cb.is_zero_word(&value);
         // If receiver doesn't exist, create it
         TransferToGadget::create_account(
             cb,
@@ -793,7 +793,7 @@ impl<F: Field, MemAddrGadget: CommonMemoryAddressGadget<F>, const IS_SUCCESS_CAL
         );
         let is_empty_code_hash =
             IsEqualWordGadget::construct(cb, &callee_code_hash, &cb.empty_code_hash());
-        let callee_not_exists = IsZeroWordGadget::construct(cb, &callee_code_hash);
+        let callee_not_exists = cb.is_zero_word(&callee_code_hash);
 
         Self {
             is_success,
@@ -975,7 +975,7 @@ impl<F: Field, T: WordExpr<F> + Clone> SstoreGasGadget<F, T> {
     ) -> Self {
         let value_eq_prev = IsEqualWordGadget::construct(cb, &value, &value_prev);
         let original_eq_prev = IsEqualWordGadget::construct(cb, &original_value, &value_prev);
-        let original_is_zero = IsZeroWordGadget::construct(cb, &original_value);
+        let original_is_zero = cb.is_zero_word(&original_value);
         let warm_case_gas = select::expr(
             value_eq_prev.expr(),
             GasCost::WARM_ACCESS.expr(),

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -30,8 +30,10 @@ use halo2_proofs::{
 };
 
 use super::{
+    math_gadget::{IsEqualGadget, LtGadget, MinMaxGadget},
     rlc, AccountAddress, CachedRegion, CellType, MemoryAddress, StoredExpression, U64Cell,
 };
+use crate::evm_circuit::util::math_gadget::IsZeroGadget;
 
 // Max degree allowed in all expressions passing through the ConstraintBuilder.
 // It aims to cap `extended_k` to 2, which allows constraint degree to 2^2+1,
@@ -579,6 +581,31 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         constrain!(memory_word_size);
         constrain!(reversible_write_counter);
         constrain!(log_id);
+    }
+
+    // Sugars
+    pub(crate) fn is_zero(&mut self, value: Expression<F>) -> IsZeroGadget<F> {
+        IsZeroGadget::construct(self, value)
+    }
+
+    pub(crate) fn is_eq(&mut self, lhs: Expression<F>, rhs: Expression<F>) -> IsEqualGadget<F> {
+        IsEqualGadget::construct(self, lhs, rhs)
+    }
+
+    pub(crate) fn is_lt<const N_BYTES: usize>(
+        &mut self,
+        lhs: Expression<F>,
+        rhs: Expression<F>,
+    ) -> LtGadget<F, N_BYTES> {
+        LtGadget::construct(self, lhs, rhs)
+    }
+
+    pub(crate) fn min_max<const N_BYTES: usize>(
+        &mut self,
+        lhs: Expression<F>,
+        rhs: Expression<F>,
+    ) -> MinMaxGadget<F, N_BYTES> {
+        MinMaxGadget::construct(self, lhs, rhs)
     }
 
     // Fixed

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -585,6 +585,19 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
     }
 
     // Math gadgets
+
+    // abs_word
+    // add_word
+    // binary_number
+    // byte_size
+    // cmp_words
+    // comparison
+    // constant_division
+    // modulo
+    // mul_add_words
+    // mul_add_words512
+    // mul_word_u64
+
     pub(crate) fn is_zero(&mut self, value: Expression<F>) -> IsZeroGadget<F> {
         IsZeroGadget::construct(self, value)
     }

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -30,7 +30,7 @@ use halo2_proofs::{
 };
 
 use super::{
-    math_gadget::{IsEqualGadget, LtGadget, MinMaxGadget},
+    math_gadget::{IsEqualGadget, IsZeroWordGadget, LtGadget, MinMaxGadget},
     rlc, AccountAddress, CachedRegion, CellType, MemoryAddress, StoredExpression, U64Cell,
 };
 use crate::evm_circuit::util::math_gadget::IsZeroGadget;
@@ -583,9 +583,13 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         constrain!(log_id);
     }
 
-    // Sugars
+    // Math gadgets
     pub(crate) fn is_zero(&mut self, value: Expression<F>) -> IsZeroGadget<F> {
         IsZeroGadget::construct(self, value)
+    }
+
+    pub(crate) fn is_zero_word<T: WordExpr<F>>(&mut self, value: &T) -> IsZeroWordGadget<F, T> {
+        IsZeroWordGadget::construct(self, value)
     }
 
     pub(crate) fn is_eq(&mut self, lhs: Expression<F>, rhs: Expression<F>) -> IsEqualGadget<F> {

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -1,7 +1,7 @@
 use super::{
     math_gadget::{
-        IsEqualGadget, IsEqualWordGadget, IsZeroGadget, IsZeroWordGadget, LtGadget, LtWordGadget,
-        MinMaxGadget,
+        ConstantDivisionGadget, IsEqualGadget, IsEqualWordGadget, IsZeroGadget, IsZeroWordGadget,
+        LtGadget, LtWordGadget, MinMaxGadget,
     },
     rlc, AccountAddress, CachedRegion, CellType, MemoryAddress, StoredExpression, U64Cell,
 };
@@ -586,18 +586,6 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
 
     // Math gadgets
 
-    // abs_word
-    // add_word
-    // binary_number
-    // byte_size
-    // cmp_words
-    // comparison
-    // constant_division
-    // modulo
-    // mul_add_words
-    // mul_add_words512
-    // mul_word_u64
-
     pub(crate) fn is_zero(&mut self, value: Expression<F>) -> IsZeroGadget<F> {
         IsZeroGadget::construct(self, value)
     }
@@ -640,6 +628,14 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         rhs: Expression<F>,
     ) -> MinMaxGadget<F, N_BYTES> {
         MinMaxGadget::construct(self, lhs, rhs)
+    }
+
+    pub(crate) fn div_by_const<const N_BYTES: usize>(
+        &mut self,
+        numerator: Expression<F>,
+        denominator: u64,
+    ) -> ConstantDivisionGadget<F, N_BYTES> {
+        ConstantDivisionGadget::construct(self, numerator, denominator)
     }
 
     // Fixed

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -3,7 +3,10 @@ use crate::{
         param::STACK_CAPACITY,
         step::{ExecutionState, Step},
         table::{FixedTableTag, Lookup, RwValues, Table},
-        util::{Cell, RandomLinearCombination},
+        util::{
+            math_gadget::{IsEqualWordGadget, IsZeroGadget},
+            Cell, RandomLinearCombination,
+        },
     },
     table::{
         AccountFieldTag, BytecodeFieldTag, CallContextFieldTag, TxContextFieldTag, TxLogFieldTag,
@@ -33,7 +36,6 @@ use super::{
     math_gadget::{IsEqualGadget, IsZeroWordGadget, LtGadget, MinMaxGadget},
     rlc, AccountAddress, CachedRegion, CellType, MemoryAddress, StoredExpression, U64Cell,
 };
-use crate::evm_circuit::util::math_gadget::IsZeroGadget;
 
 // Max degree allowed in all expressions passing through the ConstraintBuilder.
 // It aims to cap `extended_k` to 2, which allows constraint degree to 2^2+1,
@@ -594,6 +596,14 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
 
     pub(crate) fn is_eq(&mut self, lhs: Expression<F>, rhs: Expression<F>) -> IsEqualGadget<F> {
         IsEqualGadget::construct(self, lhs, rhs)
+    }
+
+    pub(crate) fn is_eq_word<T1: WordExpr<F>, T2: WordExpr<F>>(
+        &mut self,
+        lhs: &T1,
+        rhs: &T2,
+    ) -> IsEqualWordGadget<F, T1, T2> {
+        IsEqualWordGadget::construct(self, lhs, rhs)
     }
 
     pub(crate) fn is_lt<const N_BYTES: usize>(

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -1,12 +1,16 @@
+use super::{
+    math_gadget::{
+        IsEqualGadget, IsEqualWordGadget, IsZeroGadget, IsZeroWordGadget, LtGadget, LtWordGadget,
+        MinMaxGadget,
+    },
+    rlc, AccountAddress, CachedRegion, CellType, MemoryAddress, StoredExpression, U64Cell,
+};
 use crate::{
     evm_circuit::{
         param::STACK_CAPACITY,
         step::{ExecutionState, Step},
         table::{FixedTableTag, Lookup, RwValues, Table},
-        util::{
-            math_gadget::{IsEqualWordGadget, IsZeroGadget},
-            Cell, RandomLinearCombination,
-        },
+        util::{Cell, RandomLinearCombination},
     },
     table::{
         AccountFieldTag, BytecodeFieldTag, CallContextFieldTag, TxContextFieldTag, TxLogFieldTag,
@@ -30,11 +34,6 @@ use halo2_proofs::{
         Expression::{self, Constant},
         VirtualCells,
     },
-};
-
-use super::{
-    math_gadget::{IsEqualGadget, IsZeroWordGadget, LtGadget, MinMaxGadget},
-    rlc, AccountAddress, CachedRegion, CellType, MemoryAddress, StoredExpression, U64Cell,
 };
 
 // Max degree allowed in all expressions passing through the ConstraintBuilder.
@@ -612,6 +611,14 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         rhs: Expression<F>,
     ) -> LtGadget<F, N_BYTES> {
         LtGadget::construct(self, lhs, rhs)
+    }
+
+    pub(crate) fn is_lt_word<T: Expr<F> + Clone>(
+        &mut self,
+        lhs: &WordLoHi<T>,
+        rhs: &WordLoHi<T>,
+    ) -> LtWordGadget<F> {
+        LtWordGadget::construct(self, lhs, rhs)
     }
 
     pub(crate) fn min_max<const N_BYTES: usize>(

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/abs_word.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/abs_word.rs
@@ -38,7 +38,7 @@ impl<F: Field> AbsWordGadget<F> {
         let sum = cb.query_word32();
         let (x_lo, x_hi) = x.to_word().to_lo_hi();
         let (x_abs_lo, x_abs_hi) = x_abs.to_word().to_lo_hi();
-        let is_neg = LtGadget::construct(cb, 127.expr(), x.limbs[31].expr());
+        let is_neg = cb.is_lt(127.expr(), x.limbs[31].expr());
 
         cb.add_constraint(
             "x_abs_lo == x_lo when x >= 0",

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/comparison.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/comparison.rs
@@ -22,7 +22,7 @@ impl<F: Field, const N_BYTES: usize> ComparisonGadget<F, N_BYTES> {
         rhs: Expression<F>,
     ) -> Self {
         let lt = LtGadget::<F, N_BYTES>::construct(cb, lhs, rhs);
-        let eq = IsZeroGadget::<F>::construct(cb, sum::expr(&lt.diff_bytes()));
+        let eq = cb.is_zero(sum::expr(&lt.diff_bytes()));
 
         Self { lt, eq }
     }

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/comparison.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/comparison.rs
@@ -21,7 +21,7 @@ impl<F: Field, const N_BYTES: usize> ComparisonGadget<F, N_BYTES> {
         lhs: Expression<F>,
         rhs: Expression<F>,
     ) -> Self {
-        let lt = LtGadget::<F, N_BYTES>::construct(cb, lhs, rhs);
+        let lt = cb.is_lt(lhs, rhs);
         let eq = cb.is_zero(sum::expr(&lt.diff_bytes()));
 
         Self { lt, eq }

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/is_equal.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/is_equal.rs
@@ -16,7 +16,7 @@ impl<F: Field> IsEqualGadget<F> {
         lhs: Expression<F>,
         rhs: Expression<F>,
     ) -> Self {
-        let is_zero = IsZeroGadget::construct(cb, lhs - rhs);
+        let is_zero = cb.is_zero(lhs - rhs);
 
         Self { is_zero }
     }

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/is_equal_word.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/is_equal_word.rs
@@ -14,13 +14,13 @@ use crate::{
     util::word::{WordExpr, WordLoHi},
 };
 
-use super::IsZeroGadget;
+use super::IsEqualGadget;
 
 /// Returns `1` when `lhs == rhs`, and returns `0` otherwise.
 #[derive(Clone, Debug)]
 pub struct IsEqualWordGadget<F, T1, T2> {
-    is_zero_lo: IsZeroGadget<F>,
-    is_zero_hi: IsZeroGadget<F>,
+    is_zero_lo: IsEqualGadget<F>,
+    is_zero_hi: IsEqualGadget<F>,
     _marker: PhantomData<(T1, T2)>,
 }
 
@@ -28,8 +28,8 @@ impl<F: Field, T1: WordExpr<F>, T2: WordExpr<F>> IsEqualWordGadget<F, T1, T2> {
     pub(crate) fn construct(cb: &mut EVMConstraintBuilder<F>, lhs: &T1, rhs: &T2) -> Self {
         let (lhs_lo, lhs_hi) = lhs.to_word().to_lo_hi();
         let (rhs_lo, rhs_hi) = rhs.to_word().to_lo_hi();
-        let is_zero_lo = IsZeroGadget::construct(cb, lhs_lo - rhs_lo);
-        let is_zero_hi = IsZeroGadget::construct(cb, lhs_hi - rhs_hi);
+        let is_zero_lo = cb.is_eq(lhs_lo, rhs_lo);
+        let is_zero_hi = cb.is_eq(lhs_hi, rhs_hi);
 
         Self {
             is_zero_lo,
@@ -51,8 +51,8 @@ impl<F: Field, T1: WordExpr<F>, T2: WordExpr<F>> IsEqualWordGadget<F, T1, T2> {
     ) -> Result<F, Error> {
         let (lhs_lo, lhs_hi) = lhs.to_lo_hi();
         let (rhs_lo, rhs_hi) = rhs.to_lo_hi();
-        self.is_zero_lo.assign(region, offset, lhs_lo - rhs_lo)?;
-        self.is_zero_hi.assign(region, offset, lhs_hi - rhs_hi)?;
+        self.is_zero_lo.assign(region, offset, lhs_lo, rhs_lo)?;
+        self.is_zero_hi.assign(region, offset, lhs_hi, rhs_hi)?;
         Ok(F::from(2))
     }
 

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/lt_word.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/lt_word.rs
@@ -24,7 +24,7 @@ impl<F: Field> LtWordGadget<F> {
         let (lhs_lo, lhs_hi) = lhs.to_lo_hi();
         let (rhs_lo, rhs_hi) = rhs.to_lo_hi();
         let comparison_hi = ComparisonGadget::construct(cb, lhs_hi.expr(), rhs_hi.expr());
-        let lt_lo = LtGadget::construct(cb, lhs_lo.expr(), rhs_lo.expr());
+        let lt_lo = cb.is_lt(lhs_lo.expr(), rhs_lo.expr());
         Self {
             comparison_hi,
             lt_lo,

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/min_max.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/min_max.rs
@@ -19,7 +19,7 @@ impl<F: Field, const N_BYTES: usize> MinMaxGadget<F, N_BYTES> {
         lhs: Expression<F>,
         rhs: Expression<F>,
     ) -> Self {
-        let lt = LtGadget::construct(cb, lhs.clone(), rhs.clone());
+        let lt = cb.is_lt(lhs.clone(), rhs.clone());
         let max = select::expr(lt.expr(), rhs.clone(), lhs.clone());
         let min = select::expr(lt.expr(), lhs, rhs);
 

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/modulo.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/modulo.rs
@@ -39,7 +39,7 @@ impl<F: Field> ModGadget<F> {
         let n_is_zero = cb.is_zero_word(n);
         let a_or_is_zero = cb.is_zero_word(&a_or_zero);
         let mul_add_words = MulAddWordsGadget::construct(cb, [&k, n, r, &a_or_zero]);
-        let eq = cb.is_eq_word( a, &a_or_zero);
+        let eq = cb.is_eq_word(a, &a_or_zero);
         let lt = LtWordGadget::construct(cb, &r.to_word(), &n.to_word());
         // Constrain the aux variable a_or_zero to be =a or =0 if n==0:
         // (a == a_or_zero) ^ (n == 0 & a_or_zero == 0)

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/modulo.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/modulo.rs
@@ -39,7 +39,7 @@ impl<F: Field> ModGadget<F> {
         let n_is_zero = cb.is_zero_word(n);
         let a_or_is_zero = cb.is_zero_word(&a_or_zero);
         let mul_add_words = MulAddWordsGadget::construct(cb, [&k, n, r, &a_or_zero]);
-        let eq = IsEqualWordGadget::construct(cb, a, &a_or_zero);
+        let eq = cb.is_eq_word( a, &a_or_zero);
         let lt = LtWordGadget::construct(cb, &r.to_word(), &n.to_word());
         // Constrain the aux variable a_or_zero to be =a or =0 if n==0:
         // (a == a_or_zero) ^ (n == 0 & a_or_zero == 0)

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/modulo.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/modulo.rs
@@ -36,8 +36,8 @@ impl<F: Field> ModGadget<F> {
         let (a, n, r) = (words[0], words[1], words[2]);
         let k = cb.query_word32();
         let a_or_zero = cb.query_word32();
-        let n_is_zero = IsZeroWordGadget::construct(cb, n);
-        let a_or_is_zero = IsZeroWordGadget::construct(cb, &a_or_zero);
+        let n_is_zero = cb.is_zero_word(n);
+        let a_or_is_zero = cb.is_zero_word(&a_or_zero);
         let mul_add_words = MulAddWordsGadget::construct(cb, [&k, n, r, &a_or_zero]);
         let eq = IsEqualWordGadget::construct(cb, a, &a_or_zero);
         let lt = LtWordGadget::construct(cb, &r.to_word(), &n.to_word());

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/modulo.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/modulo.rs
@@ -40,7 +40,7 @@ impl<F: Field> ModGadget<F> {
         let a_or_is_zero = cb.is_zero_word(&a_or_zero);
         let mul_add_words = MulAddWordsGadget::construct(cb, [&k, n, r, &a_or_zero]);
         let eq = cb.is_eq_word(a, &a_or_zero);
-        let lt = LtWordGadget::construct(cb, &r.to_word(), &n.to_word());
+        let lt = cb.is_lt_word(&r.to_word(), &n.to_word());
         // Constrain the aux variable a_or_zero to be =a or =0 if n==0:
         // (a == a_or_zero) ^ (n == 0 & a_or_zero == 0)
         cb.add_constraint(

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/rlp.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/rlp.rs
@@ -48,7 +48,7 @@ impl<F: Field> RlpU64Gadget<F> {
                 .zip(&is_most_significant_byte)
                 .map(|(byte, indicator)| byte.expr() * indicator.expr()),
         );
-        let most_significant_byte_is_zero = IsZeroGadget::construct(cb, most_significant_byte);
+        let most_significant_byte_is_zero = cb.is_zero(most_significant_byte);
         let is_lt_128 = cb.query_bool();
 
         let value = expr_from_bytes(&value_rlc.cells);

--- a/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
@@ -339,7 +339,7 @@ pub(crate) struct MemoryWordSizeGadget<F> {
 
 impl<F: Field> MemoryWordSizeGadget<F> {
     pub(crate) fn construct(cb: &mut EVMConstraintBuilder<F>, address: Expression<F>) -> Self {
-        let memory_word_size = ConstantDivisionGadget::construct(cb, address + 31.expr(), 32);
+        let memory_word_size = cb.div_by_const(address + 31.expr(), 32);
 
         Self { memory_word_size }
     }

--- a/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
@@ -612,7 +612,7 @@ impl<F: Field, const MAX_BYTES: usize, const ADDR_SIZE_IN_BYTES: usize>
         let is_empty = not::expr(&selectors[0]);
         let cap = select::expr(is_empty.expr(), 0.expr(), MAX_BYTES.expr());
         let signed_len = addr_end - addr_start;
-        let min_gadget = MinMaxGadget::construct(cb, cap, signed_len);
+        let min_gadget = cb.min_max(cap, signed_len);
 
         // If we claim that the buffer is empty, we prove that the end is at or before the start.
         //     buffer_len = max(0, signed_len) = 0

--- a/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
@@ -85,7 +85,7 @@ impl<F: Field> MemoryAddressGadget<F> {
         memory_offset: WordLoHiCell<F>,
         memory_length: MemoryAddress<F>,
     ) -> Self {
-        let memory_length_is_zero = IsZeroGadget::construct(cb, memory_length.sum_expr());
+        let memory_length_is_zero = cb.is_zero(memory_length.sum_expr());
         let memory_offset_bytes = cb.query_memory_address();
 
         let has_length = 1.expr() - memory_length_is_zero.expr();
@@ -196,16 +196,15 @@ impl<F: Field> CommonMemoryAddressGadget<F> for MemoryExpandedAddressGadget<F> {
         let length = cb.query_word32();
         let sum = cb.query_word32();
 
-        let sum_lt_cap = LtGadget::construct(
-            cb,
+        let sum_lt_cap = cb.is_lt(
             from_bytes::expr(&sum.limbs[..N_BYTES_U64]),
             (MAX_EXPANDED_MEMORY_ADDRESS + 1).expr(),
         );
 
         let sum_overflow_hi = sum::expr(&sum.limbs[N_BYTES_U64..]);
-        let sum_within_u64 = IsZeroGadget::construct(cb, sum_overflow_hi);
+        let sum_within_u64 = cb.is_zero(sum_overflow_hi);
 
-        let length_is_zero = IsZeroGadget::construct(cb, sum::expr(&length.limbs));
+        let length_is_zero = cb.is_zero(sum::expr(&length.limbs));
         let offset_length_sum = AddWordsGadget::construct(cb, [offset, length], sum);
 
         Self {

--- a/zkevm-circuits/src/evm_circuit/util/tx.rs
+++ b/zkevm-circuits/src/evm_circuit/util/tx.rs
@@ -81,7 +81,7 @@ impl<F: Field> EndTxHelperGadget<F> {
         gas_used: Expression<F>,
         num_rw: Expression<F>,
     ) -> Self {
-        let is_first_tx = IsEqualGadget::construct(cb, tx_id.expr(), 1.expr());
+        let is_first_tx = cb.is_eq(tx_id.expr(), 1.expr());
 
         // Constrain tx receipt fields
         cb.tx_receipt_lookup(

--- a/zkevm-circuits/src/evm_circuit/util/tx.rs
+++ b/zkevm-circuits/src/evm_circuit/util/tx.rs
@@ -240,8 +240,7 @@ impl<F: Field> TxDataGadget<F> {
         // Calculate transaction gas fee
         let mul_gas_fee_by_gas = MulWordByU64Gadget::construct(cb, gas_price.clone(), gas.expr());
 
-        let call_data_word_length =
-            ConstantDivisionGadget::construct(cb, call_data_length.expr() + 31.expr(), 32);
+        let call_data_word_length = cb.div_by_const(call_data_length.expr() + 31.expr(), 32);
 
         let (cost_sum, gas_mul_gas_price_plus_value) = if calculate_total_cost {
             let cost_sum = cb.query_word32();


### PR DESCRIPTION
### Description

We improve the readability by sweeping gadget constructors under the constraint builder.


### Issue Link

Quick search and replace

### Type of change

Refactor (no updates to logic)

### Contents

- changed `XGadget::construct(cb, ...)` to `cb.x(...)`
- some IsZero checks are replaced with IsEqual checks.

### Rationale

We keep consumption of the following gadgets unchanged because they are not used frequently enough.

-  abs_word
-  add_word
-  binary_number
-  byte_size
-  cmp_words
-  comparison
-  modulo
-  mul_add_words
-  mul_add_words512
-  mul_word_u64