### PR TITLE
[proof chunk] [WIP] [testing] fix various issue found in integration test

### DIFF
--- a/.github/workflows/main-tests.yml
+++ b/.github/workflows/main-tests.yml
@@ -133,12 +133,16 @@ jobs:
           sudo chmod +x /usr/bin/solc
       - name: Update ERC20 git submodule
         run: git submodule update --init --recursive --checkout integration-tests/contracts/vendor/openzeppelin-contracts
+      - name: Run root test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --package zkevm-circuits --lib -- root_circuit::test::test_root_circuit_multiple_chunk --exact --ignored
       - name: Run heavy tests # heavy tests are run serially to avoid OOM
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --verbose --release --all --all-features --exclude integration-tests --exclude circuit-benchmarks serial_ -- --ignored --test-threads 1
-
   build:
     needs: [skip_check]
     if: |

--- a/.github/workflows/main-tests.yml
+++ b/.github/workflows/main-tests.yml
@@ -133,16 +133,12 @@ jobs:
           sudo chmod +x /usr/bin/solc
       - name: Update ERC20 git submodule
         run: git submodule update --init --recursive --checkout integration-tests/contracts/vendor/openzeppelin-contracts
-      - name: Run root test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --package zkevm-circuits --lib -- root_circuit::test::test_root_circuit_multiple_chunk --exact --ignored
       - name: Run heavy tests # heavy tests are run serially to avoid OOM
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --verbose --release --all --all-features --exclude integration-tests --exclude circuit-benchmarks serial_ -- --ignored --test-threads 1
+
   build:
     needs: [skip_check]
     if: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2179,6 +2179,7 @@ dependencies = [
  "ethers-contract-abigen",
  "glob",
  "halo2_proofs",
+ "itertools 0.10.5",
  "lazy_static",
  "log",
  "mock",

--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -556,16 +556,17 @@ impl<'a, C: CircuitsParams> CircuitInputBuilder<C> {
     pub fn commit_chunk(
         &mut self,
         to_next: bool,
-        end_tx: usize,
-        end_copy: usize,
+        next_tx_index: usize,
+        next_copy_index: usize,
         last_call: Option<Call>,
     ) {
         self.chunk_ctx.end_rwc = self.block_ctx.rwc.0;
-        self.chunk_ctx.end_tx = end_tx;
-        self.chunk_ctx.end_copy = end_copy;
+        self.chunk_ctx.end_tx_index = next_tx_index;
+        self.chunk_ctx.end_copy_index = next_copy_index;
         self.chunks[self.chunk_ctx.idx].ctx = self.chunk_ctx.clone();
         if to_next {
-            self.chunk_ctx.bump(self.block_ctx.rwc.0, end_tx, end_copy);
+            self.chunk_ctx
+                .bump(self.block_ctx.rwc.0, next_tx_index, next_copy_index);
             self.cur_chunk_mut().prev_last_call = last_call;
         }
     }

--- a/bus-mapping/src/circuit_input_builder/chunk.rs
+++ b/bus-mapping/src/circuit_input_builder/chunk.rs
@@ -25,6 +25,7 @@ pub struct ChunkContext {
     /// Index of current chunk, start from 0
     pub idx: usize,
     /// Used to track the inner chunk counter in every operation in the chunk.
+    /// it will be reset for every new chunk.
     /// Contains the next available value.
     pub rwc: RWCounter,
     /// Number of chunks
@@ -41,7 +42,7 @@ pub struct ChunkContext {
     pub initial_copy_index: usize,
     ///
     pub end_copy_index: usize,
-    /// Druing dry run, chuncking is desabled
+    /// Druing dry run, chuncking is disabled
     pub enable: bool,
 }
 

--- a/bus-mapping/src/circuit_input_builder/chunk.rs
+++ b/bus-mapping/src/circuit_input_builder/chunk.rs
@@ -33,14 +33,14 @@ pub struct ChunkContext {
     pub initial_rwc: usize,
     /// End global rw counter
     pub end_rwc: usize,
+    /// tx range in block: [initial_tx_index, end_tx_index)
+    pub initial_tx_index: usize,
     ///
-    pub initial_tx: usize,
+    pub end_tx_index: usize,
+    ///  copy range in block: [initial_copy_index, end_copy_index)
+    pub initial_copy_index: usize,
     ///
-    pub end_tx: usize,
-    ///
-    pub initial_copy: usize,
-    ///
-    pub end_copy: usize,
+    pub end_copy_index: usize,
     /// Druing dry run, chuncking is desabled
     pub enable: bool,
 }
@@ -60,10 +60,10 @@ impl ChunkContext {
             total_chunks,
             initial_rwc: 1, // rw counter start from 1
             end_rwc: 0,     // end_rwc should be set in later phase
-            initial_tx: 1,
-            end_tx: 0,
-            initial_copy: 0,
-            end_copy: 0,
+            initial_tx_index: 0,
+            end_tx_index: 0,
+            initial_copy_index: 0,
+            end_copy_index: 0,
             enable: true,
         }
     }
@@ -76,10 +76,10 @@ impl ChunkContext {
             total_chunks: 1,
             initial_rwc: 1, // rw counter start from 1
             end_rwc: 0,     // end_rwc should be set in later phase
-            initial_tx: 1,
-            end_tx: 0,
-            initial_copy: 0,
-            end_copy: 0,
+            initial_tx_index: 0,
+            end_tx_index: 0,
+            initial_copy_index: 0,
+            end_copy_index: 0,
             enable: true,
         }
     }
@@ -91,11 +91,11 @@ impl ChunkContext {
         self.idx += 1;
         self.rwc = RWCounter::new();
         self.initial_rwc = initial_rwc;
-        self.initial_tx = initial_tx;
-        self.initial_copy = initial_copy;
+        self.initial_tx_index = initial_tx;
+        self.initial_copy_index = initial_copy;
         self.end_rwc = 0;
-        self.end_tx = 0;
-        self.end_copy = 0;
+        self.end_tx_index = 0;
+        self.end_copy_index = 0;
     }
 
     /// Is first chunk

--- a/bus-mapping/src/circuit_input_builder/chunk.rs
+++ b/bus-mapping/src/circuit_input_builder/chunk.rs
@@ -42,8 +42,6 @@ pub struct ChunkContext {
     pub initial_copy_index: usize,
     ///
     pub end_copy_index: usize,
-    /// Druing dry run, chuncking is disabled
-    pub enable: bool,
 }
 
 impl Default for ChunkContext {
@@ -65,7 +63,6 @@ impl ChunkContext {
             end_tx_index: 0,
             initial_copy_index: 0,
             end_copy_index: 0,
-            enable: true,
         }
     }
 
@@ -81,7 +78,6 @@ impl ChunkContext {
             end_tx_index: 0,
             initial_copy_index: 0,
             end_copy_index: 0,
-            enable: true,
         }
     }
 

