### PR TITLE
refactor: opti build circuit input by cache previous block hashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,6 +356,7 @@ dependencies = [
  "hex",
  "itertools 0.10.5",
  "lazy_static",
+ "linked-hash-map",
  "log",
  "mock",
  "pretty_assertions",

--- a/bus-mapping/Cargo.toml
+++ b/bus-mapping/Cargo.toml
@@ -22,6 +22,9 @@ strum = "0.24"
 strum_macros = "0.24"
 revm-precompile = { version = "=2.2.0", default-features = false, optional = true }
 
+tokio = { version = "1.16.1", features = ["macros", "rt-multi-thread"] }
+linked-hash-map = "0.5.6"
+
 [dev-dependencies]
 hex = "0.4.3"
 pretty_assertions = "1.0.0"


### PR DESCRIPTION
### Description

When proving each block,  to construct the witness needs to obtain at least the previous(except the block number > 256) block hash, which need 256 times RPC.(It's a bit cost).

* Analysis
Support each block needs 8s. The oldest block which the witness needed has existed `8s*256=2048s=34mins`.
This means, that when the proving time is within 34min, some of the previous block hash can be reused.

* Solution
Add cache for them.


### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor (no updates to logic)

### Contents

- [_item_]

### Rationale

[_design decisions and extended information_]

### How Has This Been Tested?

[_explanation_]

<hr>

## How to fill a PR description 

Please give a concise description of your PR.

The target readers could be future developers, reviewers, and auditors. By reading your description, they should easily understand the changes proposed in this pull request.

MUST: Reference the issue to resolve

### Single responsibility

Is RECOMMENDED to create single responsibility commits, but not mandatory.

Anyway, you MUST enumerate the changes in a unitary way, e.g.

```
This PR contains:
- Cleanup of xxxx, yyyy
- Changed xxxx to yyyy in order to bla bla
- Added xxxx function to ...
- Refactored ....
```

### Design choices

RECOMMENDED to:
- What types of design choices did you face?
- What decisions you have made?
- Any valuable information that could help reviewers to think critically
