### PR TITLE
Merge Transfer and TransferWithGas gadget

### DIFF
--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -623,7 +623,14 @@ impl<'a> CircuitInputStateRef<'a> {
                 value_prev: sender_balance_prev,
             },
         )?;
-        self.transfer_to(step, receiver, receiver_exists, opcode_is_create, value, true)?;
+        self.transfer_to(
+            step,
+            receiver,
+            receiver_exists,
+            opcode_is_create,
+            value,
+            true,
+        )?;
 
         Ok(())
     }

--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -565,7 +565,7 @@ impl<'a> CircuitInputStateRef<'a> {
         sender: Address,
         receiver: Address,
         receiver_exists: bool,
-        opcode_is_create: bool,
+        is_create: bool,
         value: Word,
         fee: Option<Word>,
     ) -> Result<(), Error> {
@@ -621,14 +621,7 @@ impl<'a> CircuitInputStateRef<'a> {
             )?;
         }
 
-        self.transfer_to(
-            step,
-            receiver,
-            receiver_exists,
-            opcode_is_create,
-            value,
-            true,
-        )?;
+        self.transfer_to(step, receiver, receiver_exists, is_create, value, true)?;
 
         Ok(())
     }
@@ -639,11 +632,11 @@ impl<'a> CircuitInputStateRef<'a> {
         step: &mut ExecStep,
         receiver: Address,
         receiver_exists: bool,
-        opcode_is_create: bool,
+        is_create: bool,
         value: Word,
         reversible: bool,
     ) -> Result<(), Error> {
-        if !receiver_exists && (!value.is_zero() || opcode_is_create) {
+        if !receiver_exists && (!value.is_zero() || is_create) {
             self.account_write(
                 step,
                 receiver,

--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -559,13 +559,13 @@ impl<'a> CircuitInputStateRef<'a> {
     /// balance by `value`. If `fee` is existing (not None), also need to push 1
     /// non-reversible [`AccountOp`] to update `sender` balance by `fee`.
     #[allow(clippy::too_many_arguments)]
-    pub fn transfer_with_fee(
+    pub fn transfer(
         &mut self,
         step: &mut ExecStep,
         sender: Address,
         receiver: Address,
         receiver_exists: bool,
-        must_create: bool,
+        opcode_is_create: bool,
         value: Word,
         fee: Option<Word>,
     ) -> Result<(), Error> {
@@ -623,30 +623,9 @@ impl<'a> CircuitInputStateRef<'a> {
                 value_prev: sender_balance_prev,
             },
         )?;
-        self.transfer_to(step, receiver, receiver_exists, must_create, value, true)?;
+        self.transfer_to(step, receiver, receiver_exists, opcode_is_create, value, true)?;
 
         Ok(())
-    }
-
-    /// Same functionality with `transfer_with_fee` but with `fee` set zero.
-    pub fn transfer(
-        &mut self,
-        step: &mut ExecStep,
-        sender: Address,
-        receiver: Address,
-        receiver_exists: bool,
-        must_create: bool,
-        value: Word,
-    ) -> Result<(), Error> {
-        self.transfer_with_fee(
-            step,
-            sender,
-            receiver,
-            receiver_exists,
-            must_create,
-            value,
-            None,
-        )
     }
 
     /// Transfer to an address. Create an account if it is not existed before.
@@ -655,12 +634,11 @@ impl<'a> CircuitInputStateRef<'a> {
         step: &mut ExecStep,
         receiver: Address,
         receiver_exists: bool,
-        must_create: bool,
+        opcode_is_create: bool,
         value: Word,
         reversible: bool,
     ) -> Result<(), Error> {
-        // If receiver doesn't exist, create it
-        if !receiver_exists && (!value.is_zero() || must_create) {
+        if !receiver_exists && (!value.is_zero() || opcode_is_create) {
             self.account_write(
                 step,
                 receiver,

--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -609,20 +609,18 @@ impl<'a> CircuitInputStateRef<'a> {
             sender_balance
         );
 
-        if value.is_zero() {
-            // Skip transfer if value == 0
-            return Ok(());
+        if !value.is_zero() {
+            self.push_op_reversible(
+                step,
+                AccountOp {
+                    address: sender,
+                    field: AccountField::Balance,
+                    value: sender_balance,
+                    value_prev: sender_balance_prev,
+                },
+            )?;
         }
 
-        self.push_op_reversible(
-            step,
-            AccountOp {
-                address: sender,
-                field: AccountField::Balance,
-                value: sender_balance,
-                value_prev: sender_balance_prev,
-            },
-        )?;
         self.transfer_to(
             step,
             receiver,

--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -608,18 +608,7 @@ impl<'a> CircuitInputStateRef<'a> {
             sender_balance_prev,
             sender_balance
         );
-        // If receiver doesn't exist, create it
-        if !receiver_exists && (!value.is_zero() || must_create) {
-            self.push_op_reversible(
-                step,
-                AccountOp {
-                    address: receiver,
-                    field: AccountField::CodeHash,
-                    value: CodeDB::empty_code_hash().to_word(),
-                    value_prev: Word::zero(),
-                },
-            )?;
-        }
+
         if value.is_zero() {
             // Skip transfer if value == 0
             return Ok(());
@@ -634,19 +623,7 @@ impl<'a> CircuitInputStateRef<'a> {
                 value_prev: sender_balance_prev,
             },
         )?;
-
-        let (_found, receiver_account) = self.sdb.get_account(&receiver);
-        let receiver_balance_prev = receiver_account.balance;
-        let receiver_balance = receiver_account.balance + value;
-        self.push_op_reversible(
-            step,
-            AccountOp {
-                address: receiver,
-                field: AccountField::Balance,
-                value: receiver_balance,
-                value_prev: receiver_balance_prev,
-            },
-        )?;
+        self.transfer_to(step, receiver, receiver_exists, must_create, value, true)?;
 
         Ok(())
     }
@@ -683,7 +660,7 @@ impl<'a> CircuitInputStateRef<'a> {
         reversible: bool,
     ) -> Result<(), Error> {
         // If receiver doesn't exist, create it
-        if (!receiver_exists && !value.is_zero()) || must_create {
+        if !receiver_exists && (!value.is_zero() || must_create) {
             self.account_write(
                 step,
                 receiver,

--- a/bus-mapping/src/evm/opcodes/begin_end_tx.rs
+++ b/bus-mapping/src/evm/opcodes/begin_end_tx.rs
@@ -122,7 +122,7 @@ fn gen_begin_tx_steps(state: &mut CircuitInputStateRef) -> Result<ExecStep, Erro
     }
 
     // Transfer with fee
-    state.transfer_with_fee(
+    state.transfer(
         &mut exec_step,
         call.caller_address,
         call.address,

--- a/bus-mapping/src/evm/opcodes/callop.rs
+++ b/bus-mapping/src/evm/opcodes/callop.rs
@@ -195,6 +195,7 @@ impl<const N_ARGS: usize> Opcode for CallOpcode<N_ARGS> {
                 callee_exists,
                 false,
                 call.value,
+                None,
             )?;
         }
 

--- a/bus-mapping/src/evm/opcodes/create.rs
+++ b/bus-mapping/src/evm/opcodes/create.rs
@@ -217,8 +217,9 @@ impl<const IS_CREATE2: bool> Opcode for Create<IS_CREATE2> {
                 caller.address,
                 callee.address,
                 callee_exists,
-                !callee_exists,
+                true,
                 callee.value,
+                None,
             )?;
 
             // EIP 161, increase callee's nonce

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -5,7 +5,7 @@ use crate::{
         step::ExecutionState,
         util::{
             and,
-            common_gadget::TransferWithGasFeeGadget,
+            common_gadget::TransferGadget,
             constraint_builder::{
                 ConstrainBuilderCommon, EVMConstraintBuilder, ReversionInfo, StepStateTransition,
                 Transition::{Delta, To},
@@ -14,7 +14,7 @@ use crate::{
             math_gadget::{
                 ContractCreateGadget, IsEqualWordGadget, IsZeroWordGadget, RangeCheckGadget,
             },
-            not, or,
+            not,
             tx::{BeginTxHelperGadget, TxDataGadget},
             AccountAddress, CachedRegion, Cell, StepRws,
         },
@@ -41,7 +41,7 @@ pub(crate) struct BeginTxGadget<F> {
     call_callee_address: AccountAddress<F>,
     reversion_info: ReversionInfo<F>,
     sufficient_gas_left: RangeCheckGadget<F, N_BYTES_GAS>,
-    transfer_with_gas_fee: TransferWithGasFeeGadget<F>,
+    transfer_with_gas_fee: TransferGadget<F, true>,
     code_hash: WordLoHiCell<F>,
     is_empty_code_hash: IsEqualWordGadget<F, WordLoHi<Expression<F>>, WordLoHi<Expression<F>>>,
     caller_nonce_hash_bytes: Word32Cell<F>,
@@ -170,17 +170,20 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             AccountFieldTag::CodeHash,
             code_hash.to_word(),
         );
-
+        cb.require_equal(
+            "is create: callee_not_exists",
+            tx.is_create.expr(),
+            callee_not_exists.expr(),
+        );
         // Transfer value from caller to callee, creating account if necessary.
-        let transfer_with_gas_fee = TransferWithGasFeeGadget::construct(
+        let transfer_with_gas_fee = TransferGadget::construct(
             cb,
             tx.caller_address.to_word(),
             tx.callee_address.to_word(),
             not::expr(callee_not_exists.expr()),
-            or::expr([tx.is_create.expr(), callee_not_exists.expr()]),
             tx.value.clone(),
-            tx.mul_gas_fee_by_gas.product().clone(),
             &mut reversion_info,
+            Some(tx.mul_gas_fee_by_gas.product().clone()),
         );
 
         let caller_nonce_hash_bytes = cb.query_word32();
@@ -505,11 +508,14 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
         self.transfer_with_gas_fee.assign(
             region,
             offset,
-            caller_balance_sub_fee_pair,
+            (
+                Some(caller_balance_sub_fee_pair.0),
+                Some(caller_balance_sub_fee_pair.1),
+            ),
             caller_balance_sub_value_pair,
             callee_balance_pair,
             tx.value,
-            gas_fee,
+            Some(gas_fee),
         )?;
         self.code_hash
             .assign_u256(region, offset, callee_code_hash)?;

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -170,17 +170,13 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             AccountFieldTag::CodeHash,
             code_hash.to_word(),
         );
-        cb.require_equal(
-            "is create: callee_not_exists",
-            tx.is_create.expr(),
-            callee_not_exists.expr(),
-        );
         // Transfer value from caller to callee, creating account if necessary.
         let transfer_with_gas_fee = TransferGadget::construct(
             cb,
             tx.caller_address.to_word(),
             tx.callee_address.to_word(),
             not::expr(callee_not_exists.expr()),
+            tx.is_create.expr(),
             tx.value.clone(),
             &mut reversion_info,
             Some(tx.mul_gas_fee_by_gas.product().clone()),

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -470,7 +470,9 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             region,
             offset,
             &mut rws,
-            (callee_exists, tx.value, tx.is_create()),
+            callee_exists,
+            tx.value,
+            tx.is_create(),
             Some(gas_fee),
         )?;
         self.begin_tx.assign(region, offset, tx)?;

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -467,14 +467,13 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
         let callee_exists =
             is_precompiled(&tx.to_or_contract_addr()) || !callee_code_hash.is_zero();
         let caller_balance_sub_fee_pair = rws.next().account_balance_pair();
-        let must_create = tx.is_create();
 
         let caller_balance_sub_value_pair = if !tx.value.is_zero() {
             rws.next().account_balance_pair()
         } else {
             (zero, zero)
         };
-        if !callee_exists && (!tx.value.is_zero() || must_create) {
+        if !callee_exists && (!tx.value.is_zero() || tx.is_create()) {
             callee_code_hash = rws.next().account_codehash_pair().1;
         }
         let callee_balance_pair = if !tx.value.is_zero() {

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -468,16 +468,20 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             is_precompiled(&tx.to_or_contract_addr()) || !callee_code_hash.is_zero();
         let caller_balance_sub_fee_pair = rws.next().account_balance_pair();
         let must_create = tx.is_create();
+
+        let caller_balance_sub_value_pair = if !tx.value.is_zero() {
+            rws.next().account_balance_pair()
+        } else {
+            (zero, zero)
+        };
         if !callee_exists && (!tx.value.is_zero() || must_create) {
             callee_code_hash = rws.next().account_codehash_pair().1;
         }
-        let mut caller_balance_sub_value_pair = (zero, zero);
-        let mut callee_balance_pair = (zero, zero);
-        if !tx.value.is_zero() {
-            caller_balance_sub_value_pair = rws.next().account_balance_pair();
-            callee_balance_pair = rws.next().account_balance_pair();
+        let callee_balance_pair = if !tx.value.is_zero() {
+            rws.next().account_balance_pair()
+        } else {
+            (zero, zero)
         };
-
         self.begin_tx.assign(region, offset, tx)?;
         self.tx.assign(region, offset, tx)?;
 

--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -867,20 +867,12 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
             depth.low_u64() < 1025 && (!(is_call || is_callcode) || caller_balance >= value);
 
         // conditionally assign
-        if is_call && is_precheck_ok && !value.is_zero() {
-            if !callee_exists {
-                rws.next().account_codehash_pair(); // callee hash
-            }
-
-            let caller_balance_pair = rws.next().account_balance_pair();
-            let callee_balance_pair = rws.next().account_balance_pair();
+        if is_call && is_precheck_ok {
             self.transfer.assign(
                 region,
                 offset,
-                (None, None),
-                caller_balance_pair,
-                callee_balance_pair,
-                value,
+                &mut rws,
+                (callee_exists, value, false),
                 None,
             )?;
         }

--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -60,7 +60,7 @@ pub(crate) struct CallOpGadget<F> {
     is_warm: Cell<F>,
     is_warm_prev: Cell<F>,
     callee_reversion_info: ReversionInfo<F>,
-    transfer: TransferGadget<F>,
+    transfer: TransferGadget<F, false>,
     // current handling Call* opcode's caller balance
     caller_balance: WordLoHi<Cell<F>>,
     // check if insufficient balance case
@@ -242,9 +242,9 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
                 caller_address.to_word(),
                 callee_address.to_word(),
                 not::expr(call_gadget.callee_not_exists.expr()),
-                false,
                 call_gadget.value.clone(),
                 &mut callee_reversion_info,
+                None,
             )
         });
         // rwc_delta = 8 + is_delegatecall * 2 + call_gadget.rw_delta() +
@@ -876,9 +876,11 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
             self.transfer.assign(
                 region,
                 offset,
+                (None, None),
                 caller_balance_pair,
                 callee_balance_pair,
                 value,
+                None,
             )?;
         }
 

--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -868,13 +868,8 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
 
         // conditionally assign
         if is_call && is_precheck_ok {
-            self.transfer.assign(
-                region,
-                offset,
-                &mut rws,
-                (callee_exists, value, false),
-                None,
-            )?;
+            self.transfer
+                .assign(region, offset, &mut rws, callee_exists, value, false, None)?;
         }
 
         self.opcode

--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -242,7 +242,7 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
                 caller_address.to_word(),
                 callee_address.to_word(),
                 not::expr(call_gadget.callee_not_exists.expr()),
-                0.expr(),
+                false,
                 call_gadget.value.clone(),
                 &mut callee_reversion_info,
             )

--- a/zkevm-circuits/src/evm_circuit/execution/callop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callop.rs
@@ -242,6 +242,7 @@ impl<F: Field> ExecutionGadget<F> for CallOpGadget<F> {
                 caller_address.to_word(),
                 callee_address.to_word(),
                 not::expr(call_gadget.callee_not_exists.expr()),
+                false.expr(),
                 call_gadget.value.clone(),
                 &mut callee_reversion_info,
                 None,

--- a/zkevm-circuits/src/evm_circuit/execution/create.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/create.rs
@@ -333,7 +333,7 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                     cb,
                     create.caller_address(),
                     contract_addr.to_word(),
-                    0.expr(),
+                    false.expr(),
                     true.expr(),
                     value.clone(),
                     &mut callee_reversion_info,

--- a/zkevm-circuits/src/evm_circuit/execution/create.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/create.rs
@@ -639,22 +639,11 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
 
         let code_hash = if is_precheck_ok {
             if !is_address_collision {
-                // transfer
-                if callee_prev_code_hash.is_zero() {
-                    rws.next(); // codehash update
-                }
-                let [caller_balance_pair, callee_balance_pair] = if !value.is_zero() {
-                    [(); 2].map(|_| rws.next().account_balance_pair())
-                } else {
-                    [(0.into(), 0.into()), (0.into(), 0.into())]
-                };
                 self.transfer.assign(
                     region,
                     offset,
-                    (None, None),
-                    caller_balance_pair,
-                    callee_balance_pair,
-                    value,
+                    &mut rws,
+                    (!callee_prev_code_hash.is_zero(), value, true),
                     None,
                 )?;
             }

--- a/zkevm-circuits/src/evm_circuit/execution/create.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/create.rs
@@ -643,7 +643,9 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                     region,
                     offset,
                     &mut rws,
-                    (!callee_prev_code_hash.is_zero(), value, true),
+                    !callee_prev_code_hash.is_zero(),
+                    value,
+                    true,
                     None,
                 )?;
             }

--- a/zkevm-circuits/src/evm_circuit/execution/create.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/create.rs
@@ -334,7 +334,7 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                     create.caller_address(),
                     contract_addr.to_word(),
                     0.expr(),
-                    1.expr(),
+                    true,
                     value.clone(),
                     &mut callee_reversion_info,
                 );

--- a/zkevm-circuits/src/evm_circuit/execution/create.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/create.rs
@@ -63,7 +63,7 @@ pub(crate) struct CreateGadget<F, const IS_CREATE2: bool, const S: ExecutionStat
     callee_nonce: Cell<F>,
     prev_code_hash: WordLoHiCell<F>,
     prev_code_hash_is_zero: IsZeroWordGadget<F, WordLoHi<Expression<F>>>,
-    transfer: TransferGadget<F>,
+    transfer: TransferGadget<F, false>,
     create: ContractCreateGadget<F, IS_CREATE2>,
 
     init_code: MemoryAddressGadget<F>,
@@ -334,9 +334,9 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                     create.caller_address(),
                     contract_addr.to_word(),
                     0.expr(),
-                    true,
                     value.clone(),
                     &mut callee_reversion_info,
+                    None,
                 );
 
                 // EIP 161, the nonce of a newly created contract is 1
@@ -650,9 +650,11 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                 self.transfer.assign(
                     region,
                     offset,
+                    (None, None),
                     caller_balance_pair,
                     callee_balance_pair,
                     value,
+                    None,
                 )?;
             }
 

--- a/zkevm-circuits/src/evm_circuit/execution/create.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/create.rs
@@ -334,6 +334,7 @@ impl<F: Field, const IS_CREATE2: bool, const S: ExecutionState> ExecutionGadget<
                     create.caller_address(),
                     contract_addr.to_word(),
                     0.expr(),
+                    true.expr(),
                     value.clone(),
                     &mut callee_reversion_info,
                     None,

--- a/zkevm-circuits/src/evm_circuit/execution/end_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/end_tx.rs
@@ -107,6 +107,7 @@ impl<F: Field> ExecutionGadget<F> for EndTxGadget<F> {
             cb,
             coinbase.to_word(),
             1.expr() - coinbase_code_hash_is_zero.expr(),
+            false.expr(),
             mul_effective_tip_by_gas_used.product().clone(),
             None,
         );

--- a/zkevm-circuits/src/evm_circuit/execution/end_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/end_tx.rs
@@ -110,7 +110,6 @@ impl<F: Field> ExecutionGadget<F> for EndTxGadget<F> {
             false.expr(),
             mul_effective_tip_by_gas_used.product().clone(),
             None,
-            true,
         );
 
         let end_tx = EndTxHelperGadget::construct(

--- a/zkevm-circuits/src/evm_circuit/execution/end_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/end_tx.rs
@@ -11,7 +11,7 @@ use crate::{
                 MulWordByU64Gadget,
             },
             tx::EndTxHelperGadget,
-            CachedRegion, Cell,
+            CachedRegion, Cell, StepRws,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
@@ -150,9 +150,11 @@ impl<F: Field> ExecutionGadget<F> for EndTxGadget<F> {
         step: &ExecStep,
     ) -> Result<(), Error> {
         let gas_used = tx.gas() - step.gas_left;
-        let (refund, _) = block.get_rws(step, 2).tx_refund_value_pair();
-        let (caller_balance, caller_balance_prev) = block.get_rws(step, 3).account_balance_pair();
-        let (coinbase_code_hash_prev, _) = block.get_rws(step, 4).account_codehash_pair();
+        let mut rws = StepRws::new(block, step);
+        rws.offset_add(2);
+        let (refund, _) = rws.next().tx_refund_value_pair();
+        let (caller_balance, caller_balance_prev) = rws.next().account_balance_pair();
+        let (coinbase_code_hash_prev, _) = rws.next().account_codehash_pair();
 
         self.tx_id
             .assign(region, offset, Value::known(F::from(tx.id)))?;
@@ -206,24 +208,12 @@ impl<F: Field> ExecutionGadget<F> for EndTxGadget<F> {
             .assign_u256(region, offset, coinbase_code_hash_prev)?;
         self.coinbase_code_hash_is_zero
             .assign_u256(region, offset, coinbase_code_hash_prev)?;
-        if !coinbase_reward.is_zero() {
-            let coinbase_balance_pair = block
-                .get_rws(
-                    step,
-                    if coinbase_code_hash_prev.is_zero() {
-                        6
-                    } else {
-                        5
-                    },
-                )
-                .account_balance_pair();
-            self.coinbase_reward.assign(
-                region,
-                offset,
-                coinbase_balance_pair,
-                effective_tip * gas_used,
-            )?;
-        }
+        self.coinbase_reward.assign(
+            region,
+            offset,
+            &mut rws,
+            (!coinbase_code_hash_prev.is_zero(), coinbase_reward, false),
+        )?;
         self.is_persistent.assign(
             region,
             offset,

--- a/zkevm-circuits/src/evm_circuit/execution/end_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/end_tx.rs
@@ -107,7 +107,6 @@ impl<F: Field> ExecutionGadget<F> for EndTxGadget<F> {
             cb,
             coinbase.to_word(),
             1.expr() - coinbase_code_hash_is_zero.expr(),
-            false.expr(),
             mul_effective_tip_by_gas_used.product().clone(),
             None,
         );

--- a/zkevm-circuits/src/evm_circuit/execution/end_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/end_tx.rs
@@ -75,10 +75,9 @@ impl<F: Field> ExecutionGadget<F> for EndTxGadget<F> {
             tx_gas_price.clone(),
             effective_refund.min() + cb.curr.state.gas_left.expr(),
         );
-        let gas_fee_refund = UpdateBalanceGadget::construct(
-            cb,
+        let gas_fee_refund = cb.increase_balance(
             tx_caller_address.to_word(),
-            vec![mul_gas_price_by_refund.product().clone()],
+            mul_gas_price_by_refund.product().clone(),
             None,
         );
 

--- a/zkevm-circuits/src/evm_circuit/execution/end_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/end_tx.rs
@@ -212,7 +212,9 @@ impl<F: Field> ExecutionGadget<F> for EndTxGadget<F> {
             region,
             offset,
             &mut rws,
-            (!coinbase_code_hash_prev.is_zero(), coinbase_reward, false),
+            !coinbase_code_hash_prev.is_zero(),
+            coinbase_reward,
+            false,
         )?;
         self.is_persistent.assign(
             region,

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -387,6 +387,7 @@ impl<F: Field> TransferToGadget<F> {
         let value_is_zero = cb.is_zero_word(&value);
 
         // Create account
+        // See https://github.com/ethereum/go-ethereum/pull/28666 for the context of this check.
         cb.condition(
             and::expr([
                 not::expr(receiver_exists.expr()),

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -492,15 +492,6 @@ impl<F: Field> TransferWithGasFeeGadget<F> {
     ) -> Self {
         let sender_sub_fee = cb.decrease_balance(sender_address.to_word(), gas_fee, None);
         let value_is_zero = cb.is_zero_word(&value);
-        // If receiver doesn't exist, create it
-        TransferToGadget::create_account(
-            cb,
-            receiver_address.clone(),
-            receiver_exists.clone(),
-            must_create.clone(),
-            value_is_zero.expr(),
-            Some(reversion_info),
-        );
         // Skip transfer if value == 0
         let sender_sub_value = cb.condition(not::expr(value_is_zero.expr()), |cb| {
             cb.decrease_balance(sender_address, value.clone(), Some(reversion_info))
@@ -512,7 +503,7 @@ impl<F: Field> TransferWithGasFeeGadget<F> {
             must_create,
             value,
             Some(reversion_info),
-            false,
+            true,
         );
 
         Self {
@@ -607,15 +598,6 @@ impl<F: Field> TransferGadget<F> {
         reversion_info: &mut ReversionInfo<F>,
     ) -> Self {
         let value_is_zero = cb.is_zero_word(&value);
-        // If receiver doesn't exist, create it
-        TransferToGadget::create_account(
-            cb,
-            receiver_address.clone(),
-            receiver_exists.clone(),
-            must_create.expr(),
-            value_is_zero.expr(),
-            Some(reversion_info),
-        );
         // Skip transfer if value == 0
         let sender = cb.condition(not::expr(value_is_zero.expr()), |cb| {
             cb.decrease_balance(sender_address, value.clone(), Some(reversion_info))
@@ -627,7 +609,7 @@ impl<F: Field> TransferGadget<F> {
             must_create.expr(),
             value,
             Some(reversion_info),
-            false,
+            true,
         );
 
         Self {

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -603,7 +603,6 @@ impl<F: Field> TransferGadget<F> {
         receiver_address: WordLoHi<Expression<F>>,
         receiver_exists: Expression<F>,
         must_create: Expression<F>,
-        // _prev_code_hash: WordLoHi<Expression<F>>,
         value: Word32Cell<F>,
         reversion_info: &mut ReversionInfo<F>,
     ) -> Self {

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -383,19 +383,18 @@ impl<F: Field> TransferToGadget<F> {
         must_create: Expression<F>,
         value: Word32Cell<F>,
         mut reversion_info: Option<&mut ReversionInfo<F>>,
-        account_write: bool,
     ) -> Self {
         let value_is_zero = cb.is_zero_word(&value);
-        if account_write {
-            Self::create_account(
-                cb,
-                receiver_address.clone(),
-                receiver_exists.clone(),
-                must_create.clone(),
-                value_is_zero.expr(),
-                reversion_info.as_deref_mut(),
-            );
-        }
+
+        Self::create_account(
+            cb,
+            receiver_address.clone(),
+            receiver_exists.clone(),
+            must_create.clone(),
+            value_is_zero.expr(),
+            reversion_info.as_deref_mut(),
+        );
+
         let receiver = cb.condition(not::expr(value_is_zero.expr()), |cb| {
             cb.increase_balance(receiver_address, value.clone(), reversion_info)
         });
@@ -503,7 +502,6 @@ impl<F: Field> TransferWithGasFeeGadget<F> {
             must_create,
             value,
             Some(reversion_info),
-            true,
         );
 
         Self {
@@ -609,7 +607,6 @@ impl<F: Field> TransferGadget<F> {
             must_create.expr(),
             value,
             Some(reversion_info),
-            true,
         );
 
         Self {

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -371,7 +371,7 @@ pub(crate) struct TransferToGadget<F> {
     receiver: UpdateBalanceGadget<F, 2, true>,
     receiver_exists: Expression<F>,
     must_create: Expression<F>,
-    pub(crate) value_is_zero: IsZeroWordGadget<F, Word32Cell<F>>,
+    value_is_zero: IsZeroWordGadget<F, Word32Cell<F>>,
 }
 
 impl<F: Field> TransferToGadget<F> {
@@ -475,7 +475,7 @@ pub(crate) struct TransferWithGasFeeGadget<F> {
     sender_sub_fee: UpdateBalanceGadget<F, 2, false>,
     sender_sub_value: UpdateBalanceGadget<F, 2, false>,
     receiver: TransferToGadget<F>,
-    pub(crate) value_is_zero: IsZeroWordGadget<F, Word32Cell<F>>,
+    value_is_zero: IsZeroWordGadget<F, Word32Cell<F>>,
 }
 
 impl<F: Field> TransferWithGasFeeGadget<F> {

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -368,7 +368,7 @@ impl<F: Field, const N_ADDENDS: usize, const INCREASE: bool>
 
 #[derive(Clone, Debug)]
 pub(crate) struct TransferToGadget<F> {
-    receiver: UpdateBalanceGadget<F, 2, true>,
+    receiver_balance: UpdateBalanceGadget<F, 2, true>,
     receiver_exists: Expression<F>,
     opcode_is_create: Expression<F>,
     value_is_zero: IsZeroWordGadget<F, Word32Cell<F>>,
@@ -404,12 +404,12 @@ impl<F: Field> TransferToGadget<F> {
             },
         );
 
-        let receiver = cb.condition(not::expr(value_is_zero.expr()), |cb| {
+        let receiver_balance = cb.condition(not::expr(value_is_zero.expr()), |cb| {
             cb.increase_balance(receiver_address, value.clone(), reversion_info)
         });
 
         Self {
-            receiver,
+            receiver_balance,
             receiver_exists,
             opcode_is_create,
             value_is_zero,
@@ -433,7 +433,7 @@ impl<F: Field> TransferToGadget<F> {
         } else {
             (0.into(), 0.into())
         };
-        self.receiver.assign(
+        self.receiver_balance.assign(
             region,
             offset,
             receiver_balance_prev,

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -445,13 +445,13 @@ impl<F: Field> TransferToGadget<F> {
     }
 }
 
-// TODO: Merge with TransferGadget
-/// The TransferWithGasFeeGadget handles an irreversible gas fee subtraction to
-/// the sender and a transfer of value from sender to receiver.  The value
-/// transfer is only performed if the value is not zero.  If the transfer is
-/// performed and the receiver account doesn't exist, it will be created by
-/// setting it's code_hash = EMPTY_HASH.   The receiver account is also created
-/// unconditionally if must_create is true.  This gadget is used in BeginTx.
+/// The [`TransferGadget`] handles
+/// - (optional) an irreversible gas fee subtraction to the sender, and
+/// - a transfer of value from sender to receiver.
+///
+/// The value transfer is only performed if the value is not zero.
+/// It also create the receiver account when the conditions in [`TransferToGadget`] is met.
+/// This gadget is used in BeginTx, Call ops, and Create.
 #[derive(Clone, Debug)]
 pub(crate) struct TransferGadget<F, const WITH_FEE: bool> {
     sender_sub_fee: Option<UpdateBalanceGadget<F, 2, false>>,

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -423,10 +423,11 @@ impl<F: Field> TransferToGadget<F> {
         (receiver_exists, value, opcode_is_create): (bool, U256, bool),
     ) -> Result<(), Error> {
         if !receiver_exists && (!value.is_zero() || opcode_is_create) {
-            let _receiver_code_hash = rws.next().account_codehash_pair();
+            // receiver's code_hash
+            rws.next().account_codehash_pair();
         }
 
-        let receiver_balance_pair = if !value.is_zero() {
+        let (receiver_balance, receiver_balance_prev) = if !value.is_zero() {
             rws.next().account_balance_pair()
         } else {
             (0.into(), 0.into())
@@ -434,9 +435,9 @@ impl<F: Field> TransferToGadget<F> {
         self.receiver.assign(
             region,
             offset,
-            receiver_balance_pair.1,
+            receiver_balance_prev,
             vec![value],
-            receiver_balance_pair.0,
+            receiver_balance,
         )?;
         self.value_is_zero
             .assign_value(region, offset, Value::known(WordLoHi::from(value)))?;

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -421,7 +421,9 @@ impl<F: Field> TransferToGadget<F> {
         region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         rws: &mut StepRws,
-        (receiver_exists, value, is_create): (bool, U256, bool),
+        receiver_exists: bool,
+        value: U256,
+        is_create: bool,
     ) -> Result<(), Error> {
         if !receiver_exists && (!value.is_zero() || is_create) {
             // receiver's code_hash
@@ -533,7 +535,9 @@ impl<F: Field, const WITH_FEE: bool> TransferGadget<F, WITH_FEE> {
         region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         rws: &mut StepRws,
-        (receiver_exists, value, is_create): (bool, U256, bool),
+        receiver_exists: bool,
+        value: U256,
+        is_create: bool,
         gas_fee: Option<U256>,
     ) -> Result<(), Error> {
         if WITH_FEE {
@@ -559,7 +563,7 @@ impl<F: Field, const WITH_FEE: bool> TransferGadget<F, WITH_FEE> {
             sender_balance_sub_value.0,
         )?;
         self.receiver
-            .assign(region, offset, rws, (receiver_exists, value, is_create))?;
+            .assign(region, offset, rws, receiver_exists, value, is_create)?;
         self.value_is_zero
             .assign_value(region, offset, Value::known(WordLoHi::from(value)))?;
         Ok(())

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -602,7 +602,7 @@ impl<F: Field> TransferGadget<F> {
         sender_address: WordLoHi<Expression<F>>,
         receiver_address: WordLoHi<Expression<F>>,
         receiver_exists: Expression<F>,
-        must_create: Expression<F>,
+        must_create: bool,
         value: Word32Cell<F>,
         reversion_info: &mut ReversionInfo<F>,
     ) -> Self {
@@ -612,7 +612,7 @@ impl<F: Field> TransferGadget<F> {
             cb,
             receiver_address.clone(),
             receiver_exists.clone(),
-            must_create.clone(),
+            must_create.expr(),
             value_is_zero.expr(),
             Some(reversion_info),
         );
@@ -624,7 +624,7 @@ impl<F: Field> TransferGadget<F> {
             cb,
             receiver_address,
             receiver_exists,
-            must_create,
+            must_create.expr(),
             value,
             Some(reversion_info),
             false,

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -1,4 +1,5 @@
 use super::{
+    common_gadget::UpdateBalanceGadget,
     math_gadget::{
         ConstantDivisionGadget, IsEqualGadget, IsEqualWordGadget, IsZeroGadget, IsZeroWordGadget,
         LtGadget, LtWordGadget, MinMaxGadget,
@@ -637,6 +638,26 @@ impl<'a, F: Field> EVMConstraintBuilder<'a, F> {
         denominator: u64,
     ) -> ConstantDivisionGadget<F, N_BYTES> {
         ConstantDivisionGadget::construct(self, numerator, denominator)
+    }
+
+    // Common Gadget
+
+    pub(crate) fn increase_balance(
+        &mut self,
+        address: WordLoHi<Expression<F>>,
+        value: Word32Cell<F>,
+        reversion_info: Option<&mut ReversionInfo<F>>,
+    ) -> UpdateBalanceGadget<F, 2, true> {
+        UpdateBalanceGadget::construct(self, address, &[value], reversion_info)
+    }
+
+    pub(crate) fn decrease_balance(
+        &mut self,
+        address: WordLoHi<Expression<F>>,
+        value: Word32Cell<F>,
+        reversion_info: Option<&mut ReversionInfo<F>>,
+    ) -> UpdateBalanceGadget<F, 2, false> {
+        UpdateBalanceGadget::construct(self, address, &[value], reversion_info)
     }
 
     // Fixed


### PR DESCRIPTION
### Description

- Transfer and TransferWithGas gadgets are mostly the same. We can merge them and duplicate them.
- There are duplicated logics for creating the receiver account (writing empty hash). We remove the duplicated one.
- The update balance gadget is vague, it is hard to understand whether we want to add or subtract balance. We extract a helpful method for that.
- deduplicate the transfer_to logic in busmapping.
- Fix the receiver creation condition on busmapping.
- Fix the order of the sender account read-write in begin tx assignment.

Thank @curryrasul for initializing this conversation.


### Issue Link


### Type of change

Refactor (no updates to logic)

### Content

### Test

```
cargo test -p zkevm-circuits create
cargo test -p zkevm-circuits begin_tx
cargo test -p zkevm-circuits end_tx 
```