--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -148,9 +148,13 @@ impl<'a> CircuitInputStateRef<'a> {
     /// Check whether rws will overflow circuit limit.
     pub fn check_rw_num_limit(&self) -> Result<(), Error> {
         if let Some(max_rws) = self.max_rws {
-            let rwc = self.block_ctx.rwc.0;
+            let rwc = self.chunk_ctx.rwc.0;
             if rwc > max_rws {
-                log::error!("rwc > max_rws, rwc={}, max_rws={}", rwc, max_rws);
+                log::error!(
+                    "chunk inner rwc > max_rws, rwc={}, max_rws={}",
+                    rwc,
+                    max_rws
+                );
                 return Err(Error::RwsNotEnough(max_rws, rwc));
             };
         }

--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -67,6 +67,7 @@ impl<'a> CircuitInputStateRef<'a> {
             exec_state: ExecState::InvalidTx,
             gas_left: self.tx.gas(),
             rwc: self.block_ctx.rwc,
+            rwc_inner_chunk: self.chunk_ctx.rwc,
             ..Default::default()
         }
     }

--- a/circuit-benchmarks/src/copy_circuit.rs
+++ b/circuit-benchmarks/src/copy_circuit.rs
@@ -156,7 +156,7 @@ mod tests {
         .handle_block(&block.eth_block, &block.geth_traces)
         .unwrap();
         let block = block_convert(&builder).unwrap();
-        let chunk = chunk_convert(&builder, 0).unwrap();
+        let chunk = chunk_convert(&block, &builder).unwrap().remove(0);
         assert_eq!(block.copy_events.len(), copy_event_num);
         (block, chunk)
     }

--- a/circuit-benchmarks/src/evm_circuit.rs
+++ b/circuit-benchmarks/src/evm_circuit.rs
@@ -54,7 +54,7 @@ mod evm_circ_benches {
                 .unwrap();
 
         let block = block_convert(&builder).unwrap();
-        let chunk = chunk_convert(&builder, 0).unwrap();
+        let chunk = chunk_convert(&block, &builder).unwrap().remove(0);
 
         let circuit = TestEvmCircuit::<Fr>::new(block, chunk);
         let mut rng = XorShiftRng::from_seed([

--- a/circuit-benchmarks/src/exp_circuit.rs
+++ b/circuit-benchmarks/src/exp_circuit.rs
@@ -149,9 +149,8 @@ mod tests {
             .new_circuit_input_builder()
             .handle_block(&block.eth_block, &block.geth_traces)
             .unwrap();
-        (
-            block_convert(&builder).unwrap(),
-            chunk_convert(&builder, 0).unwrap(),
-        )
+        let block = block_convert(&builder).unwrap();
+        let chunk = chunk_convert(&block, &builder).unwrap().remove(0);
+        (block, chunk)
     }
 }

--- a/circuit-benchmarks/src/super_circuit.rs
+++ b/circuit-benchmarks/src/super_circuit.rs
@@ -91,8 +91,9 @@ mod tests {
             max_evm_rows: 0,
             max_keccak_rows: 0,
         };
-        let (_, circuit, instance, _) =
+        let (_, mut circuits, mut instances, _) =
             SuperCircuit::build(block, circuits_params, Fr::from(0x100)).unwrap();
+        let (circuit, instance) = (circuits.remove(0), instances.remove(0));
         let instance_refs: Vec<&[Fr]> = instance.iter().map(|v| &v[..]).collect();
 
         // Bench setup generation

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -24,6 +24,7 @@ rand_chacha = "0.3"
 paste = "1.0"
 rand_xorshift = "0.3.0"
 rand_core = "0.6.4"
+itertools = "0.10"
 mock = { path = "../mock" }
 
 [dev-dependencies]

--- a/integration-tests/src/integration_test_circuits.rs
+++ b/integration-tests/src/integration_test_circuits.rs
@@ -369,7 +369,7 @@ impl<C: SubCircuit<Fr> + Circuit<Fr>> IntegrationTest<C> {
                         col1.iter().enumerate().zip_eq(col2.iter()).for_each(
                             |((index, cellv1), cellv2)| {
                                 assert!(
-                                    cellv1.eq(&cellv2),
+                                    cellv1.eq(cellv2),
                                     "cellv1 {:?} != cellv2 {:?} on index {}",
                                     cellv1,
                                     cellv2,
@@ -407,7 +407,7 @@ impl<C: SubCircuit<Fr> + Circuit<Fr>> IntegrationTest<C> {
                             col1.iter().enumerate().zip_eq(col2.iter()).for_each(
                                 |((index, cellv1), cellv2)| {
                                     assert!(
-                                        cellv1.eq(&cellv2),
+                                        cellv1.eq(cellv2),
                                         "cellv1 {:?} != cellv2 {:?} on index {}",
                                         cellv1,
                                         cellv2,

--- a/integration-tests/src/integration_test_circuits.rs
+++ b/integration-tests/src/integration_test_circuits.rs
@@ -424,7 +424,7 @@ impl<C: SubCircuit<Fr> + Circuit<Fr>> IntegrationTest<C> {
             block_tag,
         );
         let mut block = block_convert(&builder).unwrap();
-        let chunk = chunk_convert(&builder, 0).unwrap();
+        let chunk = chunk_convert(&block, &builder).unwrap().remove(0);
         block.randomness = Fr::from(TEST_MOCK_RANDOMNESS);
         let circuit = C::new_from_block(&block, &chunk);
         let instance = circuit.instance();
@@ -441,7 +441,7 @@ impl<C: SubCircuit<Fr> + Circuit<Fr>> IntegrationTest<C> {
             );
 
             // get chronological_rwtable and byaddr_rwtable columns index
-            let mut cs = ConstraintSystem::<<Bn256 as Engine>::Scalar>::default();
+            let mut cs = ConstraintSystem::<<Bn256 as Engine>::Fr>::default();
             let config = SuperCircuit::configure(&mut cs);
             let rwtable_columns = config.get_rwtable_columns();
 
@@ -515,10 +515,9 @@ fn new_empty_block_chunk() -> (Block<Fr>, Chunk<Fr>) {
         .new_circuit_input_builder()
         .handle_block(&block.eth_block, &block.geth_traces)
         .unwrap();
-    (
-        block_convert(&builder).unwrap(),
-        chunk_convert(&builder, 0).unwrap(),
-    )
+    let block = block_convert(&builder).unwrap();
+    let chunk = chunk_convert(&block, &builder).unwrap().remove(0);
+    (block, chunk)
 }
 
 fn get_general_params(degree: u32) -> ParamsKZG<Bn256> {

--- a/testool/src/statetest/executor.rs
+++ b/testool/src/statetest/executor.rs
@@ -16,13 +16,8 @@ use std::{collections::HashMap, str::FromStr};
 use thiserror::Error;
 use zkevm_circuits::{
     super_circuit::SuperCircuit,
-<<<<<<< HEAD
-    test_util::CircuitTestBuilder,
-    witness::{Block, Chunk},
-=======
     test_util::{CircuitTestBuilder, CircuitTestError},
-    witness::Block,
->>>>>>> main
+    witness::{Block, Chunk},
 };
 
 #[derive(PartialEq, Eq, Error, Debug)]
@@ -354,12 +349,11 @@ pub fn run_test(
         let block: Block<Fr> =
             zkevm_circuits::evm_circuit::witness::block_convert(&builder).unwrap();
         let chunk: Chunk<Fr> =
-            zkevm_circuits::evm_circuit::witness::chunk_convert(&builder, 0).unwrap();
+            zkevm_circuits::evm_circuit::witness::chunk_convert(&block, &builder)
+                .unwrap()
+                .remove(0);
 
-<<<<<<< HEAD
-        CircuitTestBuilder::<1, 1>::new_from_block(block, chunk).run();
-=======
-        CircuitTestBuilder::<1, 1>::new_from_block(block)
+        CircuitTestBuilder::<1, 1>::new_from_block(block, chunk)
             .run_with_result()
             .map_err(|err| match err {
                 CircuitTestError::VerificationFailed { reasons, .. } => {
@@ -373,7 +367,6 @@ pub fn run_test(
                     found: err.to_string(),
                 },
             })?;
->>>>>>> main
     } else {
         geth_data.sign(&wallets);
 

--- a/testool/src/statetest/executor.rs
+++ b/testool/src/statetest/executor.rs
@@ -348,12 +348,9 @@ pub fn run_test(
 
         let block: Block<Fr> =
             zkevm_circuits::evm_circuit::witness::block_convert(&builder).unwrap();
-        let chunk: Chunk<Fr> =
-            zkevm_circuits::evm_circuit::witness::chunk_convert(&block, &builder)
-                .unwrap()
-                .remove(0);
-
-        CircuitTestBuilder::<1, 1>::new_from_block(block, chunk)
+        let chunks: Vec<Chunk<Fr>> =
+            zkevm_circuits::evm_circuit::witness::chunk_convert(&block, &builder).unwrap();
+        CircuitTestBuilder::<1, 1>::new_from_block(block, chunks)
             .run_with_result()
             .map_err(|err| match err {
                 CircuitTestError::VerificationFailed { reasons, .. } => {

--- a/testool/src/statetest/executor.rs
+++ b/testool/src/statetest/executor.rs
@@ -379,9 +379,12 @@ pub fn run_test(
             max_evm_rows: 0,
             max_keccak_rows: 0,
         };
-        let (k, circuit, instance, _builder) =
+        let (k, mut circuits, mut instances, _builder) =
             SuperCircuit::<Fr>::build(geth_data, circuits_params, Fr::from(0x100)).unwrap();
         builder = _builder;
+
+        let circuit = circuits.remove(0);
+        let instance = instances.remove(0);
 
         let prover = MockProver::run(k, &circuit, instance).unwrap();
         prover

--- a/zkevm-circuits/src/copy_circuit.rs
+++ b/zkevm-circuits/src/copy_circuit.rs
@@ -849,7 +849,7 @@ impl<F: Field> SubCircuit<F> for CopyCircuit<F> {
     fn new_from_block(block: &witness::Block<F>, chunk: &Chunk<F>) -> Self {
         let chunked_copy_events = block
             .copy_events
-            .get(chunk.chunk_context.initial_copy..chunk.chunk_context.end_copy)
+            .get(chunk.chunk_context.initial_copy_index..chunk.chunk_context.end_copy_index)
             .unwrap_or_default();
         Self::new_with_external_data(
             chunked_copy_events.to_owned(),

--- a/zkevm-circuits/src/copy_circuit.rs
+++ b/zkevm-circuits/src/copy_circuit.rs
@@ -859,8 +859,8 @@ impl<F: Field> SubCircuit<F> for CopyCircuit<F> {
                 max_calldata: chunk.fixed_param.max_calldata,
                 txs: block.txs.clone(),
                 max_rws: chunk.fixed_param.max_rws,
-                rws: chunk.rws.clone(),
-                prev_chunk_last_rw: chunk.prev_chunk_last_rw,
+                rws: chunk.chrono_rws.clone(),
+                prev_chunk_last_rw: chunk.prev_chunk_last_chrono_rw,
                 bytecodes: block.bytecodes.clone(),
             },
         )

--- a/zkevm-circuits/src/copy_circuit/test.rs
+++ b/zkevm-circuits/src/copy_circuit/test.rs
@@ -47,7 +47,7 @@ pub fn test_copy_circuit_from_block<F: Field>(
 ) -> Result<(), Vec<VerifyFailure>> {
     let chunked_copy_events = block
         .copy_events
-        .get(chunk.chunk_context.initial_copy..chunk.chunk_context.end_copy)
+        .get(chunk.chunk_context.initial_copy_index..chunk.chunk_context.end_copy_index)
         .unwrap_or_default();
     test_copy_circuit::<F>(
         k,

--- a/zkevm-circuits/src/copy_circuit/test.rs
+++ b/zkevm-circuits/src/copy_circuit/test.rs
@@ -58,8 +58,8 @@ pub fn test_copy_circuit_from_block<F: Field>(
             max_calldata: chunk.fixed_param.max_calldata,
             txs: block.txs,
             max_rws: chunk.fixed_param.max_rws,
-            rws: chunk.rws,
-            prev_chunk_last_rw: chunk.prev_chunk_last_rw,
+            rws: chunk.chrono_rws,
+            prev_chunk_last_rw: chunk.prev_chunk_last_chrono_rw,
             bytecodes: block.bytecodes,
         },
     )
@@ -180,7 +180,7 @@ fn gen_tx_log_data() -> CircuitInputBuilder<FixedCParams> {
 fn copy_circuit_valid_calldatacopy() {
     let builder = gen_calldatacopy_data();
     let block = block_convert::<Fr>(&builder).unwrap();
-    let chunk = chunk_convert::<Fr>(&builder, 0).unwrap();
+    let chunk = chunk_convert::<Fr>(&block, &builder).unwrap().remove(0);
     assert_eq!(test_copy_circuit_from_block(14, block, chunk), Ok(()));
 }
 
@@ -188,7 +188,7 @@ fn copy_circuit_valid_calldatacopy() {
 fn copy_circuit_valid_codecopy() {
     let builder = gen_codecopy_data();
     let block = block_convert::<Fr>(&builder).unwrap();
-    let chunk = chunk_convert::<Fr>(&builder, 0).unwrap();
+    let chunk = chunk_convert::<Fr>(&block, &builder).unwrap().remove(0);
     assert_eq!(test_copy_circuit_from_block(10, block, chunk), Ok(()));
 }
 
@@ -196,7 +196,7 @@ fn copy_circuit_valid_codecopy() {
 fn copy_circuit_valid_extcodecopy() {
     let builder = gen_extcodecopy_data();
     let block = block_convert::<Fr>(&builder).unwrap();
-    let chunk = chunk_convert::<Fr>(&builder, 0).unwrap();
+    let chunk = chunk_convert::<Fr>(&block, &builder).unwrap().remove(0);
     assert_eq!(test_copy_circuit_from_block(14, block, chunk), Ok(()));
 }
 
@@ -204,7 +204,7 @@ fn copy_circuit_valid_extcodecopy() {
 fn copy_circuit_valid_sha3() {
     let builder = gen_sha3_data();
     let block = block_convert::<Fr>(&builder).unwrap();
-    let chunk = chunk_convert::<Fr>(&builder, 0).unwrap();
+    let chunk = chunk_convert::<Fr>(&block, &builder).unwrap().remove(0);
     assert_eq!(test_copy_circuit_from_block(14, block, chunk), Ok(()));
 }
 
@@ -212,7 +212,7 @@ fn copy_circuit_valid_sha3() {
 fn copy_circuit_valid_tx_log() {
     let builder = gen_tx_log_data();
     let block = block_convert::<Fr>(&builder).unwrap();
-    let chunk = chunk_convert::<Fr>(&builder, 0).unwrap();
+    let chunk = chunk_convert::<Fr>(&block, &builder).unwrap().remove(0);
     assert_eq!(test_copy_circuit_from_block(10, block, chunk), Ok(()));
 }
 
@@ -225,7 +225,7 @@ fn copy_circuit_invalid_calldatacopy() {
         builder.block.copy_events[0].bytes[0].0.wrapping_add(1);
 
     let block = block_convert::<Fr>(&builder).unwrap();
-    let chunk = chunk_convert::<Fr>(&builder, 0).unwrap();
+    let chunk = chunk_convert::<Fr>(&block, &builder).unwrap().remove(0);
 
     assert_error_matches(
         test_copy_circuit_from_block(14, block, chunk),
@@ -242,7 +242,7 @@ fn copy_circuit_invalid_codecopy() {
         builder.block.copy_events[0].bytes[0].0.wrapping_add(1);
 
     let block = block_convert::<Fr>(&builder).unwrap();
-    let chunk = chunk_convert::<Fr>(&builder, 0).unwrap();
+    let chunk = chunk_convert::<Fr>(&block, &builder).unwrap().remove(0);
 
     assert_error_matches(
         test_copy_circuit_from_block(10, block, chunk),
@@ -259,7 +259,7 @@ fn copy_circuit_invalid_extcodecopy() {
         builder.block.copy_events[0].bytes[0].0.wrapping_add(1);
 
     let block = block_convert::<Fr>(&builder).unwrap();
-    let chunk = chunk_convert::<Fr>(&builder, 0).unwrap();
+    let chunk = chunk_convert::<Fr>(&block, &builder).unwrap().remove(0);
 
     assert_error_matches(
         test_copy_circuit_from_block(14, block, chunk),
@@ -276,7 +276,7 @@ fn copy_circuit_invalid_sha3() {
         builder.block.copy_events[0].bytes[0].0.wrapping_add(1);
 
     let block = block_convert::<Fr>(&builder).unwrap();
-    let chunk = chunk_convert::<Fr>(&builder, 0).unwrap();
+    let chunk = chunk_convert::<Fr>(&block, &builder).unwrap().remove(0);
 
     assert_error_matches(
         test_copy_circuit_from_block(14, block, chunk),
@@ -293,7 +293,7 @@ fn copy_circuit_invalid_tx_log() {
         builder.block.copy_events[0].bytes[0].0.wrapping_add(1);
 
     let block = block_convert::<Fr>(&builder).unwrap();
-    let chunk = chunk_convert::<Fr>(&builder, 0).unwrap();
+    let chunk = chunk_convert::<Fr>(&block, &builder).unwrap().remove(0);
 
     assert_error_matches(
         test_copy_circuit_from_block(10, block, chunk),

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -267,7 +267,7 @@ impl<F: Field> EvmCircuit<F> {
     }
 
     /// Compute the public inputs for this circuit.
-    fn instance_extend_chunk_ctx(&self) -> Vec<Vec<F>> {
+    pub fn instance_extend_chunk_ctx(&self) -> Vec<Vec<F>> {
         let chunk = self.chunk.as_ref().unwrap();
 
         let (rw_table_chunked_index, rw_table_total_chunks) =

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -334,9 +334,9 @@ impl<F: Field> SubCircuit<F> for EvmCircuit<F> {
             .assign_block(layouter, block, chunk, challenges)?;
 
         let (rw_rows_padding, _) = RwMap::table_assignments_padding(
-            &chunk.rws.table_assignments(true),
+            &chunk.chrono_rws.table_assignments(true),
             chunk.fixed_param.max_rws,
-            chunk.prev_chunk_last_rw,
+            chunk.prev_chunk_last_chrono_rw,
         );
         let (
             alpha_cell,
@@ -353,10 +353,10 @@ impl<F: Field> SubCircuit<F> for EvmCircuit<F> {
                     &mut region,
                     // pass non-padding rws to `load_with_region` since it will be padding
                     // inside
-                    &chunk.rws.table_assignments(true),
+                    &chunk.chrono_rws.table_assignments(true),
                     // align with state circuit to padding to same max_rws
                     chunk.fixed_param.max_rws,
-                    chunk.prev_chunk_last_rw,
+                    chunk.prev_chunk_last_chrono_rw,
                 )?;
                 let permutation_cells = config.rw_permutation_config.assign(
                     &mut region,
@@ -565,7 +565,7 @@ impl<F: Field> Circuit<F> for EvmCircuit<F> {
             chunk.fixed_param.max_txs,
             chunk.fixed_param.max_calldata,
         )?;
-        chunk.rws.check_rw_counter_sanity();
+        chunk.chrono_rws.check_rw_counter_sanity();
         config
             .bytecode_table
             .load(&mut layouter, block.bytecodes.clone())?;
@@ -698,7 +698,7 @@ mod evm_circuit_stats {
             .handle_block(&block.eth_block, &block.geth_traces)
             .unwrap();
         let block = block_convert::<Fr>(&builder).unwrap();
-        let chunk = chunk_convert::<Fr>(&builder, 0).unwrap();
+        let chunk = chunk_convert::<Fr>(&block, &builder).unwrap().remove(0);
         let k = block.get_test_degree(&chunk);
         let circuit = EvmCircuit::<Fr>::get_test_circuit_from_block(block, chunk);
         let instance = circuit.instance_extend_chunk_ctx();
@@ -723,7 +723,7 @@ mod evm_circuit_stats {
             .handle_block(&block.eth_block, &block.geth_traces)
             .unwrap();
         let block = block_convert::<Fr>(&builder).unwrap();
-        let chunk = chunk_convert::<Fr>(&builder, 0).unwrap();
+        let chunk = chunk_convert::<Fr>(&block, &builder).unwrap().remove(0);
         let k = block.get_test_degree(&chunk);
 
         let circuit = EvmCircuit::<Fr>::get_test_circuit_from_block(block, chunk);
@@ -746,7 +746,7 @@ mod evm_circuit_stats {
             .handle_block(&block.eth_block, &block.geth_traces)
             .unwrap();
         let block = block_convert::<Fr>(&builder).unwrap();
-        let chunk = chunk_convert::<Fr>(&builder, 0).unwrap();
+        let chunk = chunk_convert::<Fr>(&block, &builder).unwrap().remove(0);
         let k = block.get_test_degree(&chunk);
         let circuit = EvmCircuit::<Fr>::get_test_circuit_from_block(block, chunk);
         let instance = circuit.instance_extend_chunk_ctx();

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -390,11 +390,7 @@ impl<F: Field> SubCircuit<F> for EvmCircuit<F> {
 
     /// Compute the public inputs for this circuit.
     fn instance(&self) -> Vec<Vec<F>> {
-        let _block = self.block.as_ref().unwrap();
         let chunk = self.chunk.as_ref().unwrap();
-
-        let (_rw_table_chunked_index, _rw_table_total_chunks) =
-            (chunk.chunk_context.idx, chunk.chunk_context.total_chunks);
 
         vec![vec![
             chunk.permu_alpha,

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -638,7 +638,9 @@ mod evm_circuit_stats {
             TestContext::<0, 0>::new(None, |_| {}, |_, _| {}, |b, _| b).unwrap(),
         )
         .block_modifier(Box::new(|_block, chunk| {
-            chunk.fixed_param.max_evm_rows = (1 << 18) - 100
+            chunk
+                .iter_mut()
+                .for_each(|chunk| chunk.fixed_param.max_evm_rows = (1 << 18) - 100);
         }))
         .run();
     }

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -1443,13 +1443,6 @@ impl<F: Field> ExecutionConfig<F> {
                 step,
                 call
             );
-            // println!(
-            //     "assign_exec_step offset: {} state {:?} step: {:?} call: {:?}",
-            //     offset,
-            //     step.execution_state(),
-            //     step,
-            //     call
-            // );
         }
         // Make the region large enough for the current step and the next step.
         // The next step's next step may also be accessed, so make the region large
@@ -1467,13 +1460,6 @@ impl<F: Field> ExecutionConfig<F> {
         // so their witness values need to be known to be able
         // to correctly calculate the intermediate value.
         if let Some(next_step) = next_step {
-            // println!(
-            //     "assign_exec_step nextstep offset: {} state {:?} step: {:?} call: {:?}",
-            //     offset,
-            //     next_step.2.execution_state(),
-            //     next_step.2,
-            //     next_step.1
-            // );
             self.assign_exec_step_int(
                 region,
                 offset + height,

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -1127,7 +1127,7 @@ impl<F: Field> ExecutionConfig<F> {
                 let dummy_tx = Transaction::default();
                 let chunk_txs = block
                     .txs
-                    .get(chunk.chunk_context.initial_tx - 1..chunk.chunk_context.end_tx)
+                    .get(chunk.chunk_context.initial_tx_index..chunk.chunk_context.end_tx_index)
                     .unwrap_or_default();
 
                 let last_call = chunk_txs

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -930,7 +930,7 @@ impl<F: Field> ExecutionConfig<F> {
                 .chain(
                     [
                         (
-                            "EndTx can only transit to BeginTx or Padding or EndBlock or EndChunk",
+                            "EndTx can only transit to BeginTx or Padding or EndBlock or EndChunk or InvalidTx",
                             ExecutionState::EndTx,
                             vec![
                                 ExecutionState::BeginTx,
@@ -1171,6 +1171,10 @@ impl<F: Field> ExecutionConfig<F> {
                     // this dummy step is just for real step assignment proceed to `second last`
                     .chain(std::iter::once((&dummy_tx, &cur_chunk_last_call, padding)))
                     .peekable();
+
+                tx_call_steps
+                    .clone()
+                    .for_each(|step| println!("assigned_step step {:?}", step.2));
 
                 let evm_rows = chunk.fixed_param.max_evm_rows;
 

--- a/zkevm-circuits/src/evm_circuit/execution/begin_chunk.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_chunk.rs
@@ -4,7 +4,7 @@ use crate::{
     evm_circuit::{
         step::ExecutionState,
         util::{
-            constraint_builder::{EVMConstraintBuilder, StepStateTransition},
+            constraint_builder::{EVMConstraintBuilder, StepStateTransition, Transition::Delta},
             CachedRegion,
         },
         witness::{Block, Call, Chunk, ExecStep, Transaction},
@@ -29,7 +29,10 @@ impl<F: Field> ExecutionGadget<F> for BeginChunkGadget<F> {
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
         // state lookup
         cb.step_state_lookup(0.expr());
-        let step_state_transition = StepStateTransition::same();
+        let step_state_transition = StepStateTransition {
+            rw_counter: Delta(cb.rw_counter_offset()),
+            ..StepStateTransition::same()
+        };
         cb.require_step_state_transition(step_state_transition);
         Self {
             _marker: PhantomData {},

--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -1382,12 +1382,11 @@ mod test {
         )
         .unwrap();
 
-        // FIXME (Cecilia): Somehow needs way more than 500
         CircuitTestBuilder::new_from_test_ctx(ctx)
-            // .params(FixedCParams {
-            //     max_rws: 500,
-            //     ..Default::default()
-            // })
+            .params(FixedCParams {
+                max_rws: 500,
+                ..Default::default()
+            })
             .run();
     }
 

--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -1384,7 +1384,7 @@ mod test {
 
         CircuitTestBuilder::new_from_test_ctx(ctx)
             .params(FixedCParams {
-                max_rws: 500,
+                max_rws: 1 << 12,
                 ..Default::default()
             })
             .run();

--- a/zkevm-circuits/src/evm_circuit/execution/end_block.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/end_block.rs
@@ -174,7 +174,9 @@ mod test {
         // finish required tests using this witness block
         CircuitTestBuilder::<2, 1>::new_from_test_ctx(ctx)
             .block_modifier(Box::new(move |_block, chunk| {
-                chunk.fixed_param.max_evm_rows = evm_circuit_pad_to
+                chunk
+                    .iter_mut()
+                    .for_each(|chunk| chunk.fixed_param.max_evm_rows = evm_circuit_pad_to);
             }))
             .run();
     }

--- a/zkevm-circuits/src/evm_circuit/execution/end_chunk.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/end_chunk.rs
@@ -78,7 +78,7 @@ mod test {
         test_util::CircuitTestBuilder,
         witness::{block_convert, chunk_convert},
     };
-    use bus_mapping::{circuit_input_builder::FixedCParams, mock::BlockData, operation::Target};
+    use bus_mapping::{circuit_input_builder::FixedCParams, mock::BlockData};
     use eth_types::{address, bytecode, geth_types::GethData, Word};
     use halo2_proofs::halo2curves::bn256::Fr;
     use mock::TestContext;

--- a/zkevm-circuits/src/evm_circuit/execution/end_chunk.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/end_chunk.rs
@@ -190,6 +190,7 @@ mod test {
             .params({
                 FixedCParams {
                     total_chunks,
+                    max_evm_rows: 1 << 12,
                     max_rws: total_rws / total_chunks,
                     max_txs: 2,
                     ..Default::default()

--- a/zkevm-circuits/src/evm_circuit/execution/end_chunk.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/end_chunk.rs
@@ -29,7 +29,8 @@ impl<F: Field> ExecutionGadget<F> for EndChunkGadget<F> {
     const EXECUTION_STATE: ExecutionState = ExecutionState::EndChunk;
 
     fn configure(cb: &mut EVMConstraintBuilder<F>) -> Self {
-        // State transition
+        // State transition on non-last evm step
+        // TODO/FIXME make EndChunk must be in last evm step and remove below constraint
         cb.not_step_last(|cb| {
             // Propagate all the way down.
             cb.require_step_state_transition(StepStateTransition::same());
@@ -102,7 +103,7 @@ mod test {
             // }
             println!(
                 "=> FIXME is fixed? {:?}",
-                chunk.rws.0.get_mut(&Target::Start)
+                chunk.chrono_rws.0.get_mut(&Target::Start)
             );
         }))
         .run_dynamic_chunk(4, 2);

--- a/zkevm-circuits/src/evm_circuit/execution/end_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/end_tx.rs
@@ -453,7 +453,7 @@ mod test {
             max_txs: 5,
             ..Default::default()
         })
-        .build_block(0, 1)
+        .build_block(None)
         .unwrap();
 
         block.rws.0[&Target::CallContext]

--- a/zkevm-circuits/src/evm_circuit/step.rs
+++ b/zkevm-circuits/src/evm_circuit/step.rs
@@ -850,6 +850,11 @@ impl<F: Field> Step<F> {
             offset,
             Value::known(F::from(step.rwc_inner_chunk.into())),
         )?;
+        // println!(
+        //     "execstate {:?} self.state.call_id {:?}",
+        //     step.execution_state(),
+        //     F::from(call.call_id as u64)
+        // );
         self.state
             .call_id
             .assign(region, offset, Value::known(F::from(call.call_id as u64)))?;

--- a/zkevm-circuits/src/evm_circuit/step.rs
+++ b/zkevm-circuits/src/evm_circuit/step.rs
@@ -850,11 +850,6 @@ impl<F: Field> Step<F> {
             offset,
             Value::known(F::from(step.rwc_inner_chunk.into())),
         )?;
-        // println!(
-        //     "execstate {:?} self.state.call_id {:?}",
-        //     step.execution_state(),
-        //     F::from(call.call_id as u64)
-        // );
         self.state
             .call_id
             .assign(region, offset, Value::known(F::from(call.call_id as u64)))?;

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -1336,10 +1336,12 @@ impl<F: Field> RwTablePaddingGadget<F> {
             1.expr(),
             max_rws.expr() - inner_rws_before_padding.expr(),
         );
+
         cb.condition(is_end_padding_exist.expr(), |cb| {
             cb.rw_table_padding_lookup(inner_rws_before_padding.expr() + 1.expr());
             cb.rw_table_padding_lookup(max_rws.expr() - 1.expr());
         });
+
         // Since every lookup done in the EVM circuit must succeed and uses
         // a unique rw_counter, we know that at least there are
         // total_rws meaningful entries in the rw_table.

--- a/zkevm-circuits/src/exp_circuit/test.rs
+++ b/zkevm-circuits/src/exp_circuit/test.rs
@@ -67,7 +67,7 @@ fn test_ok(base: Word, exponent: Word, k: Option<u32>) {
     let code = gen_code_single(base, exponent);
     let builder = gen_data(code, false);
     let block = block_convert::<Fr>(&builder).unwrap();
-    let chunk = chunk_convert::<Fr>(&builder, 0).unwrap();
+    let chunk = chunk_convert::<Fr>(&block, &builder).unwrap().remove(0);
     test_exp_circuit(k.unwrap_or(18), block, chunk);
 }
 
@@ -75,7 +75,7 @@ fn test_ok_multiple(args: Vec<(Word, Word)>) {
     let code = gen_code_multiple(args);
     let builder = gen_data(code, false);
     let block = block_convert::<Fr>(&builder).unwrap();
-    let chunk = chunk_convert::<Fr>(&builder, 0).unwrap();
+    let chunk = chunk_convert::<Fr>(&block, &builder).unwrap().remove(0);
     test_exp_circuit(20, block, chunk);
 }
 
@@ -125,7 +125,7 @@ fn variadic_size_check() {
         .handle_block(&block.eth_block, &block.geth_traces)
         .unwrap();
     let block = block_convert::<Fr>(&builder).unwrap();
-    let chunk = chunk_convert::<Fr>(&builder, 0).unwrap();
+    let chunk = chunk_convert::<Fr>(&block, &builder).unwrap().remove(0);
     let circuit = ExpCircuit::<Fr>::new(block.exp_events, chunk.fixed_param.max_exp_steps);
     let prover1 = MockProver::<Fr>::run(k, &circuit, vec![]).unwrap();
 
@@ -141,7 +141,7 @@ fn variadic_size_check() {
     };
     let builder = gen_data(code, true);
     let block = block_convert::<Fr>(&builder).unwrap();
-    let chunk = chunk_convert::<Fr>(&builder, 0).unwrap();
+    let chunk = chunk_convert::<Fr>(&block, &builder).unwrap().remove(0);
     let circuit = ExpCircuit::<Fr>::new(block.exp_events, chunk.fixed_param.max_exp_steps);
     let prover2 = MockProver::<Fr>::run(k, &circuit, vec![]).unwrap();
 

--- a/zkevm-circuits/src/pi_circuit/test.rs
+++ b/zkevm-circuits/src/pi_circuit/test.rs
@@ -149,7 +149,7 @@ fn test_1tx_1maxtx() {
 
     block.sign(&wallets);
     let block = block_convert(&builder).unwrap();
-    let chunk = chunk_convert(&builder, 0).unwrap();
+    let chunk = chunk_convert(&block, &builder).unwrap().remove(0);
     // MAX_TXS, MAX_TXS align with `CircuitsParams`
     let circuit = PiCircuit::<Fr>::new_from_block(&block, &chunk);
     let public_inputs = circuit.instance();
@@ -230,7 +230,7 @@ fn test_1wd_1wdmax() {
         .unwrap();
 
     let block = block_convert(&builder).unwrap();
-    let chunk = chunk_convert(&builder, 0).unwrap();
+    let chunk = chunk_convert(&block, &builder).unwrap().remove(0);
     // MAX_TXS, MAX_TXS align with `CircuitsParams`
     let circuit = PiCircuit::<Fr>::new_from_block(&block, &chunk);
     let public_inputs = circuit.instance();

--- a/zkevm-circuits/src/root_circuit.rs
+++ b/zkevm-circuits/src/root_circuit.rs
@@ -285,7 +285,7 @@ where
                     config.aggregate::<M, As>(ctx, &key.clone(), &self.snark_witnesses)?;
 
                 // aggregate user challenge for rwtable permutation challenge
-                let (alpha, gamma) = {
+                let (_alpha, _gamma) = {
                     let mut challenges = config.aggregate_user_challenges::<M, As>(
                         loader.clone(),
                         self.user_challenges,
@@ -325,7 +325,22 @@ where
                                 .scalar_chip()
                                 .assign_constant(&mut loader.ctx_mut(), M::Fr::from(1))
                                 .unwrap();
+
                             (zero_const, one_const, total_chunk_const)
+                        };
+
+                        // TODO remove me
+                        let (_hardcode_alpha, _hardcode_gamma) = {
+                            (
+                                loader
+                                    .scalar_chip()
+                                    .assign_constant(&mut loader.ctx_mut(), M::Scalar::from(101))
+                                    .unwrap(),
+                                loader
+                                    .scalar_chip()
+                                    .assign_constant(&mut loader.ctx_mut(), M::Scalar::from(103))
+                                    .unwrap(),
+                            )
                         };
 
                         // `first.sc_rwtable_row_prev_fingerprint ==
@@ -338,11 +353,17 @@ where
                             (first_chunk.initial_rwc.assigned(), &one_const),
                             // constraint permutation fingerprint
                             // challenge: alpha
-                            (first_chunk.sc_permu_alpha.assigned(), &alpha.assigned()),
-                            (first_chunk.ec_permu_alpha.assigned(), &alpha.assigned()),
+                            // TODO remove hardcode
+                            (first_chunk.sc_permu_alpha.assigned(), &_hardcode_alpha),
+                            (first_chunk.ec_permu_alpha.assigned(), &_hardcode_alpha),
+                            // (first_chunk.sc_permu_alpha.assigned(), &alpha.assigned()),
+                            // (first_chunk.ec_permu_alpha.assigned(), &alpha.assigned()),
                             // challenge: gamma
-                            (first_chunk.sc_permu_gamma.assigned(), &gamma.assigned()),
-                            (first_chunk.ec_permu_gamma.assigned(), &gamma.assigned()),
+                            // TODO remove hardcode
+                            (first_chunk.sc_permu_gamma.assigned(), &_hardcode_gamma),
+                            (first_chunk.ec_permu_gamma.assigned(), &_hardcode_gamma),
+                            // (first_chunk.sc_permu_gamma.assigned(), &gamma.assigned()),
+                            // (first_chunk.ec_permu_gamma.assigned(), &gamma.assigned()),
                             // fingerprint
                             (
                                 first_chunk.ec_rwtable_prev_fingerprint.assigned(),

--- a/zkevm-circuits/src/root_circuit.rs
+++ b/zkevm-circuits/src/root_circuit.rs
@@ -334,11 +334,11 @@ where
                             (
                                 loader
                                     .scalar_chip()
-                                    .assign_constant(&mut loader.ctx_mut(), M::Scalar::from(101))
+                                    .assign_constant(&mut loader.ctx_mut(), M::Fr::from(101))
                                     .unwrap(),
                                 loader
                                     .scalar_chip()
-                                    .assign_constant(&mut loader.ctx_mut(), M::Scalar::from(103))
+                                    .assign_constant(&mut loader.ctx_mut(), M::Fr::from(103))
                                     .unwrap(),
                             )
                         };

--- a/zkevm-circuits/src/root_circuit/test.rs
+++ b/zkevm-circuits/src/root_circuit/test.rs
@@ -20,70 +20,87 @@ use rand::rngs::OsRng;
 
 #[ignore = "Due to high memory requirement"]
 #[test]
-fn test_root_circuit() {
-    let (params, protocol, proof, instance, rwtable_columns) = {
+fn test_root_circuit_multiple_chunk() {
+    let (params, protocol, proofs, instances, rwtable_columns) = {
         // Preprocess
         const TEST_MOCK_RANDOMNESS: u64 = 0x100;
         let circuits_params = FixedCParams {
-            total_chunks: 1,
+            total_chunks: 3,
             max_txs: 1,
             max_withdrawals: 5,
             max_calldata: 32,
-            max_rws: 256,
+            max_rws: 100,
             max_copy_rows: 256,
             max_exp_steps: 256,
             max_bytecode: 512,
-            max_evm_rows: 0,
+            max_evm_rows: 1 << 12,
             max_keccak_rows: 0,
         };
-        let (k, circuit, instance, _) =
+        let (k, circuits, instances, _) =
             SuperCircuit::<_>::build(block_1tx(), circuits_params, TEST_MOCK_RANDOMNESS.into())
                 .unwrap();
+        assert!(!circuits.is_empty());
+        assert!(circuits.len() == instances.len());
 
         // get chronological_rwtable and byaddr_rwtable columns index
         let mut cs = ConstraintSystem::default();
-        let config = SuperCircuit::configure_with_params(&mut cs, circuit.params());
+        let config = SuperCircuit::configure_with_params(&mut cs, circuits[0].params());
         let rwtable_columns = config.get_rwtable_columns();
 
         let params = ParamsKZG::<Bn256>::setup(k, OsRng);
-        let pk = keygen_pk(&params, keygen_vk(&params, &circuit).unwrap(), &circuit).unwrap();
+        let pk = keygen_pk(
+            &params,
+            keygen_vk(&params, &circuits[0]).unwrap(),
+            &circuits[0],
+        )
+        .unwrap();
         let protocol = compile(
             &params,
             pk.get_vk(),
             Config::kzg()
-                .with_num_instance(instance.iter().map(|instance| instance.len()).collect()),
+                .with_num_instance(instances[0].iter().map(|instance| instance.len()).collect()),
         );
 
-        // Create proof
-        let proof = {
-            let mut transcript = PoseidonTranscript::new(Vec::new());
-            create_proof::<KZGCommitmentScheme<_>, ProverGWC<_>, _, _, _, _>(
-                &params,
-                &pk,
-                &[circuit],
-                &[&instance.iter().map(Vec::as_slice).collect_vec()],
-                OsRng,
-                &mut transcript,
-            )
-            .unwrap();
-            transcript.finalize()
-        };
-
-        (params, protocol, proof, instance, rwtable_columns)
+        let proofs: Vec<Vec<u8>> = circuits
+            .into_iter()
+            .zip(instances.iter())
+            .map(|(circuit, instance)| {
+                // Create proof
+                let proof = {
+                    let mut transcript = PoseidonTranscript::new(Vec::new());
+                    create_proof::<KZGCommitmentScheme<_>, ProverGWC<_>, _, _, _, _>(
+                        &params,
+                        &pk,
+                        &[circuit],
+                        &[&instance.iter().map(Vec::as_slice).collect_vec()],
+                        OsRng,
+                        &mut transcript,
+                    )
+                    .unwrap();
+                    transcript.finalize()
+                };
+                proof
+            })
+            .collect();
+        (params, protocol, proofs, instances, rwtable_columns)
     };
 
     let user_challenge = UserChallenge {
         column_indexes: rwtable_columns,
         num_challenges: 2, // alpha, gamma
     };
+    let snark_witnesses: Vec<_> = proofs
+        .iter()
+        .zip(instances.iter())
+        .map(|(proof, instance)| {
+            SnarkWitness::new(&protocol, Value::known(instance), Value::known(proof))
+        })
+        .collect();
+
     let root_circuit = RootCircuit::<Bn256, Gwc<_>>::new(
         &params,
         &protocol,
-        vec![SnarkWitness::new(
-            &protocol,
-            Value::known(&instance),
-            Value::known(&proof),
-        )],
+        snark_witnesses,
         Some(&user_challenge),
     )
     .unwrap();

--- a/zkevm-circuits/src/state_circuit.rs
+++ b/zkevm-circuits/src/state_circuit.rs
@@ -506,7 +506,7 @@ impl<F: Field> SubCircuit<F> for StateCircuit<F> {
     /// Return the minimum number of rows required to prove the block
     fn min_num_rows_block(_block: &witness::Block<F>, chunk: &Chunk<F>) -> (usize, usize) {
         (
-            chunk.chrono_rws.0.values().flatten().count() + 1,
+            chunk.by_address_rws.0.values().flatten().count() + 1,
             chunk.fixed_param.max_rws,
         )
     }

--- a/zkevm-circuits/src/state_circuit.rs
+++ b/zkevm-circuits/src/state_circuit.rs
@@ -484,7 +484,7 @@ impl<F: Field> StateCircuit<F> {
             permu_alpha: chunk.permu_alpha,
             permu_gamma: chunk.permu_gamma,
             rw_fingerprints: chunk.by_address_rw_fingerprints.clone(),
-            prev_chunk_last_rw: chunk.prev_chunk_last_chrono_rw,
+            prev_chunk_last_rw: chunk.prev_chunk_last_by_address_rw,
             _marker: PhantomData::default(),
         }
     }

--- a/zkevm-circuits/src/state_circuit.rs
+++ b/zkevm-circuits/src/state_circuit.rs
@@ -471,7 +471,7 @@ pub struct StateCircuit<F: Field> {
 impl<F: Field> StateCircuit<F> {
     /// make a new state circuit from an RwMap
     pub fn new(chunk: &Chunk<F>) -> Self {
-        let rows = chunk.rws.table_assignments(false); // address sorted
+        let rows = chunk.by_address_rws.table_assignments(false); // address sorted
         let updates = MptUpdates::mock_from(&rows);
         Self {
             rows,
@@ -483,8 +483,8 @@ impl<F: Field> StateCircuit<F> {
             overrides: HashMap::new(),
             permu_alpha: chunk.permu_alpha,
             permu_gamma: chunk.permu_gamma,
-            rw_fingerprints: chunk.rw_fingerprints.clone(),
-            prev_chunk_last_rw: chunk.prev_chunk_last_rw,
+            rw_fingerprints: chunk.by_address_rw_fingerprints.clone(),
+            prev_chunk_last_rw: chunk.prev_chunk_last_chrono_rw,
             _marker: PhantomData::default(),
         }
     }
@@ -506,7 +506,7 @@ impl<F: Field> SubCircuit<F> for StateCircuit<F> {
     /// Return the minimum number of rows required to prove the block
     fn min_num_rows_block(_block: &witness::Block<F>, chunk: &Chunk<F>) -> (usize, usize) {
         (
-            chunk.rws.0.values().flatten().count() + 1,
+            chunk.chrono_rws.0.values().flatten().count() + 1,
             chunk.fixed_param.max_rws,
         )
     }

--- a/zkevm-circuits/src/state_circuit/lexicographic_ordering.rs
+++ b/zkevm-circuits/src/state_circuit/lexicographic_ordering.rs
@@ -99,7 +99,7 @@ pub struct Config {
     pub(crate) selector: Column<Fixed>,
     pub first_different_limb: BinaryNumberConfig<LimbIndex, 5>,
     limb_difference: Column<Advice>,
-    limb_difference_inverse: Column<Advice>,
+    // limb_difference_inverse: Column<Advice>,
 }
 
 impl Config {
@@ -112,26 +112,26 @@ impl Config {
         let selector = meta.fixed_column();
         let first_different_limb = BinaryNumberChip::configure(meta, selector, None);
         let limb_difference = meta.advice_column();
-        let limb_difference_inverse = meta.advice_column();
+        // let limb_difference_inverse = meta.advice_column();
 
         let config = Config {
             selector,
             first_different_limb,
             limb_difference,
-            limb_difference_inverse,
+            // limb_difference_inverse,
         };
 
         lookup.range_check_u16(meta, "limb_difference fits into u16", |meta| {
             meta.query_advice(limb_difference, Rotation::cur())
         });
 
-        meta.create_gate("limb_difference is not zero", |meta| {
-            let selector = meta.query_fixed(selector, Rotation::cur());
-            let limb_difference = meta.query_advice(limb_difference, Rotation::cur());
-            let limb_difference_inverse =
-                meta.query_advice(limb_difference_inverse, Rotation::cur());
-            vec![selector * (1.expr() - limb_difference * limb_difference_inverse)]
-        });
+        // meta.create_gate("limb_difference is not zero", |meta| {
+        //     let selector = meta.query_fixed(selector, Rotation::cur());
+        //     let limb_difference = meta.query_advice(limb_difference, Rotation::cur());
+        //     let limb_difference_inverse =
+        //         meta.query_advice(limb_difference_inverse, Rotation::cur());
+        //     vec![selector * (1.expr() - limb_difference * limb_difference_inverse)]
+        // });
 
         meta.create_gate(
             "limb differences before first_different_limb are all 0",
@@ -221,24 +221,15 @@ impl Config {
             offset,
             || Value::known(limb_difference),
         )?;
-        region.assign_advice(
-            || "limb_difference_inverse",
-            self.limb_difference_inverse,
-            offset,
-            || Value::known(limb_difference.invert().unwrap()),
-        )?;
 
         Ok(index)
     }
 
     /// Annotates columns of this gadget embedded within a circuit region.
     pub fn annotate_columns_in_region<F: Field>(&self, region: &mut Region<F>, prefix: &str) {
-        [
-            (self.limb_difference, "LO_limb_difference"),
-            (self.limb_difference_inverse, "LO_limb_difference_inverse"),
-        ]
-        .iter()
-        .for_each(|(col, ann)| region.name_column(|| format!("{}_{}", prefix, ann), *col));
+        [(self.limb_difference, "LO_limb_difference")]
+            .iter()
+            .for_each(|(col, ann)| region.name_column(|| format!("{}_{}", prefix, ann), *col));
         // fixed column
         region.name_column(
             || format!("{}_LO_upper_limb_difference", prefix),

--- a/zkevm-circuits/src/state_circuit/lexicographic_ordering.rs
+++ b/zkevm-circuits/src/state_circuit/lexicographic_ordering.rs
@@ -99,7 +99,6 @@ pub struct Config {
     pub(crate) selector: Column<Fixed>,
     pub first_different_limb: BinaryNumberConfig<LimbIndex, 5>,
     limb_difference: Column<Advice>,
-    // limb_difference_inverse: Column<Advice>,
 }
 
 impl Config {
@@ -112,26 +111,16 @@ impl Config {
         let selector = meta.fixed_column();
         let first_different_limb = BinaryNumberChip::configure(meta, selector, None);
         let limb_difference = meta.advice_column();
-        // let limb_difference_inverse = meta.advice_column();
 
         let config = Config {
             selector,
             first_different_limb,
             limb_difference,
-            // limb_difference_inverse,
         };
 
         lookup.range_check_u16(meta, "limb_difference fits into u16", |meta| {
             meta.query_advice(limb_difference, Rotation::cur())
         });
-
-        // meta.create_gate("limb_difference is not zero", |meta| {
-        //     let selector = meta.query_fixed(selector, Rotation::cur());
-        //     let limb_difference = meta.query_advice(limb_difference, Rotation::cur());
-        //     let limb_difference_inverse =
-        //         meta.query_advice(limb_difference_inverse, Rotation::cur());
-        //     vec![selector * (1.expr() - limb_difference * limb_difference_inverse)]
-        // });
 
         meta.create_gate(
             "limb differences before first_different_limb are all 0",

--- a/zkevm-circuits/src/state_circuit/test.rs
+++ b/zkevm-circuits/src/state_circuit/test.rs
@@ -1012,7 +1012,7 @@ fn prover(rows: Vec<Rw>, overrides: HashMap<(AdviceColumn, isize), Fr>) -> MockP
     let rw_rows: Vec<witness::RwRow<Value<Fr>>> =
         rw_overrides_skip_first_padding(&rw_rows, &overrides);
     let rwtable_fingerprints =
-        get_permutation_fingerprint_of_rwrowvec(&rw_rows, N_ROWS, Fr::ONE, Fr::ONE, Fr::ONE);
+        get_permutation_fingerprint_of_rwrowvec(&rw_rows, N_ROWS, Fr::ONE, Fr::ONE, Fr::ONE, None);
     let row_padding_and_overridess = rw_rows.to2dvec();
 
     let updates = MptUpdates::mock_from(&rows);

--- a/zkevm-circuits/src/state_circuit/test.rs
+++ b/zkevm-circuits/src/state_circuit/test.rs
@@ -45,7 +45,7 @@ fn test_state_circuit_ok(
         storage: storage_ops,
         ..Default::default()
     });
-    let chunk = Chunk::new_from_rw_map(&rw_map);
+    let chunk = Chunk::new_from_rw_map(&rw_map, None, None);
 
     let circuit = StateCircuit::<Fr>::new(&chunk);
     let instance = circuit.instance();
@@ -69,15 +69,19 @@ fn verifying_key_independent_of_rw_length() {
 
     let no_rows = StateCircuit::<Fr>::new(&chunk);
 
-    chunk = Chunk::new_from_rw_map(&RwMap::from(&OperationContainer {
-        memory: vec![Operation::new(
-            RWCounter::from(1),
-            RWCounter::from(1),
-            RW::WRITE,
-            MemoryOp::new(1, MemoryAddress::from(0), 32),
-        )],
-        ..Default::default()
-    }));
+    chunk = Chunk::new_from_rw_map(
+        &RwMap::from(&OperationContainer {
+            memory: vec![Operation::new(
+                RWCounter::from(1),
+                RWCounter::from(1),
+                RW::WRITE,
+                MemoryOp::new(1, MemoryAddress::from(0), 32),
+            )],
+            ..Default::default()
+        }),
+        None,
+        None,
+    );
     let one_row = StateCircuit::<Fr>::new(&chunk);
 
     let vk_no_rows = keygen_vk(&params, &no_rows).unwrap();
@@ -944,7 +948,11 @@ fn variadic_size_check() {
         },
     ];
     // let rw_map: RwMap = rows.clone().into();
-    let circuit = StateCircuit::new(&Chunk::new_from_rw_map(&RwMap::from(rows.clone())));
+    let circuit = StateCircuit::new(&Chunk::new_from_rw_map(
+        &RwMap::from(rows.clone()),
+        None,
+        None,
+    ));
     let power_of_randomness = circuit.instance();
     let prover1 = MockProver::<Fr>::run(17, &circuit, power_of_randomness).unwrap();
 
@@ -965,7 +973,7 @@ fn variadic_size_check() {
         },
     ]);
 
-    let circuit = StateCircuit::new(&Chunk::new_from_rw_map(&rows.into()));
+    let circuit = StateCircuit::new(&Chunk::new_from_rw_map(&rows.into(), None, None));
     let power_of_randomness = circuit.instance();
     let prover2 = MockProver::<Fr>::run(17, &circuit, power_of_randomness).unwrap();
 

--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -426,7 +426,9 @@ impl<F: Field> SubCircuit<F> for SuperCircuit<F> {
         instance.extend_from_slice(&self.copy_circuit.instance());
         instance.extend_from_slice(&self.state_circuit.instance());
         instance.extend_from_slice(&self.exp_circuit.instance());
-        instance.extend_from_slice(&self.evm_circuit.instance());
+        // remove first vector which is chunk_ctx
+        // which supercircuit already supply globally on top
+        instance.extend_from_slice(&self.evm_circuit.instance()[1..]);
 
         instance
     }

--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -79,6 +79,7 @@ use halo2_proofs::{
     circuit::{Layouter, SimpleFloorPlanner, Value},
     plonk::{Any, Circuit, Column, ConstraintSystem, Error, Expression},
 };
+use itertools::Itertools;
 
 use std::array;
 
@@ -560,8 +561,15 @@ impl<F: Field> SuperCircuit<F> {
         geth_data: GethData,
         circuits_params: FixedCParams,
         mock_randomness: F,
-    ) -> Result<(u32, Self, Vec<Vec<F>>, CircuitInputBuilder<FixedCParams>), bus_mapping::Error>
-    {
+    ) -> Result<
+        (
+            u32,
+            Vec<Self>,
+            Vec<Vec<Vec<F>>>,
+            CircuitInputBuilder<FixedCParams>,
+        ),
+        bus_mapping::Error,
+    > {
         let block_data =
             BlockData::new_from_geth_data_with_params(geth_data.clone(), circuits_params);
         let builder = block_data
@@ -578,21 +586,43 @@ impl<F: Field> SuperCircuit<F> {
     ///
     /// Also, return with it the minimum required SRS degree for the circuit and
     /// the Public Inputs needed.
+    #[allow(clippy::type_complexity)]
     pub fn build_from_circuit_input_builder(
         builder: &CircuitInputBuilder<FixedCParams>,
         mock_randomness: F,
-    ) -> Result<(u32, Self, Vec<Vec<F>>), bus_mapping::Error> {
+    ) -> Result<(u32, Vec<Self>, Vec<Vec<Vec<F>>>), bus_mapping::Error> {
         let mut block = block_convert(builder).unwrap();
-        let chunk = chunk_convert(&block, builder).unwrap().remove(0);
+        let chunks = chunk_convert(&block, builder).unwrap();
         block.randomness = mock_randomness;
 
-        let (_, rows_needed) = Self::min_num_rows_block(&block, &chunk);
-        let k = log2_ceil(Self::unusable_rows() + rows_needed);
+        let (rows_needed, circuit_instance_pairs): (Vec<usize>, Vec<(_, _)>) = chunks
+            .iter()
+            .map(|chunk| {
+                let (_, rows_needed) = Self::min_num_rows_block(&block, chunk);
+
+                let circuit = SuperCircuit::new_from_block(&block, chunk);
+                let instance = circuit.instance();
+                (rows_needed, (circuit, instance))
+            })
+            .unzip();
+
+        // assert all rows needed are equal
+        rows_needed
+            .iter()
+            .tuple_windows()
+            .for_each(|rows_needed: (&usize, &usize)| {
+                assert!(
+                    rows_needed.0 == rows_needed.1,
+                    "mismatched super_circuit rows_needed {:?} != {:?}",
+                    rows_needed.0,
+                    rows_needed.1
+                )
+            });
+
+        let k = log2_ceil(Self::unusable_rows() + rows_needed[0]);
         log::debug!("super circuit uses k = {}", k);
 
-        let circuit = SuperCircuit::new_from_block(&block, &chunk);
-
-        let instance = circuit.instance();
-        Ok((k, circuit, instance))
+        let (circuits, instances) = circuit_instance_pairs.into_iter().unzip();
+        Ok((k, circuits, instances))
     }
 }

--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -581,7 +581,7 @@ impl<F: Field> SuperCircuit<F> {
         mock_randomness: F,
     ) -> Result<(u32, Self, Vec<Vec<F>>), bus_mapping::Error> {
         let mut block = block_convert(builder).unwrap();
-        let chunk = chunk_convert(builder, 0).unwrap();
+        let chunk = chunk_convert(&block, builder).unwrap().remove(0);
         block.randomness = mock_randomness;
 
         let (_, rows_needed) = Self::min_num_rows_block(&block, &chunk);

--- a/zkevm-circuits/src/super_circuit/test.rs
+++ b/zkevm-circuits/src/super_circuit/test.rs
@@ -207,6 +207,7 @@ where
 {
     let circuits_params = FixedCParams {
         max_txs: 1,
+        max_withdrawals: 5,
         max_calldata: 32,
         max_rws: 256,
         max_copy_rows: 256,
@@ -214,6 +215,7 @@ where
         max_bytecode: 512,
         max_evm_rows: 0,
         max_keccak_rows: 0,
+        total_chunks: 1,
     };
     let rw_map = RwMap::from(&OperationContainer {
         ..Default::default()
@@ -224,22 +226,19 @@ where
 
     // synthesize to get degree
     let mut cs = ConstraintSystem::<<Scheme as CommitmentScheme>::Scalar>::default();
-    let config = SuperCircuit::configure_with_params(
+    let _config = SuperCircuit::configure_with_params(
         &mut cs,
         SuperCircuitParams {
             max_txs: circuits_params.max_txs,
+            max_withdrawals: circuits_params.max_withdrawals,
             max_calldata: circuits_params.max_calldata,
             mock_randomness: TEST_MOCK_RANDOMNESS.into(),
+            feature_config: FeatureConfig::default(),
         },
     );
     let degree = cs.degree();
 
-    let advice_commitments = get_rwtable_cols_commitment::<Scheme>(
-        degree,
-        &rows,
-        circuits_params.max_rws,
-        params,
-        false,
-    );
-    println!("advice_commitments {:?}", advice_commitments[0]);
+    let advice_commitments =
+        get_rwtable_cols_commitment::<Scheme>(degree, &rows, circuits_params.max_rws, params);
+    println!("advice_commitments len() {:?}", advice_commitments.len());
 }

--- a/zkevm-circuits/src/super_circuit/test.rs
+++ b/zkevm-circuits/src/super_circuit/test.rs
@@ -201,7 +201,7 @@ fn test_rw_table_commitment() {
     rw_table_commitment::<KZGCommitmentScheme<_>>(&params);
 }
 
-fn rw_table_commitment<'params, Scheme: CommitmentScheme>(params: &'params Scheme::ParamsProver)
+fn rw_table_commitment<Scheme: CommitmentScheme>(params: &Scheme::ParamsProver)
 where
     <Scheme as CommitmentScheme>::Scalar: WithSmallOrderMulGroup<3> + eth_types::Field,
 {

--- a/zkevm-circuits/src/super_circuit/test.rs
+++ b/zkevm-circuits/src/super_circuit/test.rs
@@ -1,13 +1,25 @@
+use crate::{table::rw_table::get_rwtable_cols_commitment, witness::RwMap};
+
 pub use super::*;
+use bus_mapping::operation::OperationContainer;
+use eth_types::{address, bytecode, geth_types::GethData, Word};
 use ethers_signers::{LocalWallet, Signer};
-use halo2_proofs::{dev::MockProver, halo2curves::bn256::Fr};
+use halo2_proofs::{
+    dev::MockProver,
+    halo2curves::{
+        bn256::{Bn256, Fr},
+        ff::WithSmallOrderMulGroup,
+    },
+    poly::{
+        commitment::CommitmentScheme,
+        kzg::commitment::{KZGCommitmentScheme, ParamsKZG},
+    },
+};
 use log::error;
 use mock::{TestContext, MOCK_CHAIN_ID};
 use rand::SeedableRng;
-use rand_chacha::ChaCha20Rng;
+use rand_chacha::{rand_core::OsRng, ChaCha20Rng};
 use std::collections::HashMap;
-
-use eth_types::{address, bytecode, geth_types::GethData, Word};
 
 #[test]
 fn super_circuit_degree() {
@@ -179,4 +191,55 @@ fn serial_test_super_circuit_2tx_2max_tx() {
         max_keccak_rows: 0,
     };
     test_super_circuit(block, circuits_params, Fr::from(TEST_MOCK_RANDOMNESS));
+}
+
+#[ignore]
+#[test]
+fn test_rw_table_commitment() {
+    let k = 18;
+    let params = ParamsKZG::<Bn256>::setup(k, OsRng);
+    rw_table_commitment::<KZGCommitmentScheme<_>>(&params);
+}
+
+fn rw_table_commitment<'params, Scheme: CommitmentScheme>(params: &'params Scheme::ParamsProver)
+where
+    <Scheme as CommitmentScheme>::Scalar: WithSmallOrderMulGroup<3> + eth_types::Field,
+{
+    let circuits_params = FixedCParams {
+        max_txs: 1,
+        max_calldata: 32,
+        max_rws: 256,
+        max_copy_rows: 256,
+        max_exp_steps: 256,
+        max_bytecode: 512,
+        max_evm_rows: 0,
+        max_keccak_rows: 0,
+    };
+    let rw_map = RwMap::from(&OperationContainer {
+        ..Default::default()
+    });
+    let rows = rw_map.table_assignments(false);
+
+    const TEST_MOCK_RANDOMNESS: u64 = 0x100;
+
+    // synthesize to get degree
+    let mut cs = ConstraintSystem::<<Scheme as CommitmentScheme>::Scalar>::default();
+    let config = SuperCircuit::configure_with_params(
+        &mut cs,
+        SuperCircuitParams {
+            max_txs: circuits_params.max_txs,
+            max_calldata: circuits_params.max_calldata,
+            mock_randomness: TEST_MOCK_RANDOMNESS.into(),
+        },
+    );
+    let degree = cs.degree();
+
+    let advice_commitments = get_rwtable_cols_commitment::<Scheme>(
+        degree,
+        &rows,
+        circuits_params.max_rws,
+        params,
+        false,
+    );
+    println!("advice_commitments {:?}", advice_commitments[0]);
 }

--- a/zkevm-circuits/src/table/rw_table.rs
+++ b/zkevm-circuits/src/table/rw_table.rs
@@ -89,30 +89,28 @@ impl RwTable {
     /// Construct a new RwTable
     pub fn construct<F: Field>(meta: &mut ConstraintSystem<F>) -> Self {
         Self {
-            // TODO upgrade halo2 to use `unblinded_advice_column`
-            // https://github.com/privacy-scaling-explorations/halo2/blob/main/halo2_proofs/examples/vector-ops-unblinded.rs
-            // rw_counter: meta.unblinded_advice_column(),
-            // is_write: meta.unblinded_advice_column(),
-            // tag: meta.unblinded_advice_column(),
-            // id: meta.unblinded_advice_column(),
-            // address: meta.unblinded_advice_column(),
-            // field_tag: meta.unblinded_advice_column(),
-            // storage_key: word::Word::new([meta.unblinded_advice_column(),
-            // meta.unblinded_advice_column()]), value: word::Word::new([meta.
-            // unblinded_advice_column(), meta.unblinded_advice_column()]), value_prev:
-            // word::Word::new([meta.unblinded_advice_column(), meta.unblinded_advice_column()]),
-            // init_val: word::Word::new([meta.unblinded_advice_column(),
-            // meta.unblinded_advice_column()]),
-            rw_counter: meta.advice_column(),
-            is_write: meta.advice_column(),
-            tag: meta.advice_column(),
-            id: meta.advice_column(),
-            address: meta.advice_column(),
-            field_tag: meta.advice_column(),
-            storage_key: word::Word::new([meta.advice_column(), meta.advice_column()]),
-            value: word::Word::new([meta.advice_column(), meta.advice_column()]),
-            value_prev: word::Word::new([meta.advice_column(), meta.advice_column()]),
-            init_val: word::Word::new([meta.advice_column(), meta.advice_column()]),
+            rw_counter: meta.unblinded_advice_column(),
+            is_write: meta.unblinded_advice_column(),
+            tag: meta.unblinded_advice_column(),
+            id: meta.unblinded_advice_column(),
+            address: meta.unblinded_advice_column(),
+            field_tag: meta.unblinded_advice_column(),
+            storage_key: word::Word::new([
+                meta.unblinded_advice_column(),
+                meta.unblinded_advice_column(),
+            ]),
+            value: word::Word::new([
+                meta.unblinded_advice_column(),
+                meta.unblinded_advice_column(),
+            ]),
+            value_prev: word::Word::new([
+                meta.unblinded_advice_column(),
+                meta.unblinded_advice_column(),
+            ]),
+            init_val: word::Word::new([
+                meta.unblinded_advice_column(),
+                meta.unblinded_advice_column(),
+            ]),
         }
     }
     fn assign<F: Field>(

--- a/zkevm-circuits/src/table/rw_table.rs
+++ b/zkevm-circuits/src/table/rw_table.rs
@@ -1,4 +1,19 @@
-use halo2_proofs::circuit::AssignedCell;
+use bus_mapping::operation::OperationContainer;
+use halo2_proofs::{
+    self,
+    circuit::{AssignedCell, SimpleFloorPlanner},
+    halo2curves::ff::{BatchInvert, WithSmallOrderMulGroup},
+};
+
+use halo2_proofs::{
+    halo2curves::{bn256::Fr, group::Curve, CurveAffine},
+    plonk::{Advice, Assigned, Assignment, Challenge, Fixed, FloorPlanner, Instance, Selector},
+    poly::{
+        commitment::{Blind, CommitmentScheme, Params},
+        EvaluationDomain, LagrangeCoeff, Polynomial,
+    },
+};
+use snark_verifier::util::arithmetic::PrimeCurveAffine;
 
 use super::*;
 
@@ -72,6 +87,20 @@ impl RwTable {
     /// Construct a new RwTable
     pub fn construct<F: Field>(meta: &mut ConstraintSystem<F>) -> Self {
         Self {
+            // TODO upgrade halo2 to use `unblinded_advice_column`
+            // https://github.com/privacy-scaling-explorations/halo2/blob/main/halo2_proofs/examples/vector-ops-unblinded.rs
+            // rw_counter: meta.unblinded_advice_column(),
+            // is_write: meta.unblinded_advice_column(),
+            // tag: meta.unblinded_advice_column(),
+            // id: meta.unblinded_advice_column(),
+            // address: meta.unblinded_advice_column(),
+            // field_tag: meta.unblinded_advice_column(),
+            // storage_key: word::Word::new([meta.unblinded_advice_column(),
+            // meta.unblinded_advice_column()]), value: word::Word::new([meta.
+            // unblinded_advice_column(), meta.unblinded_advice_column()]), value_prev:
+            // word::Word::new([meta.unblinded_advice_column(), meta.unblinded_advice_column()]),
+            // init_val: word::Word::new([meta.unblinded_advice_column(),
+            // meta.unblinded_advice_column()]),
             rw_counter: meta.advice_column(),
             is_write: meta.advice_column(),
             tag: meta.advice_column(),
@@ -154,4 +183,290 @@ impl RwTable {
         }
         Ok(rows)
     }
+}
+
+/// get rw table column commitment
+/// implementation snippet from halo2 `create_proof` https://github.com/privacy-scaling-explorations/halo2/blob/9b33f9ce524dbb9133fc8b9638b2afd0571659a8/halo2_proofs/src/plonk/prover.rs#L37
+pub fn get_rwtable_cols_commitment<'params, Scheme: CommitmentScheme>(
+    degree: usize,
+    rws: &[Rw],
+    n_rows: usize,
+    params_prover: &'params Scheme::ParamsProver,
+    is_first_row_padding: bool,
+) -> Vec<<Scheme as CommitmentScheme>::Curve>
+where
+    <Scheme as CommitmentScheme>::Scalar: WithSmallOrderMulGroup<3> + Field,
+{
+    struct WitnessCollection<F: Field> {
+        k: u32,
+        advice: Vec<Polynomial<Assigned<F>, LagrangeCoeff>>,
+        _marker: std::marker::PhantomData<F>,
+    }
+
+    impl<'a, F: Field> Assignment<F> for WitnessCollection<F> {
+        fn enter_region<NR, N>(&mut self, _: N)
+        where
+            NR: Into<String>,
+            N: FnOnce() -> NR,
+        {
+            // Do nothing; we don't care about regions in this context.
+        }
+
+        fn exit_region(&mut self) {
+            // Do nothing; we don't care about regions in this context.
+        }
+
+        fn enable_selector<A, AR>(&mut self, _: A, _: &Selector, _: usize) -> Result<(), Error>
+        where
+            A: FnOnce() -> AR,
+            AR: Into<String>,
+        {
+            // We only care about advice columns here
+
+            Ok(())
+        }
+
+        fn annotate_column<A, AR>(&mut self, _annotation: A, _column: Column<Any>)
+        where
+            A: FnOnce() -> AR,
+            AR: Into<String>,
+        {
+            // Do nothing
+        }
+
+        fn query_instance(&self, column: Column<Instance>, row: usize) -> Result<Value<F>, Error> {
+            Err(Error::BoundsFailure)
+        }
+
+        fn assign_advice<V, VR, A, AR>(
+            &mut self,
+            _: A,
+            column: Column<Advice>,
+            row: usize,
+            to: V,
+        ) -> Result<(), Error>
+        where
+            V: FnOnce() -> Value<VR>,
+            VR: Into<Assigned<F>>,
+            A: FnOnce() -> AR,
+            AR: Into<String>,
+        {
+            to().into_field().map(|v| {
+                *self
+                    .advice
+                    .get_mut(column.index())
+                    .and_then(|v| v.get_mut(row))
+                    .ok_or(Error::BoundsFailure)
+                    .unwrap() = v;
+            });
+            Ok(())
+        }
+
+        fn assign_fixed<V, VR, A, AR>(
+            &mut self,
+            _: A,
+            _: Column<Fixed>,
+            _: usize,
+            _: V,
+        ) -> Result<(), Error>
+        where
+            V: FnOnce() -> Value<VR>,
+            VR: Into<Assigned<F>>,
+            A: FnOnce() -> AR,
+            AR: Into<String>,
+        {
+            // We only care about advice columns here
+
+            Ok(())
+        }
+
+        fn copy(
+            &mut self,
+            _: Column<Any>,
+            _: usize,
+            _: Column<Any>,
+            _: usize,
+        ) -> Result<(), Error> {
+            // We only care about advice columns here
+
+            Ok(())
+        }
+
+        fn fill_from_row(
+            &mut self,
+            _: Column<Fixed>,
+            _: usize,
+            _: Value<Assigned<F>>,
+        ) -> Result<(), Error> {
+            Ok(())
+        }
+
+        fn get_challenge(&self, challenge: Challenge) -> Value<F> {
+            Value::unknown()
+        }
+
+        fn push_namespace<NR, N>(&mut self, _: N)
+        where
+            NR: Into<String>,
+            N: FnOnce() -> NR,
+        {
+            // Do nothing; we don't care about namespaces in this context.
+        }
+
+        fn pop_namespace(&mut self, _: Option<String>) {
+            // Do nothing; we don't care about namespaces in this context.
+        }
+    }
+
+    let rw_map = RwMap::from(&OperationContainer {
+        ..Default::default()
+    });
+    let rows = rw_map.table_assignments(false);
+    let rwtable_circuit = RwTableCircuit::new(&rows, 1, false);
+
+    let domain = EvaluationDomain::<<Scheme as CommitmentScheme>::Scalar>::new(
+        degree as u32,
+        params_prover.k(),
+    );
+
+    let mut cs = ConstraintSystem::default();
+    let rwtable_circuit_config = RwTableCircuit::configure(&mut cs);
+    // TODO adjust domain.empty_lagrange_assigned() visibility in halo2 library to public
+    let mut witness = WitnessCollection {
+        k: params_prover.k(),
+        advice: vec![
+            domain.empty_lagrange_assigned();
+            rwtable_circuit_config.rw_table.advice_columns().len()
+        ],
+        _marker: std::marker::PhantomData,
+    };
+
+    // Synthesize the circuit to obtain the witness and other information.
+    <RwTableCircuit<'_> as Circuit<Fr>>::FloorPlanner::synthesize(
+        &mut witness,
+        &rwtable_circuit,
+        rwtable_circuit_config,
+        cs.constants().clone(),
+    )
+    .unwrap();
+
+    let mut advice_values =
+        batch_invert_assigned::<Scheme::Scalar>(domain, witness.advice.into_iter().collect());
+
+    // Compute commitments to advice column polynomials
+    let blinds = vec![Blind::default(); witness.advice.len()];
+    let advice_commitments_projective: Vec<_> = advice_values
+        .iter()
+        .zip(blinds.iter())
+        .map(|(poly, blind)| params_prover.commit_lagrange(poly, *blind))
+        .collect();
+    let mut advice_commitments =
+        vec![Scheme::Curve::identity(); advice_commitments_projective.len()];
+
+    <Scheme::Curve as CurveAffine>::CurveExt::batch_normalize(
+        &advice_commitments_projective,
+        &mut advice_commitments,
+    );
+
+    advice_commitments
+}
+
+struct RwTableCircuit<'a> {
+    rws: &'a [Rw],
+    n_rows: usize,
+    is_first_row_padding: bool,
+}
+
+impl<'a> RwTableCircuit<'a> {
+    #[allow(dead_code)]
+    pub(crate) fn new(rws: &'a [Rw], n_rows: usize, is_first_row_padding: bool) -> Self {
+        Self {
+            rws,
+            n_rows,
+            is_first_row_padding,
+        }
+    }
+}
+
+#[derive(Clone)]
+struct RwTableCircuitConfig {
+    pub rw_table: RwTable,
+}
+
+impl<'a> RwTableCircuitConfig {}
+
+impl<'a, F: Field> Circuit<F> for RwTableCircuit<'a> {
+    type Config = RwTableCircuitConfig;
+
+    type FloorPlanner = SimpleFloorPlanner;
+
+    type Params = ();
+
+    fn without_witnesses(&self) -> Self {
+        todo!()
+    }
+
+    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+        RwTableCircuitConfig {
+            rw_table: RwTable::construct(meta),
+        }
+    }
+
+    fn synthesize(
+        &self,
+        config: Self::Config,
+        mut layouter: impl Layouter<F>,
+    ) -> Result<(), Error> {
+        layouter.assign_region(
+            || "XXXX",
+            |mut region| {
+                config.rw_table.load_with_region(
+                    &mut region,
+                    self.rws,
+                    self.n_rows,
+                    self.is_first_row_padding,
+                )
+            },
+        )?;
+        Ok(())
+    }
+}
+
+// migrate from halo2 library
+fn batch_invert_assigned<F: Field + WithSmallOrderMulGroup<3>>(
+    domain: EvaluationDomain<F>,
+    assigned: Vec<Polynomial<Assigned<F>, LagrangeCoeff>>,
+) -> Vec<Polynomial<F, LagrangeCoeff>> {
+    let mut assigned_denominators: Vec<_> = assigned
+        .iter()
+        .map(|f| {
+            f.iter()
+                .map(|value| value.denominator())
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+    assigned_denominators
+        .iter_mut()
+        .flat_map(|f| {
+            f.iter_mut()
+                // If the denominator is trivial, we can skip it, reducing the
+                // size of the batch inversion.
+                .filter_map(|d| d.as_mut())
+        })
+        .batch_invert();
+
+    assigned
+        .iter()
+        .zip(assigned_denominators.into_iter())
+        .map(|(poly, inv_denoms)| {
+            let inv_denoms = inv_denoms.into_iter().map(|d| d.unwrap_or(F::ONE));
+            domain.lagrange_from_vec(
+                poly.iter()
+                    .zip(inv_denoms.into_iter())
+                    .map(|(a, inv_den)| a.numerator() * inv_den)
+                    .collect(),
+            )
+        })
+        .collect()
 }

--- a/zkevm-circuits/src/table/rw_table.rs
+++ b/zkevm-circuits/src/table/rw_table.rs
@@ -5,14 +5,17 @@ use halo2_proofs::{
 };
 
 use halo2_proofs::{
-    halo2curves::{bn256::Fr, group::Curve, CurveAffine},
+    halo2curves::{
+        bn256::Fr,
+        group::{prime::PrimeCurveAffine, Curve},
+        CurveAffine,
+    },
     plonk::{Advice, Assigned, Assignment, Challenge, Fixed, FloorPlanner, Instance, Selector},
     poly::{
         commitment::{Blind, CommitmentScheme, Params},
         EvaluationDomain, LagrangeCoeff, Polynomial,
     },
 };
-use snark_verifier::util::arithmetic::PrimeCurveAffine;
 
 use super::*;
 
@@ -186,11 +189,12 @@ impl RwTable {
 
 /// get rw table column commitment
 /// implementation snippet from halo2 `create_proof` https://github.com/privacy-scaling-explorations/halo2/blob/9b33f9ce524dbb9133fc8b9638b2afd0571659a8/halo2_proofs/src/plonk/prover.rs#L37
-pub fn get_rwtable_cols_commitment<'params, Scheme: CommitmentScheme>(
+#[allow(unused)]
+pub fn get_rwtable_cols_commitment<Scheme: CommitmentScheme>(
     degree: usize,
     rws: &[Rw],
     n_rows: usize,
-    params_prover: &'params Scheme::ParamsProver,
+    params_prover: &Scheme::ParamsProver,
 ) -> Vec<<Scheme as CommitmentScheme>::Curve>
 where
     <Scheme as CommitmentScheme>::Scalar: WithSmallOrderMulGroup<3> + Field,
@@ -200,7 +204,7 @@ where
         _marker: std::marker::PhantomData<F>,
     }
 
-    impl<'a, F: Field> Assignment<F> for WitnessCollection<F> {
+    impl<F: Field> Assignment<F> for WitnessCollection<F> {
         fn enter_region<NR, N>(&mut self, _: N)
         where
             NR: Into<String>,
@@ -319,7 +323,7 @@ where
         }
     }
 
-    let rwtable_circuit = RwTableCircuit::new(&rws, n_rows, None);
+    let rwtable_circuit = RwTableCircuit::new(rws, n_rows, None);
 
     let domain = EvaluationDomain::<<Scheme as CommitmentScheme>::Scalar>::new(
         degree as u32,
@@ -392,7 +396,7 @@ struct RwTableCircuitConfig {
     pub rw_table: RwTable,
 }
 
-impl<'a> RwTableCircuitConfig {}
+impl RwTableCircuitConfig {}
 
 impl<'a, F: Field> Circuit<F> for RwTableCircuit<'a> {
     type Config = RwTableCircuitConfig;
@@ -432,6 +436,7 @@ impl<'a, F: Field> Circuit<F> for RwTableCircuit<'a> {
 }
 
 // migrate from halo2 library
+#[allow(unused)]
 fn batch_invert_assigned<F: Field + WithSmallOrderMulGroup<3>>(
     domain: EvaluationDomain<F>,
     assigned: Vec<Polynomial<Assigned<F>, LagrangeCoeff>>,

--- a/zkevm-circuits/src/test_util.rs
+++ b/zkevm-circuits/src/test_util.rs
@@ -381,7 +381,7 @@ impl<const NACC: usize, const NTX: usize> CircuitTestBuilder<NACC, NTX> {
                 MockProver::<Fr>::run(k, &circuit, instance)
             } else {
                 let circuit = EvmCircuit::get_test_circuit_from_block(block.clone(), chunk.clone());
-                let instance = circuit.instance_extend_chunk_ctx();
+                let instance = circuit.instance();
                 MockProver::<Fr>::run(k, &circuit, instance)
             };
 

--- a/zkevm-circuits/src/test_util.rs
+++ b/zkevm-circuits/src/test_util.rs
@@ -78,8 +78,12 @@ const NUM_BLINDING_ROWS: usize = 64;
 /// .unwrap();
 ///
 /// CircuitTestBuilder::new_from_test_ctx(ctx)
-///     .block_modifier(Box::new(|block, chunk| chunk.fixed_param.max_evm_rows = (1 << 18) - 100))
-///     .run();
+///    .block_modifier(Box::new(|_block, chunk| {
+///        chunk
+///            .iter_mut()
+///            .for_each(|chunk| chunk.fixed_param.max_evm_rows = (1 << 18) - 100);
+///    }))
+///    .run()
 /// ```
 pub struct CircuitTestBuilder<const NACC: usize, const NTX: usize> {
     test_ctx: Option<TestContext<NACC, NTX>>,

--- a/zkevm-circuits/src/witness/block.rs
+++ b/zkevm-circuits/src/witness/block.rs
@@ -295,9 +295,14 @@ pub fn block_convert<F: Field>(
         .chunks
         .iter()
         .fold(BTreeMap::new(), |mut map, chunk| {
-            assert!(chunk.ctx.rwc.0.saturating_sub(1) <= builder.circuits_params.max_rws);
-            // [chunk.ctx.rwc.0, builder.circuits_params.max_rws + 1)
-            (chunk.ctx.rwc.0..builder.circuits_params.max_rws + 1).for_each(|padding_rw_counter| {
+            assert!(
+                chunk.ctx.rwc.0.saturating_sub(1) <= builder.circuits_params.max_rws,
+                "max_rws size {} must larger than chunk rws size {}",
+                builder.circuits_params.max_rws,
+                chunk.ctx.rwc.0.saturating_sub(1),
+            );
+            // [chunk.ctx.rwc.0, builder.circuits_params.max_rws)
+            (chunk.ctx.rwc.0..builder.circuits_params.max_rws).for_each(|padding_rw_counter| {
                 *map.entry(padding_rw_counter).or_insert(0) += 1;
             });
             map

--- a/zkevm-circuits/src/witness/chunk.rs
+++ b/zkevm-circuits/src/witness/chunk.rs
@@ -189,7 +189,7 @@ pub fn chunk_convert<F: Field>(
             // by_address_rws
             let start = min(
                 chunk.ctx.idx * builder.circuits_params.max_rws,
-                by_address_rws.len() - 1,
+                by_address_rws.len(),
             );
             let end = min(
                 (chunk.ctx.idx + 1) * builder.circuits_params.max_rws,

--- a/zkevm-circuits/src/witness/chunk.rs
+++ b/zkevm-circuits/src/witness/chunk.rs
@@ -103,7 +103,8 @@ pub fn chunk_convert<F: Field>(
     let chunk = builder.get_chunk(idx);
     let mut rws = RwMap::default();
     let prev_chunk_last_rw = builder.prev_chunk().map(|chunk| {
-        RwMap::get_rw(&block.container, chunk.ctx.end_rwc).expect("Rw does not exist")
+        // rws range [chunk.ctx.initial_rwc, chunk.ctx.end_rwc)
+        RwMap::get_rw(&block.container, chunk.ctx.end_rwc - 1).expect("Rw does not exist")
     });
 
     // FIXME(Cecilia): debug

--- a/zkevm-circuits/src/witness/chunk.rs
+++ b/zkevm-circuits/src/witness/chunk.rs
@@ -109,11 +109,6 @@ pub fn chunk_convert<F: Field>(
             }
         });
 
-        println!(
-            "| {:?} ... {:?} | @chunk_convert",
-            chunk.ctx.initial_rwc, chunk.ctx.end_rwc
-        );
-
         // Get the rws in the i-th chunk
         let chrono_rws = {
             let mut chrono_rws = RwMap::from(&builder.block.container);
@@ -185,7 +180,6 @@ pub fn chunk_convert<F: Field>(
             true,
             prev_chunk_last_chrono_rw,
         );
-
         chunks.push(Chunk {
             permu_alpha: alpha,
             permu_gamma: gamma,
@@ -202,6 +196,13 @@ pub fn chunk_convert<F: Field>(
             prev_chunk_last_chrono_rw,
             prev_chunk_last_by_address_rw,
         });
+    }
+
+    if log::log_enabled!(log::Level::Debug) {
+        chunks
+            .iter()
+            .enumerate()
+            .for_each(|(i, chunk)| log::debug!("{}th chunk context {:?}", i, chunk,));
     }
 
     Ok(chunks)

--- a/zkevm-circuits/src/witness/chunk.rs
+++ b/zkevm-circuits/src/witness/chunk.rs
@@ -113,7 +113,7 @@ pub fn chunk_convert<F: Field>(
     );
 
     // Compute fingerprints of all chunks
-    let mut alpha_gamas = Vec::with_capacity(builder.chunks.len());
+    let mut challenges = Vec::with_capacity(builder.chunks.len());
     let mut rw_fingerprints: Vec<RwFingerprints<F>> = Vec::with_capacity(builder.chunks.len());
     let mut chrono_rw_fingerprints: Vec<RwFingerprints<F>> =
         Vec::with_capacity(builder.chunks.len());
@@ -154,7 +154,7 @@ pub fn chunk_convert<F: Field>(
             true,
         );
 
-        alpha_gamas.push(vec![alpha, gamma]);
+        challenges.push(vec![alpha, gamma]);
         rw_fingerprints.push(cur_fingerprints);
         chrono_rw_fingerprints.push(cur_chrono_fingerprints);
         if i == idx {
@@ -164,8 +164,8 @@ pub fn chunk_convert<F: Field>(
 
     // TODO(Cecilia): if we chunk across blocks then need to store the prev_block
     let chunck = Chunk {
-        permu_alpha: alpha_gamas[idx][0],
-        permu_gamma: alpha_gamas[idx][1],
+        permu_alpha: challenges[idx][0],
+        permu_gamma: challenges[idx][1],
         rw_fingerprints: rw_fingerprints[idx].clone(),
         chrono_rw_fingerprints: chrono_rw_fingerprints[idx].clone(),
         begin_chunk: chunk.begin_chunk.clone(),

--- a/zkevm-circuits/src/witness/rw.rs
+++ b/zkevm-circuits/src/witness/rw.rs
@@ -133,7 +133,7 @@ impl RwMap {
     pub fn table_assignments_padding(
         rows: &[Rw],
         target_len: usize,
-        prev_chunk_last_rw: Option<Rw>,
+        padding_start_rw: Option<Rw>,
     ) -> (Vec<Rw>, usize) {
         // Remove Start/Padding rows as we will add them from scratch.
         let rows_trimmed: Vec<Rw> = rows
@@ -162,7 +162,7 @@ impl RwMap {
             .map(|rw_counter| Rw::Padding { rw_counter });
         (
             iter::empty()
-                .chain([prev_chunk_last_rw.unwrap_or(Rw::Start { rw_counter: 1 })])
+                .chain([padding_start_rw.unwrap_or(Rw::Start { rw_counter: 1 })])
                 .chain(rows_trimmed.into_iter())
                 .chain(padding.into_iter())
                 .collect(),

--- a/zkevm-circuits/src/witness/rw.rs
+++ b/zkevm-circuits/src/witness/rw.rs
@@ -190,19 +190,13 @@ impl RwMap {
         rows
     }
 
-    /// Get RwMap for a chunk specified by start and end
-    pub fn from_chunked(
-        container: &operation::OperationContainer,
-        start: usize,
-        end: usize,
-    ) -> Self {
-        let mut rws: Self = container.into();
-        for rw in rws.0.values_mut() {
+    /// take only rw_counter within range
+    pub fn take_rw_counter_range(mut self, start: usize, end: usize) -> Self {
+        for rw in self.0.values_mut() {
             rw.retain(|r| r.rw_counter() >= start && r.rw_counter() < end)
         }
-        rws
+        self
     }
-
     /// Get one Rw for a chunk specified by index
     pub fn get_rw(container: &operation::OperationContainer, counter: usize) -> Option<Rw> {
         let rws: Self = container.into();

--- a/zkevm-circuits/tests/prover_error.rs
+++ b/zkevm-circuits/tests/prover_error.rs
@@ -97,7 +97,9 @@ fn prover_error() {
         .expect("handle_block");
     let (block, chunk) = {
         let mut block = block_convert(&builder).expect("block_convert");
-        let chunk = chunk_convert(&builder, 0).expect("chunk_convert");
+        let chunk = chunk_convert(&block, &builder)
+            .expect("chunk_convert")
+            .remove(0);
 
         block.randomness = Fr::from(MOCK_RANDOMNESS);
         (block, chunk)


### PR DESCRIPTION
### Content
Reported issues found on multi-chunk testing

- [x] refactor 1: simply chunking boundary judgement logic in bus-mapping to ready for finish other incompleted features + avoid tech dept in the future 
- [x] add uncompleted logic in bus-mapping: chronological and by-address rwtable not propagate pre-chunk last rw correctly.
- [x] edge case: deal with dummy chunk for real chunk less than desired chunk in circuit params
- [x] allow zero limb diff in state_circuit lexicoordering  => we allow duplicated `rw_counter` in `padding`, and rely on permutation constraints on by-address/chronological rw_table to avoid malicious padding insert.
- [x] super_circuit/root_circuit tests adopt multiple chunk  

### Related Issue
To close https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/1778
