### PR TITLE
Change testool URL (enforce HTTP to HTTPS redirection)

### DIFF
--- a/.github/testoolScripts/cleanup.sh
+++ b/.github/testoolScripts/cleanup.sh
@@ -6,7 +6,7 @@ runner_vpc_id="vpc-05dedcb650bd24f8d"
 # Get runner status
 runner=$(aws ec2 describe-instances --profile $profile --filters Name=tag:Name,Values=[testool] Name=network-interface.vpc-id,Values=[$runner_vpc_id] --query "Reservations[*].Instances[*][InstanceId]" --output text | xargs)
 
-echo "Reports: http://testool-public.s3-website.eu-central-1.amazonaws.com"
+echo "Reports: https://testool.pse.dev"
 echo "Shuting down instance..."
 aws ec2 stop-instances --profile $profile --instance-ids $runner
 


### PR DESCRIPTION
### Description

The testool URL has been changed and now points to a CloudFront distribution domain name. Access to the testool S3 bucket is through CloudFront in order to enforce HTTP to HTTPS redirection.

### Issue Link

As requested in a Discord discussion

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor (no updates to logic)


### How Has This Been Tested?
Executed the workflow manually