### PR TITLE
Add typos tool to CI to automate typo detection

### DIFF
--- a/.github/workflows/config/typos.toml
+++ b/.github/workflows/config/typos.toml
@@ -1,0 +1,9 @@
+[default.extend-words]
+groth = "groth"
+pn = "pn"
+struc = "struc"
+ba = "ba"
+advices = "advices"
+
+[files]
+extend-exclude = ["integration-tests/contracts"]

--- a/.github/workflows/config/typos.toml
+++ b/.github/workflows/config/typos.toml
@@ -4,6 +4,8 @@ pn = "pn"
 struc = "struc"
 ba = "ba"
 advices = "advices"
+unexpect = "unexpect"
+Convertion = "Convertion"
 
 [files]
 extend-exclude = ["integration-tests/contracts"]

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,0 +1,20 @@
+name: Typo Check
+
+on:
+  merge_group:
+  pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
+  push:
+    branches:
+      - main
+
+jobs:
+  typos:
+    name: Spell Check with Typos
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use typos with config file
+        uses: crate-ci/typos@v1.21.0
+        with:
+          config: config/typos.toml

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -17,4 +17,4 @@ jobs:
       - name: Use typos with config file
         uses: crate-ci/typos@v1.21.0
         with:
-          config: config/typos.toml
+          config: .github/workflows/config/typos.toml

--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -148,7 +148,7 @@ pub trait CircuitsParams: Debug + Copy {
     fn total_chunks(&self) -> usize;
     /// Set total number of chunks
     fn set_total_chunk(&mut self, total_chunks: usize);
-    /// Return the maximun Rw
+    /// Return the maximum Rw
     fn max_rws(&self) -> Option<usize>;
 }
 
@@ -211,7 +211,7 @@ impl Default for FixedCParams {
 /// [`eth_types::GethExecTrace`] to build the circuit input associated with
 /// each transaction, and the bus-mapping operations associated with each
 /// [`eth_types::GethExecStep`] in the [`eth_types::GethExecTrace`]. 3. If `Rw`s
-/// generated during Transactions exceed the `max_rws` threshold, seperate witness
+/// generated during Transactions exceed the `max_rws` threshold, separate witness
 /// into multiple chunks.
 ///
 /// The generated bus-mapping operations are:
@@ -366,7 +366,7 @@ impl<'a, C: CircuitsParams> CircuitInputBuilder<C> {
             return Ok(false);
         };
 
