### PR TITLE
fix(zkevm-circuits/begin_tx): add missing constraints

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -209,6 +209,8 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             create.caller_nonce(),
         );
 
+        // TODO: add missing constraints:
+
         // 1. Handle contract creation transaction.
         cb.condition(tx.is_create.expr(), |cb| {
             cb.keccak_table_lookup(


### PR DESCRIPTION
### Description

This PR aims to fix #1475 by adding missing constraints.

### Issue Link

#1475

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

### Questions / Need Help

1. Meaning of `value_prev` argument in `account_access_list_write_unchecked`. Why is it sometimes set to 0, and sometimes to bool values such as `is_coinbase_warm` or `is_caller_callee_equal`. What is `is_caller_callee_equal` for?
2. There's expression: https://github.com/privacy-scaling-explorations/zkevm-circuits/blob/main/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs#L163 
Why do we have summation - if `is_empty_code_hash.expr()` is enough (as well as `callee_not_exists` is enough)?
3. What's [caller_nonce_hash_bytes](https://github.com/privacy-scaling-explorations/zkevm-circuits/blob/main/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs#L186)? Is it Keccak(sender, nonce) and we have to constrain this exact value?