-        // Optain the first op of the next GethExecStep, for fixed case also lookahead
+        // Obtain the first op of the next GethExecStep, for fixed case also lookahead
         let (mut cib, mut tx, mut tx_ctx) = (self.clone(), tx, tx_ctx);
         let mut cib_ref = cib.state_ref(&mut tx, &mut tx_ctx);
         let mut next_ops = if let Some((i, step)) = next_geth_step {
@@ -397,8 +397,8 @@ impl<'a, C: CircuitsParams> CircuitInputBuilder<C> {
     /// `self.block.container`, and each step stores the
     /// [`OperationRef`](crate::exec_trace::OperationRef) to each of the
     /// generated operations.
-    /// When dynamic builder handles Tx with is_chuncked = false, we don't chunk
-    /// When fixed builder handles Tx with is_chuncked = true, we chunk
+    /// When dynamic builder handles Tx with is_chunked = false, we don't chunk
+    /// When fixed builder handles Tx with is_chunked = true, we chunk
     fn handle_tx(
         &mut self,
         eth_tx: &eth_types::Transaction,
@@ -475,7 +475,7 @@ impl<'a, C: CircuitsParams> CircuitInputBuilder<C> {
                 self.check_and_chunk(geth_trace, tx.clone(), tx_ctx.clone(), None, None)?;
             if is_chunk {
                 // TODO we dont support chunk after invalid_tx
-                // becasuse begin_chunk will constraints what next step execution state.
+                // because begin_chunk will constraints what next step execution state.
                 // And for next step either begin_tx or invalid_tx will both failed because
                 // begin_tx/invalid_tx define new execution state.
                 unimplemented!("dont support invalid_tx with multiple chunks")
@@ -1054,7 +1054,7 @@ pub fn keccak_inputs_tx_circuit(
     chain_id: u64,
 ) -> Result<Vec<Vec<u8>>, Error> {
     let mut inputs = Vec::new();
-    let sign_datas: Vec<SignData> = txs
+    let sign_data: Vec<SignData> = txs
         .iter()
         .enumerate()
         .filter(|(i, tx)| {
@@ -1068,7 +1068,7 @@ pub fn keccak_inputs_tx_circuit(
         .map(|(_, tx)| tx.sign_data(chain_id))
         .try_collect()?;
     // Keccak inputs from SignVerify Chip
-    let sign_verify_inputs = keccak_inputs_sign_verify(&sign_datas);
+    let sign_verify_inputs = keccak_inputs_sign_verify(&sign_data);
     inputs.extend_from_slice(&sign_verify_inputs);
     // NOTE: We don't verify the Tx Hash in the circuit yet, so we don't have more
     // hash inputs.

--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -814,7 +814,7 @@ impl CircuitInputBuilder<FixedCParams> {
         );
         assert!(
             self.chunks.len() == self.chunk_ctx.idx + 1,
-            "number of chunks {} mis-match with chunk_ctx id {}",
+            "number of chunks {} miss-match with chunk_ctx id {}",
             self.chunks.len(),
             self.chunk_ctx.idx + 1,
         );
@@ -975,7 +975,7 @@ impl CircuitInputBuilder<DynamicCParams> {
     }
 
     /// Handle a block by handling each transaction to generate all the
-    /// associated operations. Dry run the block to determind the target
+    /// associated operations. Dry run the block to determined the target
     /// [`FixedCParams`] from to total number of chunks.
     pub fn handle_block(
         self,

--- a/bus-mapping/src/circuit_input_builder/tracer_tests.rs
+++ b/bus-mapping/src/circuit_input_builder/tracer_tests.rs
@@ -427,7 +427,7 @@ fn tracer_invalid_tx_insufficient_balance() {
 
 #[test]
 fn tracer_err_address_collision() {
-    // We do CREATE2 twice with the same parameters, with a code_creater
+    // We do CREATE2 twice with the same parameters, with a code_creator
     // that outputs the same, which will lead to the same new
     // contract address.
     let code_creator = bytecode! {
@@ -540,7 +540,7 @@ fn tracer_err_address_collision() {
 
 #[test]
 fn tracer_create_collision_free() {
-    // We do CREATE twice with the same parameters, with a code_creater
+    // We do CREATE twice with the same parameters, with a code_creator
     // that outputs not the same, which will lead to the different new
     // contract address.
     let code_creator = bytecode! {

--- a/geth-utils/gethutil/mpt/trie/committer.go
+++ b/geth-utils/gethutil/mpt/trie/committer.go
@@ -39,7 +39,7 @@ type leaf struct {
 
 // committer is a type used for the trie Commit operation. A committer has some
 // internal preallocated temp space, and also a callback that is invoked when
-// leaves are committed. The leafs are passed through the `leafCh`,  to allow
+// leaves are committed. The leaves are passed through the `leafCh`,  to allow
 // some level of parallelism.
 // By 'some level' of parallelism, it's still the case that all leaves will be
 // processed sequentially - onleaf will never be called in parallel or out of order.
@@ -243,7 +243,7 @@ func (c *committer) makeHashNode(data []byte) HashNode {
 
 // estimateSize estimates the size of an rlp-encoded node, without actually
 // rlp-encoding it (zero allocs). This method has been experimentally tried, and with a trie
-// with 1000 leafs, the only errors above 1% are on small shortnodes, where this
+// with 1000 leaves, the only errors above 1% are on small shortnodes, where this
 // method overestimates by 2 or 3 bytes (e.g. 37 instead of 35)
 func estimateSize(n Node) int {
 	switch n := n.(type) {

--- a/geth-utils/gethutil/mpt/trie/trie.go
+++ b/geth-utils/gethutil/mpt/trie/trie.go
@@ -60,7 +60,7 @@ type LeafCallback func(paths [][]byte, hexpath []byte, leaf []byte, parent commo
 type Trie struct {
 	db   *Database
 	root Node
-	// Keep track of the number leafs which have been inserted since the last
+	// Keep track of the number leaves which have been inserted since the last
 	// hashing operation. This number will not directly map to the number of
 	// actually unhashed nodes
 	unhashed int

--- a/geth-utils/gethutil/mpt/witness/gen_witness_from_infura_blockchain_test.go
+++ b/geth-utils/gethutil/mpt/witness/gen_witness_from_infura_blockchain_test.go
@@ -465,7 +465,7 @@ func TestAddBranchTwoLevels(t *testing.T) {
 	// Test for case when branch is added in the second level. So, instead of having only
 	// branch1 with some nodes and then one of this nodes is replaced with a branch (that's
 	// the case of TestAddBranch), we have here branch1 and then inside it another
-	// branch: branch2. Inside brach2 we have a node which gets replaced by a branch.
+	// branch: branch2. Inside branch2 we have a node which gets replaced by a branch.
 	// This is to test cases when the key contains odd number of nibbles as well as
 	// even number of nibbles.
 

--- a/testool/src/statetest/executor.rs
+++ b/testool/src/statetest/executor.rs
@@ -27,7 +27,7 @@ pub enum StateTestError {
     NonceMismatch { expected: u64, found: u64 },
     #[error("CodeMismatch(expected: {expected:?}, found:{found:?})")]
     CodeMismatch { expected: Bytes, found: Bytes },
-    #[error("StorgeMismatch(slot:{slot:?} expected:{expected:?}, found: {found:?})")]
+    #[error("StorageMismatch(slot:{slot:?} expected:{expected:?}, found: {found:?})")]
     StorageMismatch {
         slot: U256,
         expected: U256,

--- a/testool/src/statetest/json.rs
+++ b/testool/src/statetest/json.rs
@@ -107,7 +107,7 @@ impl<'a> JsonStateTestBuilder<'a> {
         Self { compiler }
     }
 
-    /// generates `StateTest` vectors from a ethereum josn test specification
+    /// generates `StateTest` vectors from a ethereum json test specification
     pub fn load_json(&mut self, path: &str, source: &str) -> Result<Vec<StateTest>> {
         let mut state_tests = Vec::new();
         let tests: HashMap<String, JsonStateTest> = serde_json::from_str(source)?;

--- a/testool/src/statetest/results.rs
+++ b/testool/src/statetest/results.rs
@@ -41,8 +41,8 @@ impl ResultLevel {
         use ResultLevel::*;
         match self {
             Panic => "💀PANIC",
-            Fail => "🔴FAILD",
-            Ignored => "🟠IGNOR",
+            Fail => "🔴FAIL",
+            Ignored => "🟠IGNORE",
             Success => "🟢SUCCS",
         }
         .to_string()

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget/abs_word.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget/abs_word.rs
@@ -188,7 +188,7 @@ mod tests {
     }
 
     #[test]
-    fn test_abs_unexpected_is_neg_for_negitive() {
+    fn test_abs_unexpected_is_neg_for_negative() {
         try_test!(AbsWordGadgetContainer<Fr, false>, [Word::MAX, Word::from(1)], false);
     }
 }

--- a/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
@@ -797,7 +797,7 @@ mod test {
     }
 
     #[test]
-    fn test_buffer_reader_gadget_completness() {
+    fn test_buffer_reader_gadget_completeness() {
         // buffer len = data len
         try_test!(
             BufferReaderGadgetTestContainer<Fr, 2, 10>,

--- a/zkevm-circuits/src/mpt_circuit/account_leaf.rs
+++ b/zkevm-circuits/src/mpt_circuit/account_leaf.rs
@@ -409,7 +409,7 @@ impl<F: Field> AccountLeafConfig<F> {
             } elsex {
                 ifx! {and::expr(&[not!(config.parent_data[true.idx()].is_placeholder), not!(config.parent_data[false.idx()].is_placeholder)]) => {
                     // Check that there is only one modification, except when the account is being deleted or
-                    // the parent branch is a placeholder (meaning the account leafs in S are C are different).
+                    // the parent branch is a placeholder (meaning the account leaves in S are C are different).
                     // Nonce needs to remain the same when not modifying the nonce
                     ifx!{not!(config.is_nonce_mod) => {
                         require!(nonce[false.idx()] => nonce[true.idx()]);

--- a/zkevm-circuits/src/root_circuit.rs
+++ b/zkevm-circuits/src/root_circuit.rs
@@ -104,7 +104,7 @@ impl<T: Clone + Copy> SuperCircuitInstance<T> {
     }
 }
 
-/// UserChallange
+/// UserChallenge
 #[derive(Clone)]
 pub struct UserChallenge {
     /// column_indexes

--- a/zkevm-circuits/src/tx_circuit.rs
+++ b/zkevm-circuits/src/tx_circuit.rs
@@ -337,7 +337,7 @@ impl<F: Field> SubCircuit<F> for TxCircuit<F> {
         layouter: &mut impl Layouter<F>,
     ) -> Result<(), Error> {
         assert!(self.txs.len() <= self.max_txs);
-        let sign_datas: Vec<SignData> = self
+        let sign_data: Vec<SignData> = self
             .txs
             .iter()
             .map(|tx| {
@@ -351,7 +351,7 @@ impl<F: Field> SubCircuit<F> for TxCircuit<F> {
         config.load_aux_tables(layouter)?;
         let assigned_sig_verifs =
             self.sign_verify
-                .assign(&config.sign_verify, layouter, &sign_datas, challenges)?;
+                .assign(&config.sign_verify, layouter, &sign_data, challenges)?;
         self.assign_tx_table(config, layouter, assigned_sig_verifs)?;
         Ok(())
     }

--- a/zkevm-circuits/src/util/word.rs
+++ b/zkevm-circuits/src/util/word.rs
@@ -1,6 +1,6 @@
 //! Define generic Word type with utility functions
 // Naming Conversion
-// - Limbs: An EVN word is 256 bits. Limbs N means split 256 into N limb. For example, N = 4, each
+// - Limbs: An EVEN word is 256 bits. Limbs N means split 256 into N limb. For example, N = 4, each
 //   limb is 256/4 = 64 bits
 
 use bus_mapping::state_db::CodeDB;


### PR DESCRIPTION
### Description

- `advices` -> `advice` but It has appeared many times,Fear of side effects from excessive changes, this PR do not process this typo for now
- `extend-exclude = ["integration-tests/contracts"]`  is third party lib


### Issue Link

close:https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/1781
